### PR TITLE
Used versioned APIs for Docker Engine

### DIFF
--- a/KubeArmor/build/Dockerfile.kubearmor
+++ b/KubeArmor/build/Dockerfile.kubearmor
@@ -20,9 +20,11 @@ COPY ./monitor ./build/monitor
 COPY ./types ./build/types
 COPY ./go.mod ./build
 COPY ./main.go ./build
+COPY ./patch.sh ./build
 
 WORKDIR /usr/src/KubeArmor/build
 
+RUN ./patch.sh
 RUN GOOS=linux GOARCH=amd64 go build -a -ldflags '-s -w' -o kubearmor main.go
 
 ### Make executable image

--- a/KubeArmor/build/patch.sh
+++ b/KubeArmor/build/patch.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# download gobpf
+go get github.com/iovisor/gobpf
+
+# fix module.go
+for GOBPF in $(ls $GOPATH/pkg/mod/github.com/iovisor);
+do
+	echo $GOBPF
+	sed -i 's/C.bpf_attach_uprobe(C.int(fd), attachType, evNameCS, binaryPathCS, (C.uint64_t)(addr), (C.pid_t)(pid), 0)/C.bpf_attach_uprobe(C.int(fd), attachType, evNameCS, binaryPathCS, (C.uint64_t)(addr), (C.pid_t)(pid))/g' $GOPATH/pkg/mod/github.com/iovisor/$GOBPF/bcc/module.go
+done

--- a/KubeArmor/go.mod
+++ b/KubeArmor/go.mod
@@ -7,16 +7,17 @@ require (
 	github.com/containerd/ttrpc v1.0.2 // indirect
 	github.com/containerd/typeurl v1.0.1
 	github.com/docker/distribution v2.7.1+incompatible // indirect
-	github.com/docker/docker v1.13.1
+	github.com/docker/docker v20.10.2+incompatible
 	github.com/docker/go-connections v0.4.0 // indirect
 	github.com/docker/go-units v0.4.0 // indirect
-	github.com/iovisor/gobpf v0.0.0-20200614202714-e6b321d32103
+	github.com/imdario/mergo v0.3.11 // indirect
+	github.com/iovisor/gobpf v0.0.0-20210102170715-cf224c919a95
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.0.1 // indirect
 	github.com/opencontainers/runtime-spec v1.0.2
 	github.com/sirupsen/logrus v1.7.0 // indirect
 	go.uber.org/zap v1.16.0
-	golang.org/x/net v0.0.0-20200707034311-ab3426394381
+	golang.org/x/net v0.0.0-20201224014010-6772e930b67b
 	google.golang.org/grpc v1.34.0
 	google.golang.org/protobuf v1.25.0
 	k8s.io/api v0.19.0

--- a/KubeArmor/monitor/containerMonitor.go
+++ b/KubeArmor/monitor/containerMonitor.go
@@ -198,10 +198,14 @@ func (mon *ContainerMonitor) InitBPF(HomeDir string) error {
 	}
 	bpfSource := string(content)
 
+	kg.Print("Initializing an eBPF program")
+
 	mon.BpfModule = bcc.NewModule(bpfSource, []string{"-w"})
 	if mon.BpfModule == nil {
 		return errors.New("bpf module is nil")
 	}
+
+	kg.Print("Initialized the eBPF program")
 
 	sysPrefix := bcc.GetSyscallPrefix()
 	systemCalls := []string{

--- a/KubeArmor/run.sh
+++ b/KubeArmor/run.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+ARMOR_HOME=`dirname $(realpath "$0")`
+cd $ARMOR_HOME
+
+if [ ! -f "kubearmor" ]; then
+    make
+fi
+
+sudo -E ./kubearmor


### PR DESCRIPTION
core/dockerHandler.go: use versioned APIs

We directly used Docker Engine APIs for v1.13.
Now, we use versioned APIs by checking the API version that a given Docker engine supports.

Fixes: #36 

core/go.mod: update go module
I updated the version of the docker Go module to the latest one.

Fixes: #36 

Dockerfile.kubearmor / KubeArmor/build/patch.sh: add a patch due to gobpf params error
run.sh: add a script for local test
