### PR TITLE
Auto-annotating apparmor profiles

### DIFF
--- a/KubeArmor/core/containerdHandler.go
+++ b/KubeArmor/core/containerdHandler.go
@@ -247,9 +247,12 @@ func (dm *KubeArmorDaemon) UpdateContainerdContainer(containerID, action string)
 		}
 		dm.ContainersLock.Unlock()
 
+		if ok := dm.UpdateContainerGroupWithContainer("ADDED", container); !ok {
+			return
+		}
+
 		kg.Printf("Detected a container (added/%s/%s)", container.NamespaceName, container.ContainerID[:12])
 
-		dm.UpdateContainerGroupWithContainer("ADDED", container)
 	} else if action == "destroy" {
 		dm.ContainersLock.Lock()
 		val, ok := dm.Containers[containerID]
@@ -266,9 +269,11 @@ func (dm *KubeArmorDaemon) UpdateContainerdContainer(containerID, action string)
 			return
 		}
 
-		kg.Printf("Detected a container (removed/%s/%s)", container.NamespaceName, container.ContainerID[:12])
+		if ok := dm.UpdateContainerGroupWithContainer("DELETED", container); !ok {
+			return
+		}
 
-		dm.UpdateContainerGroupWithContainer("DELETED", container)
+		kg.Printf("Detected a container (removed/%s/%s)", container.NamespaceName, container.ContainerID[:12])
 	}
 }
 

--- a/KubeArmor/core/dockerHandler.go
+++ b/KubeArmor/core/dockerHandler.go
@@ -208,9 +208,12 @@ func (dm *KubeArmorDaemon) UpdateDockerContainer(containerID, action string) {
 		}
 		dm.ContainersLock.Unlock()
 
+		if ok := dm.UpdateContainerGroupWithContainer("ADDED", container); !ok {
+			return
+		}
+
 		kg.Printf("Detected a container (added/%s/%s)", container.NamespaceName, container.ContainerName)
 
-		dm.UpdateContainerGroupWithContainer("ADDED", container)
 	} else if action == "stop" || action == "destroy" {
 		// case 1: kill -> die -> stop
 		// case 2: kill -> die -> destroy
@@ -231,9 +234,11 @@ func (dm *KubeArmorDaemon) UpdateDockerContainer(containerID, action string) {
 			return
 		}
 
-		kg.Printf("Detected a container (removed/%s/%s)", container.NamespaceName, container.ContainerName)
+		if ok := dm.UpdateContainerGroupWithContainer("DELETED", container); !ok {
+			return
+		}
 
-		dm.UpdateContainerGroupWithContainer("DELETED", container)
+		kg.Printf("Detected a container (removed/%s/%s)", container.NamespaceName, container.ContainerName)
 	}
 }
 

--- a/KubeArmor/core/k8sHandler.go
+++ b/KubeArmor/core/k8sHandler.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 	rest "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -218,6 +219,63 @@ func (kh *K8sHandler) GetContainerRuntime() string {
 	}
 
 	return node.Status.NodeInfo.ContainerRuntimeVersion
