### PR TITLE
multiple protocols/caps handling in the same rule

### DIFF
--- a/KubeArmor/common/common.go
+++ b/KubeArmor/common/common.go
@@ -41,6 +41,63 @@ func ContainsElement(slice interface{}, element interface{}) bool {
 	return false
 }
 
+// ObjCommaCanBeExpanded Function
+func ObjCommaCanBeExpanded(objptr interface{}) bool {
+	ovptr := reflect.ValueOf(objptr)
+	if ovptr.Kind() != reflect.Ptr {
+		return false
+	}
+
+	ov := ovptr.Elem()
+	if ov.Kind() != reflect.Slice {
+		return false
+	}
+
+	if ov.Len() == 0 {
+		return false
+	}
+
+	ovelm := ov.Index(0)
+	if ovelm.Kind() != reflect.Struct {
+		return false
+	}
+
+	field0 := ovelm.Field(0)
+	if field0.Kind() != reflect.String {
+		return false
+	}
+
+	value := field0.Interface().(string)
+	if strings.Split(value, ",")[0] == value {
+		return false
+	}
+
+	return true
+}
+
+// ObjCommaExpand Function
+func ObjCommaExpand(v reflect.Value) []string {
+	return strings.Split(v.Field(0).Interface().(string), ",")
+}
+
+// ObjCommaExpandFirstDupOthers Function
+func ObjCommaExpandFirstDupOthers(objptr interface{}) {
+	if ObjCommaCanBeExpanded(objptr) {
+		old := reflect.ValueOf(objptr).Elem()
+		new := reflect.New(reflect.TypeOf(objptr).Elem()).Elem()
+
+		for i := 0; i < old.Len(); i++ {
+			for _, f := range ObjCommaExpand(old.Index(i)) {
+				field := strings.ReplaceAll(f, " ", "")
+				new.Set(reflect.Append(new, old.Index(i)))
+				new.Index(new.Len()-1).Field(0).SetString(field)
+			}
+		}
+
+		reflect.ValueOf(objptr).Elem().Set(new)
+	}
+}
+
 // ========== //
 // == Time == //
 // ========== //

--- a/KubeArmor/core/kubeUpdate.go
+++ b/KubeArmor/core/kubeUpdate.go
@@ -424,6 +424,8 @@ func (dm *KubeArmorDaemon) WatchSecurityPolicies() {
 					}
 
 					kl.Clone(event.Object.Spec, &secPolicy.Spec)
+					kl.ObjCommaExpandFirstDupOthers(&secPolicy.Spec.Network.MatchProtocols)
+					kl.ObjCommaExpandFirstDupOthers(&secPolicy.Spec.Capabilities.MatchCapabilities)
 
 					switch secPolicy.Spec.Action {
 					case "block":

--- a/pkg/k8s/api/v1/kubearmorpolicy_types.go
+++ b/pkg/k8s/api/v1/kubearmorpolicy_types.go
@@ -122,7 +122,7 @@ type FileType struct {
 	MatchPatterns    []FilePatternType   `json:"matchPatterns,omitempty"`
 }
 
-// +kubebuilder:validation:Enum=TCP;tcp;UDP;udp;ICMP;icmp
+// +kubebuilder:validation:Pattern=(icmp|ICMP|tcp|TCP|udp|UDP)$
 type MatchNetworkProtocolStringType string
 
 type MatchNetworkProtocolType struct {
@@ -136,7 +136,7 @@ type NetworkType struct {
 	MatchProtocols []MatchNetworkProtocolType `json:"matchProtocols,omitempty"`
 }
 
-// +kubebuilder:validation:Enum=chown;dac_override;dac_read_search;fowner;fsetid;kill;setgid;setuid;setpcap;linux_immutable;net_bind_service;net_broadcast;net_admin;net_raw;ipc_lock;ipc_owner;sys_module;sys_rawio;sys_chroot;sys_ptrace;sys_pacct;sys_admin;sys_boot;sys_nice;sys_resource;sys_time;sys_tty_config;mknod;lease;audit_write;audit_control;setfcap;mac_override;mac_admin
+// +kubebuilder:validation:Pattern=(chown|dac_override|dac_read_search|fowner|fsetid|kill|setgid|setuid|setpcap|linux_immutable|net_bind_service|net_broadcast|net_admin|net_raw|ipc_lock|ipc_owner|sys_module|sys_rawio|sys_chroot|sys_ptrace|sys_pacct|sys_admin|sys_boot|sys_nice|sys_resource|sys_time|sys_tty_config|mknod|lease|audit_write|audit_control|setfcap|mac_override|mac_admin)$
 type MatchCapabilitiesStringType string
 
 type MatchCapabilitiesType struct {


### PR DESCRIPTION
KubeArmor/common/common.go
KubeArmor/core/kubeUpdate.go
pkg/k8s/api/v1/kubearmorpolicy_types.go

The code added is able to expand any struct whose first field is a comma separated string to a list of structs (expanding the first field and duplicating the others).

The following struct, for example:

```
{"one, two, three", <anything>}
```

will be translated to:
```
{"one",  <anything>}, { "two",  <anything>}, {"three", <anything>}
```

Fixes: #91 

