### PR TITLE
updated runtime detection (#32)

### DIFF
--- a/KubeArmor/core/k8sHandler.go
+++ b/KubeArmor/core/k8sHandler.go
@@ -214,7 +214,7 @@ func (kh *K8sHandler) GetContainerRuntime() string {
 	// get a node from k8s api client
 	node, err := kh.K8sClient.CoreV1().Nodes().Get(context.Background(), hostName, metav1.GetOptions{})
 	if err != nil {
-		return ""
+		return "Unknown"
 	}
 
 	return node.Status.NodeInfo.ContainerRuntimeVersion

--- a/KubeArmor/core/kubeArmor.go
+++ b/KubeArmor/core/kubeArmor.go
@@ -304,14 +304,28 @@ func KubeArmor(auditLogOption, systemLogOption string) {
 
 		kg.Printf("Container Runtime: %s", cr)
 
-		if strings.Contains(cr, "containerd") {
-			// monitor containerd events
-			go dm.MonitorContainerdEvents()
-			WgDaemon.Add(1)
-		} else if strings.Contains(cr, "docker") {
+		if strings.Contains(cr, "docker") {
 			// monitor docker events
 			go dm.MonitorDockerEvents()
 			WgDaemon.Add(1)
+		} else if strings.Contains(cr, "containerd") {
+			// monitor containerd events
+			go dm.MonitorContainerdEvents()
+			WgDaemon.Add(1)
+		} else {
+			kg.Print("Trying to monitor both Docker and Containerd")
+
+			// monitor containerd events
+			go dm.MonitorContainerdEvents()
+			WgDaemon.Add(1)
+
+			// monitor docker events
+			go dm.MonitorDockerEvents()
+			WgDaemon.Add(1)
+
+			if Docker == nil && Containerd == nil {
+				kg.Print("Detected no container runtime")
+			}
 		}
 
 		// watch k8s pods


### PR DESCRIPTION
Fix: #32

- If no container runtime is detected from k8s, try to monitor both Docker and Containerd.
- If no container runtime is still detected, then show a message ("Detected no container runtime")