+}
+
+// ================ //
+// == Deployment == //
+// ================ //
+
+// PatchDeploymentWithAppArmorAnnotations Function
+func (kh *K8sHandler) PatchDeploymentWithAppArmorAnnotations(namespaceName, deploymentName string, annotations map[string]string) error {
+	if !kl.IsK8sEnv() { // not Kubernetes
+		return nil
+	}
+
+	spec := `{"spec":{"template":{"metadata":{"annotations":{`
+
+	for k, v := range annotations {
+		kv := `"container.apparmor.security.beta.kubernetes.io/` + k + `":"localhost/` + v + `"`
+		spec = spec + kv
+	}
+
+	spec = spec + `}}}}}`
+
+	_, err := kh.K8sClient.AppsV1().Deployments(namespaceName).Patch(context.Background(), deploymentName, types.StrategicMergePatchType, []byte(spec), metav1.PatchOptions{})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// ================ //
+// == ReplicaSet == //
+// ================ //
+
+// GetDeploymentNameControllingReplicaSet Function
+func (kh *K8sHandler) GetDeploymentNameControllingReplicaSet(namespaceName, replicaSetName string) string {
+	if !kl.IsK8sEnv() { // not Kubernetes
+		return ""
+	}
+
+	// get replicaSet from k8s api client
+	rs, err := kh.K8sClient.AppsV1().ReplicaSets(namespaceName).Get(context.Background(), replicaSetName, metav1.GetOptions{})
+	if err != nil {
+		return ""
+	}
+
+	// check if we have ownerReferences
+	if len(rs.ObjectMeta.OwnerReferences) == 0 {
+		return ""
+	}
+
+	// check if given ownerReferences are for Deployment
+	if rs.ObjectMeta.OwnerReferences[0].Kind != "Deployment" {
+		return ""
+	}
+
+	// return the deployment name
+	return rs.ObjectMeta.OwnerReferences[0].Name
 }
 
 // ========== //

--- a/KubeArmor/core/k8sHandler.go
+++ b/KubeArmor/core/k8sHandler.go
@@ -233,8 +233,16 @@ func (kh *K8sHandler) PatchDeploymentWithAppArmorAnnotations(namespaceName, depl
 
 	spec := `{"spec":{"template":{"metadata":{"annotations":{`
 
+	count := len(annotations)
+
 	for k, v := range annotations {
 		kv := `"container.apparmor.security.beta.kubernetes.io/` + k + `":"localhost/` + v + `"`
+
+		if count > 1 {
+			kv = kv + ","
+		}
+		count--
+
 		spec = spec + kv
 	}
 

--- a/KubeArmor/core/kubeUpdate.go
+++ b/KubeArmor/core/kubeUpdate.go
@@ -18,7 +18,7 @@ import (
 // ============================ //
 
 // UpdateContainerGroupWithContainer Function
-func (dm *KubeArmorDaemon) UpdateContainerGroupWithContainer(action string, container tp.Container) {
+func (dm *KubeArmorDaemon) UpdateContainerGroupWithContainer(action string, container tp.Container) bool {
 	dm.ContainerGroupsLock.Lock()
 	defer dm.ContainerGroupsLock.Unlock()
 
@@ -34,8 +34,7 @@ func (dm *KubeArmorDaemon) UpdateContainerGroupWithContainer(action string, cont
 	}
 
 	if conGroupIdx == -1 {
-		kg.Errf("No container group (%s/%s) for a container (%s)", container.NamespaceName, container.ContainerGroupName, container.ContainerID[:12])
-		return
+		return false
 	}
 
 	// update container in a container group
@@ -78,6 +77,8 @@ func (dm *KubeArmorDaemon) UpdateContainerGroupWithContainer(action string, cont
 
 	// enforce security policies
 	dm.RuntimeEnforcer.UpdateSecurityPolicies(dm.ContainerGroups[conGroupIdx])
+
+	return true
 }
 
 // ================ //
@@ -222,8 +223,43 @@ func (dm *KubeArmorDaemon) WatchK8sPods() {
 				}
 
 				pod.Annotations = map[string]string{}
+				appArmorAnnotations := map[string]string{}
+
 				for k, v := range event.Object.Annotations {
 					pod.Annotations[k] = v
+
+					if strings.HasPrefix(k, "container.apparmor.security.beta.kubernetes.io") {
+						containerName := strings.Split(k, "/")[1]
+						appArmorAnnotations[containerName] = strings.Split(v, "/")[1]
+					}
+				}
+
+				updateAppArmor := false
+				for _, container := range event.Object.Spec.Containers {
+					if _, ok := appArmorAnnotations[container.Name]; !ok {
+						appArmorAnnotations[container.Name] = "kubearmor-" + pod.Metadata["namespaceName"] + "-" + pod.Metadata["podName"] + "-" + container.Name
+						updateAppArmor = true
+					}
+				}
+
+				if event.Type == "ADDED" && pod.Metadata["namespaceName"] != "kube-system" {
+					if updateAppArmor && event.Object.ObjectMeta.OwnerReferences[0].Kind == "ReplicaSet" {
+						deploymentName := K8s.GetDeploymentNameControllingReplicaSet(pod.Metadata["namespaceName"], event.Object.ObjectMeta.OwnerReferences[0].Name)
+						if deploymentName != "" {
+							if err := K8s.PatchDeploymentWithAppArmorAnnotations(pod.Metadata["namespaceName"], deploymentName, appArmorAnnotations); err != nil {
+								kg.Errf("Failed to update AppArmor Profiles (%s)", err.Error())
+							} else {
+								kg.Printf("Updated AppArmor Profiles (%s/%s)", pod.Metadata["namespaceName"], pod.Metadata["podName"])
+							}
+						}
+						dm.K8sPodsLock.Unlock()
+						continue
+					}
+				} else if pod.Metadata["namespaceName"] != "kube-system" {
+					if updateAppArmor && event.Object.ObjectMeta.OwnerReferences[0].Kind == "ReplicaSet" {
+						dm.K8sPodsLock.Unlock()
+						continue
+					}
 				}
 
 				pod.Labels = map[string]string{}

--- a/contributions/bare-metal/k8s/install_kubernetes.sh
+++ b/contributions/bare-metal/k8s/install_kubernetes.sh
@@ -24,3 +24,9 @@ sudo apt-get install -y kubelet kubeadm
 
 # mount bpffs (for cilium)
 echo "bpffs                                     /sys/fs/bpf     bpf     defaults          0       0" | sudo tee -a /etc/fstab
+
+# install apparmor and audit
+sudo apt-get install -y apparmor apparmor-utils auditd
+
+# enable auditd
+sudo systemctl enable auditd && sudo systemctl start auditd

--- a/contributions/bare-metal/microk8s/install_microk8s.sh
+++ b/contributions/bare-metal/microk8s/install_microk8s.sh
@@ -25,3 +25,9 @@ sudo mv kubectl /usr/local/bin/
 
 # check kubectl
 kubectl cluster-info
+
+# install apparmor and audit
+sudo apt-get install -y apparmor apparmor-utils auditd
+
+# enable auditd
+sudo systemctl enable auditd && sudo systemctl start auditd


### PR DESCRIPTION
add AppArmor annotations in deployments and perform rolling updates

target: deployment -> replica set -> pod -> container

if there is no AppArmor annotation in a pod, check if the pod is controlled by a replica set.
if the pod is controlled by a replica set, check if the replica set is controlled by a deployment.
if the replica set is controlled by a deployment, add AppArmor annotations in the deployment and perform a rolling update.

Fixes: #59 