### PR TITLE
Improve the system monitor's performance

### DIFF
--- a/KubeArmor/audit/auditLog.go
+++ b/KubeArmor/audit/auditLog.go
@@ -1,0 +1,186 @@
+package audit
+
+import (
+	"strings"
+
+	tp "github.com/accuknox/KubeArmor/KubeArmor/types"
+)
+
+// ================ //
+// == Map Lookup == //
+// ================ //
+
+// GetProcessInfoFromHostPid Function
+func (adt *AuditLogger) GetProcessInfoFromHostPid(log tp.Log, hostPid uint32) tp.Log {
+	ActiveHostPidMap := *(adt.ActiveHostPidMap)
+	ActivePidMapLock := *(adt.ActivePidMapLock)
+
+	ActivePidMapLock.RLock()
+	defer ActivePidMapLock.RUnlock()
+
+	for id, pidMap := range ActiveHostPidMap {
+		if node, ok := pidMap[hostPid]; ok {
+			log.ContainerID = id
+
+			// log.HostPID is already assigned
+
+			log.PPID = int32(node.PPID)
+			log.PID = int32(node.PID)
+			log.UID = int32(node.UID)
+
+			break
+		}
+	}
+
+	if log.PID == 0 {
+		log.PPID = -1
+		log.PID = -1
+		log.UID = -1
+	}
+
+	return log
+}
+
+// GetContainerInfoFromContainerID Function
+func (adt *AuditLogger) GetContainerInfoFromContainerID(log tp.Log, profileName string) tp.Log {
+	Containers := *(adt.Containers)
+	ContainersLock := *(adt.ContainersLock)
+
+	ContainersLock.RLock()
+	defer ContainersLock.RUnlock()
+
+	if log.ContainerID != "" {
+		if val, ok := Containers[log.ContainerID]; ok {
+			log.NamespaceName = val.NamespaceName
+			log.PodName = val.ContainerGroupName
+
+			// ContainerID is already assigned
+			log.ContainerName = val.ContainerName
+		}
+	} else {
+		for _, container := range Containers {
+			if strings.HasPrefix(profileName, container.AppArmorProfile) {
+				log.NamespaceName = container.NamespaceName
+				log.PodName = container.ContainerGroupName
+
+				log.ContainerID = container.ContainerID
+				log.ContainerName = container.ContainerName
+
+				break
+			}
+		}
+	}
+
+	return log
+}
+
+// GetExecPath Function
+func (adt *AuditLogger) GetExecPath(containerID string, pid uint32) string {
+	ActivePidMap := *(adt.ActivePidMap)
+	ActivePidMapLock := *(adt.ActivePidMapLock)
+
+	ActivePidMapLock.RLock()
+	defer ActivePidMapLock.RUnlock()
+
+	if pidMap, ok := ActivePidMap[containerID]; ok {
+		if node, ok := pidMap[pid]; ok {
+			return node.ExecPath
+		}
+	}
+
+	return ""
+}
+
+// UpdateSourceAndResource Function
+func (adt *AuditLogger) UpdateSourceAndResource(log tp.Log, source, resource string) tp.Log {
+	if log.Operation == "Process" {
+		log.Source = adt.GetExecPath(log.ContainerID, uint32(log.PPID))
+		if log.Source == "" {
+			log.Source = source
+		}
+
+		log.Resource = adt.GetExecPath(log.ContainerID, uint32(log.PID))
+		if log.Resource == "" {
+			log.Resource = resource
+		} else if !strings.HasPrefix(log.Resource, resource) {
+			log.Resource = resource
+		}
+	} else { // File
+		log.Source = adt.GetExecPath(log.ContainerID, uint32(log.PID))
+		if log.Source == "" {
+			log.Source = source
+		}
+
+		log.Resource = resource
+	}
+
+	return log
+}
+
+// GetHostProcessInfoFromHostPid Function
+func (adt *AuditLogger) GetHostProcessInfoFromHostPid(log tp.Log, hostPid uint32) tp.Log {
+	ActiveHostMap := *(adt.ActiveHostMap)
+	ActiveHostMapLock := *(adt.ActiveHostMapLock)
+
+	ActiveHostMapLock.RLock()
+	defer ActiveHostMapLock.RUnlock()
+
+	if pidMap, ok := ActiveHostMap[hostPid]; ok {
+		if node, ok := pidMap[hostPid]; ok {
+			log.PPID = int32(node.PPID)
+			log.PID = int32(node.PID)
+			log.UID = int32(node.UID)
+		}
+	}
+
+	if log.PID == 0 {
+		log.PPID = -1
+		log.PID = int32(hostPid)
+		log.UID = -1
+	}
+
+	return log
+}
+
+// GetHostExecPath Function
+func (adt *AuditLogger) GetHostExecPath(hostPid uint32) string {
+	ActiveHostMap := *(adt.ActiveHostMap)
+	ActiveHostMapLock := *(adt.ActiveHostMapLock)
+
+	ActiveHostMapLock.RLock()
+	defer ActiveHostMapLock.RUnlock()
+
+	if pidMap, ok := ActiveHostMap[hostPid]; ok {
+		if node, ok := pidMap[hostPid]; ok {
+			return node.ExecPath
+		}
+	}
+
+	return ""
+}
+
+// UpdateHostSourceAndResource Function
+func (adt *AuditLogger) UpdateHostSourceAndResource(log tp.Log, source, resource string) tp.Log {
+	if log.Operation == "Process" {
+		log.Source = adt.GetHostExecPath(uint32(log.PPID))
+		if log.Source == "" {
+			log.Source = source
+		}
+
+		log.Resource = adt.GetHostExecPath(uint32(log.PID))
+		if log.Resource == "" {
+			log.Resource = resource
+		} else if !strings.HasPrefix(log.Resource, resource) {
+			log.Resource = resource
+		}
+	} else { // File
+		log.Source = adt.GetHostExecPath(uint32(log.PID))
+		if log.Source == "" {
+			log.Source = source
+		}
+
+		log.Resource = resource
+	}
+
+	return log
+}

--- a/KubeArmor/audit/auditLogger.go
+++ b/KubeArmor/audit/auditLogger.go
@@ -28,21 +28,26 @@ type AuditLogger struct {
 
 	// container id -> cotnainer
 	Containers     *map[string]tp.Container
-	ContainersLock **sync.Mutex
+	ContainersLock **sync.RWMutex
 
 	// container id -> (host) pid
 	ActivePidMap     *map[string]tp.PidMap
 	ActiveHostPidMap *map[string]tp.PidMap
+	ActivePidMapLock **sync.RWMutex
 
-	// pid map lock
-	ActivePidMapLock **sync.Mutex
+	// host pid -> host pid
+	ActiveHostMap     *map[uint32]tp.PidMap
+	ActiveHostMapLock **sync.RWMutex
 
 	// GKE
 	IsCOS bool
 }
 
 // NewAuditLogger Function
-func NewAuditLogger(feeder *fd.Feeder, HomeDir string, containers *map[string]tp.Container, containersLock **sync.Mutex, activePidMap *map[string]tp.PidMap, activeHostPidMap *map[string]tp.PidMap, activePidMapLock **sync.Mutex) *AuditLogger {
+func NewAuditLogger(feeder *fd.Feeder,
+	containers *map[string]tp.Container, containersLock **sync.RWMutex,
+	activePidMap *map[string]tp.PidMap, activeHostPidMap *map[string]tp.PidMap, activePidMapLock **sync.RWMutex,
+	activeHostMap *map[uint32]tp.PidMap, activeHostMapLock **sync.RWMutex) *AuditLogger {
 	adt := new(AuditLogger)
 
 	adt.HostName = kl.GetHostName()
@@ -55,6 +60,9 @@ func NewAuditLogger(feeder *fd.Feeder, HomeDir string, containers *map[string]tp
 	adt.ActivePidMap = activePidMap
 	adt.ActiveHostPidMap = activeHostPidMap
 	adt.ActivePidMapLock = activePidMapLock
+
+	adt.ActiveHostMap = activeHostMap
+	adt.ActiveHostMapLock = activeHostMapLock
 
 	adt.IsCOS = false
 
@@ -141,164 +149,6 @@ func (adt *AuditLogger) DestroyAuditLogger() error {
 // == Auditd == //
 // ============ //
 
-// GetProcessInfoFromHostPid Function
-func (adt *AuditLogger) GetProcessInfoFromHostPid(log tp.Log, hostPid int32) tp.Log {
-	ActiveHostPidMap := *(adt.ActiveHostPidMap)
-
-	ActivePidMapLock := *(adt.ActivePidMapLock)
-	ActivePidMapLock.Lock()
-	defer ActivePidMapLock.Unlock()
-
-	for id, pidMap := range ActiveHostPidMap {
-		for pid, node := range pidMap {
-			if hostPid == int32(pid) {
-				log.ContainerID = id
-
-				log.PPID = int32(node.PPID)
-				log.PID = int32(node.PID)
-				log.UID = int32(node.UID)
-
-				break
-			}
-		}
-
-		if log.ContainerID != "" {
-			break
-		}
-	}
-
-	if log.ContainerID == "" {
-		for id, pidMap := range ActiveHostPidMap {
-			for pid, node := range pidMap {
-				if hostPid == int32(pid) {
-					log.ContainerID = id
-
-					log.PPID = int32(node.PPID)
-					log.PID = int32(node.PID)
-					log.UID = int32(node.UID)
-
-					break
-				}
-			}
-
-			if log.ContainerID != "" {
-				break
-			}
-		}
-	}
-
-	if log.PID == 0 {
-		log.PPID = -1
-		log.PID = -1
-		log.UID = -1
-	}
-
-	return log
-}
-
-// GetContainerInfoFromContainerID Function
-func (adt *AuditLogger) GetContainerInfoFromContainerID(log tp.Log, profileName string) tp.Log {
-	Containers := *(adt.Containers)
-	ContainersLock := *(adt.ContainersLock)
-
-	ContainersLock.Lock()
-	defer ContainersLock.Unlock()
-
-	if log.ContainerID != "" {
-		if val, ok := Containers[log.ContainerID]; ok {
-			log.NamespaceName = val.NamespaceName
-			log.PodName = val.ContainerGroupName
-			log.ContainerName = val.ContainerName
-		}
-	} else {
-		for _, container := range Containers {
-			if strings.HasPrefix(profileName, container.AppArmorProfile) {
-				log.NamespaceName = container.NamespaceName
-				log.PodName = container.ContainerGroupName
-				log.ContainerID = container.ContainerID
-				log.ContainerName = container.ContainerName
-				break
-			}
-		}
-	}
-
-	return log
-}
-
-// GetExecPath Function
-func (adt *AuditLogger) GetExecPath(containerID string, pid uint32) string {
-	ActivePidMap := *(adt.ActivePidMap)
-
-	ActivePidMapLock := *(adt.ActivePidMapLock)
-	ActivePidMapLock.Lock()
-	defer ActivePidMapLock.Unlock()
-
-	if pidMap, ok := ActivePidMap[containerID]; ok {
-		if node, ok := pidMap[pid]; ok {
-			if node.PID == pid {
-				return node.ExecPath
-			}
-		}
-	}
-
-	return ""
-}
-
-// UpdateSourceAndResource Function
-func (adt *AuditLogger) UpdateSourceAndResource(log tp.Log, source, resource string) tp.Log {
-	if log.Operation == "Process" {
-		log.Source = adt.GetExecPath(log.ContainerID, uint32(log.PPID))
-		if log.Source == "" {
-			log.Source = source
-		}
-
-		log.Resource = adt.GetExecPath(log.ContainerID, uint32(log.PID))
-		if log.Resource == "" {
-			log.Resource = resource
-		} else if !strings.HasPrefix(log.Resource, resource) {
-			log.Resource = resource
-		}
-	} else { // File
-		log.Source = adt.GetExecPath(log.ContainerID, uint32(log.PID))
-		if log.Source == "" {
-			log.Source = source
-		}
-
-		log.Resource = resource
-	}
-
-	return log
-}
-
-// GetHostProcessInfoFromHostPid Function
-func (adt *AuditLogger) GetHostProcessInfoFromHostPid(log tp.Log, hostPid int32) tp.Log {
-	ActiveHostPidMap := *(adt.ActiveHostPidMap)
-
-	ActivePidMapLock := *(adt.ActivePidMapLock)
-	ActivePidMapLock.Lock()
-	defer ActivePidMapLock.Unlock()
-
-	for _, pidMap := range ActiveHostPidMap {
-		for pid, node := range pidMap {
-			if hostPid == int32(pid) {
-				log.PPID = int32(node.PPID)
-				log.PID = int32(node.PID)
-				log.UID = int32(node.UID)
-
-				break
-			}
-		}
-	}
-
-	if log.PID == 0 {
-		log.PPID = -1
-		log.PID = hostPid
-		log.UID = -1
-	}
-
-	return log
-}
-
 // GenerateAuditLog Function
 func (adt *AuditLogger) GenerateAuditLog(hostPid int32, profileName, source, operation, resource, action, data string) {
 	log := tp.Log{}
@@ -309,14 +159,14 @@ func (adt *AuditLogger) GenerateAuditLog(hostPid int32, profileName, source, ope
 	log.HostPID = hostPid
 	log.Operation = operation
 
-	if profileName == "kubearmor.host" {
-		log = adt.GetHostProcessInfoFromHostPid(log, hostPid) // PPID, PID, UID
-	} else {
-		log = adt.GetProcessInfoFromHostPid(log, hostPid)           // ContainerID, PPID, PID, UID
+	if profileName == "kubearmor.host" { // host
+		log = adt.GetHostProcessInfoFromHostPid(log, uint32(hostPid)) // PPID, PID, UID
+		log = adt.UpdateHostSourceAndResource(log, source, resource)  // Source, Resource
+	} else { // containers
+		log = adt.GetProcessInfoFromHostPid(log, uint32(hostPid))   // ContainerID, PPID, PID, UID
 		log = adt.GetContainerInfoFromContainerID(log, profileName) // NamespaceName, PodName, ContainerName
+		log = adt.UpdateSourceAndResource(log, source, resource)    // Source, Resource
 	}
-
-	log = adt.UpdateSourceAndResource(log, source, resource) // Source, Resource
 
 	log.Data = data
 
@@ -350,7 +200,7 @@ func (adt *AuditLogger) MonitorAuditLogs() {
 
 		if !strings.Contains(line, "AVC") {
 			continue
-		} else if !strings.Contains(line, "DENIED") && !strings.Contains(line, "AUDIT") {
+		} else if !strings.Contains(line, "DENIED") { // && !strings.Contains(line, "AUDIT") {
 			continue
 		} else if !strings.Contains(line, "exec") && !strings.Contains(line, "open") {
 			continue

--- a/KubeArmor/core/kubeUpdate.go
+++ b/KubeArmor/core/kubeUpdate.go
@@ -68,6 +68,9 @@ func (dm *KubeArmorDaemon) UpdateContainerGroupWithContainer(action string, cont
 			}
 			delete(dm.ContainerGroups[conGroupIdx].AppArmorProfiles, container.ContainerID)
 		}
+
+		// update NsMap
+		dm.SystemMonitor.DeleteContainerIDFromNsMap(container.ContainerID)
 	}
 
 	// enforce security policies
@@ -651,6 +654,10 @@ func (dm *KubeArmorDaemon) WatchHostSecurityPolicies() {
 					break
 				} else if err != nil {
 					break
+				}
+
+				if event.Type == "" {
+					continue
 				}
 
 				dm.HostSecurityPoliciesLock.Lock()

--- a/KubeArmor/enforcer/appArmorEnforcer_test.go
+++ b/KubeArmor/enforcer/appArmorEnforcer_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestAppArmorEnforcer(t *testing.T) {
 	// Create Feeder
-	logFeeder := fd.NewFeeder("32767", "none")
+	logFeeder := fd.NewFeeder("32767", "none", false)
 	if logFeeder == nil {
 		t.Log("[FAIL] Failed to create Feeder")
 		return
@@ -16,7 +16,7 @@ func TestAppArmorEnforcer(t *testing.T) {
 
 	// Create AppArmor Enforcer
 
-	enforcer := NewAppArmorEnforcer(logFeeder, false)
+	enforcer := NewAppArmorEnforcer(logFeeder, false, false)
 	if enforcer == nil {
 		t.Log("[FAIL] Failed to create AppArmor Enforcer")
 		return
@@ -44,7 +44,7 @@ func TestAppArmorEnforcer(t *testing.T) {
 
 func TestAppArmorProfile(t *testing.T) {
 	// Create Feeder
-	logFeeder := fd.NewFeeder("32767", "none")
+	logFeeder := fd.NewFeeder("32767", "none", false)
 	if logFeeder == nil {
 		t.Log("[FAIL] Failed to create Feeder")
 		return
@@ -52,7 +52,7 @@ func TestAppArmorProfile(t *testing.T) {
 
 	// Create AppArmor Enforcer
 
-	enforcer := NewAppArmorEnforcer(logFeeder, false)
+	enforcer := NewAppArmorEnforcer(logFeeder, false, false)
 	if enforcer == nil {
 		t.Log("[FAIL] Failed to create AppArmor Enforcer")
 		return
@@ -77,6 +77,42 @@ func TestAppArmorProfile(t *testing.T) {
 	}
 
 	t.Log("[PASS] Unregister AppArmorProfile")
+
+	// Destroy AppArmor Enforcer
+
+	if err := enforcer.DestroyAppArmorEnforcer(); err != nil {
+		t.Log("[FAIL] Failed to destroy AppArmor Enforcer")
+		return
+	}
+
+	t.Log("[PASS] Destroyed AppArmor Enforcer")
+
+	// destroy Feeder
+	if err := logFeeder.DestroyFeeder(); err != nil {
+		t.Log("[FAIL] Failed to destroy Feeder")
+		return
+	}
+
+	t.Log("[PASS] Destroyed Feeder")
+}
+
+func TestHostAppArmorProfile(t *testing.T) {
+	// Create Feeder
+	logFeeder := fd.NewFeeder("32767", "none", false)
+	if logFeeder == nil {
+		t.Log("[FAIL] Failed to create Feeder")
+		return
+	}
+
+	// Create AppArmor Enforcer
+
+	enforcer := NewAppArmorEnforcer(logFeeder, false, true)
+	if enforcer == nil {
+		t.Log("[FAIL] Failed to create AppArmor Enforcer")
+		return
+	}
+
+	t.Log("[PASS] Created AppArmor Enforcer")
 
 	// Destroy AppArmor Enforcer
 

--- a/KubeArmor/enforcer/appArmorHostProfile.go
+++ b/KubeArmor/enforcer/appArmorHostProfile.go
@@ -20,7 +20,7 @@ import (
 
 //
 
-func auditedHostProcesses(secPolicy tp.HostSecurityPolicy) []string {
+func auditedHostProcesses(enableAuditd bool, secPolicy tp.HostSecurityPolicy) []string {
 	processAuditList := []string{}
 
 	if len(secPolicy.Spec.Process.MatchPaths) > 0 {
@@ -30,13 +30,21 @@ func auditedHostProcesses(secPolicy tp.HostSecurityPolicy) []string {
 			}
 
 			if path.OwnerOnly {
-				// line := fmt.Sprintf("  audit owner %s ix,\n", path.Path)
-				line := fmt.Sprintf("  owner %s ix,\n", path.Path)
-				processAuditList = append(processAuditList, line)
+				if enableAuditd {
+					line := fmt.Sprintf("  audit owner %s ix,\n", path.Path)
+					processAuditList = append(processAuditList, line)
+				} else {
+					line := fmt.Sprintf("  owner %s ix,\n", path.Path)
+					processAuditList = append(processAuditList, line)
+				}
 			} else { // !path.OwnerOnly
-				// line := fmt.Sprintf("  audit %s ix,\n", path.Path)
-				line := fmt.Sprintf("  %s ix,\n", path.Path)
-				processAuditList = append(processAuditList, line)
+				if enableAuditd {
+					line := fmt.Sprintf("  audit %s ix,\n", path.Path)
+					processAuditList = append(processAuditList, line)
+				} else {
+					line := fmt.Sprintf("  %s ix,\n", path.Path)
+					processAuditList = append(processAuditList, line)
+				}
 			}
 		}
 	}
@@ -48,21 +56,37 @@ func auditedHostProcesses(secPolicy tp.HostSecurityPolicy) []string {
 			}
 
 			if dir.Recursive && dir.OwnerOnly {
-				// line := fmt.Sprintf("  audit owner %s{*,**} ix,\n", dir.Directory)
-				line := fmt.Sprintf("  owner %s{*,**} ix,\n", dir.Directory)
-				processAuditList = append(processAuditList, line)
+				if enableAuditd {
+					line := fmt.Sprintf("  audit owner %s{*,**} ix,\n", dir.Directory)
+					processAuditList = append(processAuditList, line)
+				} else {
+					line := fmt.Sprintf("  owner %s{*,**} ix,\n", dir.Directory)
+					processAuditList = append(processAuditList, line)
+				}
 			} else if dir.Recursive && !dir.OwnerOnly {
-				// line := fmt.Sprintf("  audit %s{*,**} ix,\n", dir.Directory)
-				line := fmt.Sprintf("  %s{*,**} ix,\n", dir.Directory)
-				processAuditList = append(processAuditList, line)
+				if enableAuditd {
+					line := fmt.Sprintf("  audit %s{*,**} ix,\n", dir.Directory)
+					processAuditList = append(processAuditList, line)
+				} else {
+					line := fmt.Sprintf("  %s{*,**} ix,\n", dir.Directory)
+					processAuditList = append(processAuditList, line)
+				}
 			} else if !dir.Recursive && dir.OwnerOnly {
-				// line := fmt.Sprintf("  audit owner %s* ix,\n", dir.Directory)
-				line := fmt.Sprintf("  owner %s* ix,\n", dir.Directory)
-				processAuditList = append(processAuditList, line)
+				if enableAuditd {
+					line := fmt.Sprintf("  audit owner %s* ix,\n", dir.Directory)
+					processAuditList = append(processAuditList, line)
+				} else {
+					line := fmt.Sprintf("  owner %s* ix,\n", dir.Directory)
+					processAuditList = append(processAuditList, line)
+				}
 			} else { // !dir.Recursive && !dir.OwnerOnly
-				// line := fmt.Sprintf("  audit %s* ix,\n", dir.Directory)
-				line := fmt.Sprintf("  %s* ix,\n", dir.Directory)
-				processAuditList = append(processAuditList, line)
+				if enableAuditd {
+					line := fmt.Sprintf("  audit %s* ix,\n", dir.Directory)
+					processAuditList = append(processAuditList, line)
+				} else {
+					line := fmt.Sprintf("  %s* ix,\n", dir.Directory)
+					processAuditList = append(processAuditList, line)
+				}
 			}
 		}
 	}
@@ -70,13 +94,21 @@ func auditedHostProcesses(secPolicy tp.HostSecurityPolicy) []string {
 	if len(secPolicy.Spec.Process.MatchPatterns) > 0 {
 		for _, pat := range secPolicy.Spec.Process.MatchPatterns {
 			if pat.OwnerOnly {
-				// line := fmt.Sprintf("  audit owner %s ix,\n", pat.Pattern)
-				line := fmt.Sprintf("  owner %s ix,\n", pat.Pattern)
-				processAuditList = append(processAuditList, line)
+				if enableAuditd {
+					line := fmt.Sprintf("  audit owner %s ix,\n", pat.Pattern)
+					processAuditList = append(processAuditList, line)
+				} else {
+					line := fmt.Sprintf("  owner %s ix,\n", pat.Pattern)
+					processAuditList = append(processAuditList, line)
+				}
 			} else { // !pat.OwnerOnly
-				// line := fmt.Sprintf("  audit %s* ix,\n", pat.Pattern)
-				line := fmt.Sprintf("  %s* ix,\n", pat.Pattern)
-				processAuditList = append(processAuditList, line)
+				if enableAuditd {
+					line := fmt.Sprintf("  audit %s* ix,\n", pat.Pattern)
+					processAuditList = append(processAuditList, line)
+				} else {
+					line := fmt.Sprintf("  %s* ix,\n", pat.Pattern)
+					processAuditList = append(processAuditList, line)
+				}
 			}
 		}
 	}
@@ -84,7 +116,7 @@ func auditedHostProcesses(secPolicy tp.HostSecurityPolicy) []string {
 	return processAuditList
 }
 
-func auditedHostFiles(secPolicy tp.HostSecurityPolicy) []string {
+func auditedHostFiles(enableAuditd bool, secPolicy tp.HostSecurityPolicy) []string {
 	fileAuditList := []string{}
 
 	if len(secPolicy.Spec.File.MatchPaths) > 0 {
@@ -94,21 +126,37 @@ func auditedHostFiles(secPolicy tp.HostSecurityPolicy) []string {
 			}
 
 			if path.ReadOnly && path.OwnerOnly {
-				// line := fmt.Sprintf("  audit owner %s r,\n", path.Path)
-				line := fmt.Sprintf("  owner %s r,\n", path.Path)
-				fileAuditList = append(fileAuditList, line)
+				if enableAuditd {
+					line := fmt.Sprintf("  audit owner %s r,\n", path.Path)
+					fileAuditList = append(fileAuditList, line)
+				} else {
+					line := fmt.Sprintf("  owner %s r,\n", path.Path)
+					fileAuditList = append(fileAuditList, line)
+				}
 			} else if path.ReadOnly && !path.OwnerOnly {
-				// line := fmt.Sprintf("  audit %s r,\n", path.Path)
-				line := fmt.Sprintf("  %s r,\n", path.Path)
-				fileAuditList = append(fileAuditList, line)
+				if enableAuditd {
+					line := fmt.Sprintf("  audit %s r,\n", path.Path)
+					fileAuditList = append(fileAuditList, line)
+				} else {
+					line := fmt.Sprintf("  %s r,\n", path.Path)
+					fileAuditList = append(fileAuditList, line)
+				}
 			} else if !path.ReadOnly && path.OwnerOnly {
-				// line := fmt.Sprintf("  audit owner %s rw,\n", path.Path)
-				line := fmt.Sprintf("  owner %s rw,\n", path.Path)
-				fileAuditList = append(fileAuditList, line)
+				if enableAuditd {
+					line := fmt.Sprintf("  audit owner %s rw,\n", path.Path)
+					fileAuditList = append(fileAuditList, line)
+				} else {
+					line := fmt.Sprintf("  owner %s rw,\n", path.Path)
+					fileAuditList = append(fileAuditList, line)
+				}
 			} else { // !path.ReadOnly && !path.OwnerOnly
-				// line := fmt.Sprintf("  audit %s rw,\n", path.Path)
-				line := fmt.Sprintf("  %s rw,\n", path.Path)
-				fileAuditList = append(fileAuditList, line)
+				if enableAuditd {
+					line := fmt.Sprintf("  audit %s rw,\n", path.Path)
+					fileAuditList = append(fileAuditList, line)
+				} else {
+					line := fmt.Sprintf("  %s rw,\n", path.Path)
+					fileAuditList = append(fileAuditList, line)
+				}
 			}
 		}
 	}
@@ -121,43 +169,75 @@ func auditedHostFiles(secPolicy tp.HostSecurityPolicy) []string {
 
 			if dir.ReadOnly && dir.OwnerOnly {
 				if dir.Recursive {
-					// line := fmt.Sprintf("  audit owner %s{*,**} r,\n", dir.Directory)
-					line := fmt.Sprintf("  owner %s{*,**} r,\n", dir.Directory)
-					fileAuditList = append(fileAuditList, line)
+					if enableAuditd {
+						line := fmt.Sprintf("  audit owner %s{*,**} r,\n", dir.Directory)
+						fileAuditList = append(fileAuditList, line)
+					} else {
+						line := fmt.Sprintf("  owner %s{*,**} r,\n", dir.Directory)
+						fileAuditList = append(fileAuditList, line)
+					}
 				} else {
-					// line := fmt.Sprintf("  audit owner %s* r,\n", dir.Directory)
-					line := fmt.Sprintf("  owner %s* r,\n", dir.Directory)
-					fileAuditList = append(fileAuditList, line)
+					if enableAuditd {
+						line := fmt.Sprintf("  audit owner %s* r,\n", dir.Directory)
+						fileAuditList = append(fileAuditList, line)
+					} else {
+						line := fmt.Sprintf("  owner %s* r,\n", dir.Directory)
+						fileAuditList = append(fileAuditList, line)
+					}
 				}
 			} else if dir.ReadOnly && !dir.OwnerOnly {
 				if dir.Recursive {
-					// line := fmt.Sprintf("  audit %s{*,**} r,\n", dir.Directory)
-					line := fmt.Sprintf("  %s{*,**} r,\n", dir.Directory)
-					fileAuditList = append(fileAuditList, line)
+					if enableAuditd {
+						line := fmt.Sprintf("  audit %s{*,**} r,\n", dir.Directory)
+						fileAuditList = append(fileAuditList, line)
+					} else {
+						line := fmt.Sprintf("  %s{*,**} r,\n", dir.Directory)
+						fileAuditList = append(fileAuditList, line)
+					}
 				} else {
-					// line := fmt.Sprintf("  audit %s* r,\n", dir.Directory)
-					line := fmt.Sprintf("  %s* r,\n", dir.Directory)
-					fileAuditList = append(fileAuditList, line)
+					if enableAuditd {
+						line := fmt.Sprintf("  audit %s* r,\n", dir.Directory)
+						fileAuditList = append(fileAuditList, line)
+					} else {
+						line := fmt.Sprintf("  %s* r,\n", dir.Directory)
+						fileAuditList = append(fileAuditList, line)
+					}
 				}
 			} else if !dir.ReadOnly && dir.OwnerOnly {
 				if dir.Recursive {
-					// line := fmt.Sprintf("  audit owner %s{*,**} rw,\n", dir.Directory)
-					line := fmt.Sprintf("  owner %s{*,**} rw,\n", dir.Directory)
-					fileAuditList = append(fileAuditList, line)
+					if enableAuditd {
+						line := fmt.Sprintf("  audit owner %s{*,**} rw,\n", dir.Directory)
+						fileAuditList = append(fileAuditList, line)
+					} else {
+						line := fmt.Sprintf("  owner %s{*,**} rw,\n", dir.Directory)
+						fileAuditList = append(fileAuditList, line)
+					}
 				} else {
-					// line := fmt.Sprintf("  audit owner %s* rw,\n", dir.Directory)
-					line := fmt.Sprintf("  owner %s* rw,\n", dir.Directory)
-					fileAuditList = append(fileAuditList, line)
+					if enableAuditd {
+						line := fmt.Sprintf("  audit owner %s* rw,\n", dir.Directory)
+						fileAuditList = append(fileAuditList, line)
+					} else {
+						line := fmt.Sprintf("  owner %s* rw,\n", dir.Directory)
+						fileAuditList = append(fileAuditList, line)
+					}
 				}
 			} else { // !dir.ReadOnly && !dir.OwnerOnly
 				if dir.Recursive {
-					// line := fmt.Sprintf("  audit %s{*,**} rw,\n", dir.Directory)
-					line := fmt.Sprintf("  %s{*,**} rw,\n", dir.Directory)
-					fileAuditList = append(fileAuditList, line)
+					if enableAuditd {
+						line := fmt.Sprintf("  audit %s{*,**} rw,\n", dir.Directory)
+						fileAuditList = append(fileAuditList, line)
+					} else {
+						line := fmt.Sprintf("  %s{*,**} rw,\n", dir.Directory)
+						fileAuditList = append(fileAuditList, line)
+					}
 				} else {
-					// line := fmt.Sprintf("  audit %s* rw,\n", dir.Directory)
-					line := fmt.Sprintf("  %s* rw,\n", dir.Directory)
-					fileAuditList = append(fileAuditList, line)
+					if enableAuditd {
+						line := fmt.Sprintf("  audit %s* rw,\n", dir.Directory)
+						fileAuditList = append(fileAuditList, line)
+					} else {
+						line := fmt.Sprintf("  %s* rw,\n", dir.Directory)
+						fileAuditList = append(fileAuditList, line)
+					}
 				}
 			}
 		}
@@ -166,21 +246,37 @@ func auditedHostFiles(secPolicy tp.HostSecurityPolicy) []string {
 	if len(secPolicy.Spec.File.MatchPatterns) > 0 {
 		for _, pat := range secPolicy.Spec.File.MatchPatterns {
 			if pat.ReadOnly && pat.OwnerOnly {
-				// line := fmt.Sprintf("  audit owner %s r,\n", pat.Pattern)
-				line := fmt.Sprintf("  owner %s r,\n", pat.Pattern)
-				fileAuditList = append(fileAuditList, line)
+				if enableAuditd {
+					line := fmt.Sprintf("  audit owner %s r,\n", pat.Pattern)
+					fileAuditList = append(fileAuditList, line)
+				} else {
+					line := fmt.Sprintf("  owner %s r,\n", pat.Pattern)
+					fileAuditList = append(fileAuditList, line)
+				}
 			} else if pat.ReadOnly && !pat.OwnerOnly {
-				// line := fmt.Sprintf("  audit %s r,\n", pat.Pattern)
-				line := fmt.Sprintf("  %s r,\n", pat.Pattern)
-				fileAuditList = append(fileAuditList, line)
+				if enableAuditd {
+					line := fmt.Sprintf("  audit %s r,\n", pat.Pattern)
+					fileAuditList = append(fileAuditList, line)
+				} else {
+					line := fmt.Sprintf("  %s r,\n", pat.Pattern)
+					fileAuditList = append(fileAuditList, line)
+				}
 			} else if !pat.ReadOnly && pat.OwnerOnly {
-				// line := fmt.Sprintf("  audit owner %s rw,\n", pat.Pattern)
-				line := fmt.Sprintf("  owner %s rw,\n", pat.Pattern)
-				fileAuditList = append(fileAuditList, line)
+				if enableAuditd {
+					line := fmt.Sprintf("  audit owner %s rw,\n", pat.Pattern)
+					fileAuditList = append(fileAuditList, line)
+				} else {
+					line := fmt.Sprintf("  owner %s rw,\n", pat.Pattern)
+					fileAuditList = append(fileAuditList, line)
+				}
 			} else { // !pat.ReadOnly && !pat.OwnerOnly
-				// line := fmt.Sprintf("  audit %s rw,\n", pat.Pattern)
-				line := fmt.Sprintf("  %s rw,\n", pat.Pattern)
-				fileAuditList = append(fileAuditList, line)
+				if enableAuditd {
+					line := fmt.Sprintf("  audit %s rw,\n", pat.Pattern)
+					fileAuditList = append(fileAuditList, line)
+				} else {
+					line := fmt.Sprintf("  %s rw,\n", pat.Pattern)
+					fileAuditList = append(fileAuditList, line)
+				}
 			}
 		}
 	}
@@ -190,7 +286,7 @@ func auditedHostFiles(secPolicy tp.HostSecurityPolicy) []string {
 
 //
 
-func blockedHostProcesses(secPolicy tp.HostSecurityPolicy) []string {
+func blockedHostProcesses(enableAuditd bool, secPolicy tp.HostSecurityPolicy) []string {
 	processBlackList := []string{}
 
 	if len(secPolicy.Spec.Process.MatchPaths) > 0 {
@@ -200,10 +296,20 @@ func blockedHostProcesses(secPolicy tp.HostSecurityPolicy) []string {
 			}
 
 			if path.OwnerOnly {
+				if enableAuditd {
+					//
+				} else {
+					//
+				}
 				// line := fmt.Sprintf("  audit owner %s ix,\n", path.Path)
 				line := fmt.Sprintf("  owner %s ix,\n", path.Path)
 				processBlackList = append(processBlackList, line)
 			} else { // !path.OwnerOnly
+				if enableAuditd {
+					//
+				} else {
+					//
+				}
 				// line := fmt.Sprintf("  audit deny %s x,\n", path.Path)
 				line := fmt.Sprintf("  deny %s x,\n", path.Path)
 				processBlackList = append(processBlackList, line)
@@ -218,21 +324,37 @@ func blockedHostProcesses(secPolicy tp.HostSecurityPolicy) []string {
 			}
 
 			if dir.Recursive && dir.OwnerOnly {
-				// line := fmt.Sprintf("  audit owner %s{*,**} ix,\n", dir.Directory)
-				line := fmt.Sprintf("  owner %s{*,**} ix,\n", dir.Directory)
-				processBlackList = append(processBlackList, line)
+				if enableAuditd {
+					line := fmt.Sprintf("  audit owner %s{*,**} ix,\n", dir.Directory)
+					processBlackList = append(processBlackList, line)
+				} else {
+					line := fmt.Sprintf("  owner %s{*,**} ix,\n", dir.Directory)
+					processBlackList = append(processBlackList, line)
+				}
 			} else if dir.Recursive && !dir.OwnerOnly {
-				// line := fmt.Sprintf("  audit deny %s{*,**} x,\n", dir.Directory)
-				line := fmt.Sprintf("  deny %s{*,**} x,\n", dir.Directory)
-				processBlackList = append(processBlackList, line)
+				if enableAuditd {
+					line := fmt.Sprintf("  audit deny %s{*,**} x,\n", dir.Directory)
+					processBlackList = append(processBlackList, line)
+				} else {
+					line := fmt.Sprintf("  deny %s{*,**} x,\n", dir.Directory)
+					processBlackList = append(processBlackList, line)
+				}
 			} else if !dir.Recursive && dir.OwnerOnly {
-				// line := fmt.Sprintf("  audit owner %s* ix,\n", dir.Directory)
-				line := fmt.Sprintf("  owner %s* ix,\n", dir.Directory)
-				processBlackList = append(processBlackList, line)
+				if enableAuditd {
+					line := fmt.Sprintf("  audit owner %s* ix,\n", dir.Directory)
+					processBlackList = append(processBlackList, line)
+				} else {
+					line := fmt.Sprintf("  owner %s* ix,\n", dir.Directory)
+					processBlackList = append(processBlackList, line)
+				}
 			} else { // !dir.Recursive && !dir.OwnerOnly
-				// line := fmt.Sprintf("  audit deny %s* x,\n", dir.Directory)
-				line := fmt.Sprintf("  deny %s* x,\n", dir.Directory)
-				processBlackList = append(processBlackList, line)
+				if enableAuditd {
+					line := fmt.Sprintf("  audit deny %s* x,\n", dir.Directory)
+					processBlackList = append(processBlackList, line)
+				} else {
+					line := fmt.Sprintf("  deny %s* x,\n", dir.Directory)
+					processBlackList = append(processBlackList, line)
+				}
 			}
 		}
 	}
@@ -240,13 +362,21 @@ func blockedHostProcesses(secPolicy tp.HostSecurityPolicy) []string {
 	if len(secPolicy.Spec.Process.MatchPatterns) > 0 {
 		for _, pat := range secPolicy.Spec.Process.MatchPatterns {
 			if pat.OwnerOnly {
-				// line := fmt.Sprintf("  audit owner %s ix,\n", pat.Pattern)
-				line := fmt.Sprintf("  owner %s ix,\n", pat.Pattern)
-				processBlackList = append(processBlackList, line)
+				if enableAuditd {
+					line := fmt.Sprintf("  audit owner %s ix,\n", pat.Pattern)
+					processBlackList = append(processBlackList, line)
+				} else {
+					line := fmt.Sprintf("  owner %s ix,\n", pat.Pattern)
+					processBlackList = append(processBlackList, line)
+				}
 			} else { // !path.OwnerOnly
-				// line := fmt.Sprintf("  audit deny %s x,\n", pat.Pattern)
-				line := fmt.Sprintf("  deny %s x,\n", pat.Pattern)
-				processBlackList = append(processBlackList, line)
+				if enableAuditd {
+					line := fmt.Sprintf("  audit deny %s x,\n", pat.Pattern)
+					processBlackList = append(processBlackList, line)
+				} else {
+					line := fmt.Sprintf("  deny %s x,\n", pat.Pattern)
+					processBlackList = append(processBlackList, line)
+				}
 			}
 		}
 	}
@@ -254,7 +384,7 @@ func blockedHostProcesses(secPolicy tp.HostSecurityPolicy) []string {
 	return processBlackList
 }
 
-func blockedHostFiles(secPolicy tp.HostSecurityPolicy) []string {
+func blockedHostFiles(enableAuditd bool, secPolicy tp.HostSecurityPolicy) []string {
 	fileBlackList := []string{}
 
 	if len(secPolicy.Spec.File.MatchPaths) > 0 {
@@ -264,21 +394,37 @@ func blockedHostFiles(secPolicy tp.HostSecurityPolicy) []string {
 			}
 
 			if path.ReadOnly && path.OwnerOnly {
-				// line := fmt.Sprintf("  audit owner %s r,\n", path.Path)
-				line := fmt.Sprintf("  owner %s r,\n", path.Path)
-				fileBlackList = append(fileBlackList, line)
+				if enableAuditd {
+					line := fmt.Sprintf("  audit owner %s r,\n", path.Path)
+					fileBlackList = append(fileBlackList, line)
+				} else {
+					line := fmt.Sprintf("  owner %s r,\n", path.Path)
+					fileBlackList = append(fileBlackList, line)
+				}
 			} else if path.ReadOnly && !path.OwnerOnly {
-				// line := fmt.Sprintf("  audit deny %s w,\n", path.Path)
-				line := fmt.Sprintf("  deny %s w,\n", path.Path)
-				fileBlackList = append(fileBlackList, line)
+				if enableAuditd {
+					line := fmt.Sprintf("  audit deny %s w,\n", path.Path)
+					fileBlackList = append(fileBlackList, line)
+				} else {
+					line := fmt.Sprintf("  deny %s w,\n", path.Path)
+					fileBlackList = append(fileBlackList, line)
+				}
 			} else if !path.ReadOnly && path.OwnerOnly {
-				// line := fmt.Sprintf("  audit owner %s rw,\n", path.Path)
-				line := fmt.Sprintf("  owner %s rw,\n", path.Path)
-				fileBlackList = append(fileBlackList, line)
+				if enableAuditd {
+					line := fmt.Sprintf("  audit owner %s rw,\n", path.Path)
+					fileBlackList = append(fileBlackList, line)
+				} else {
+					line := fmt.Sprintf("  owner %s rw,\n", path.Path)
+					fileBlackList = append(fileBlackList, line)
+				}
 			} else { // !path.ReadOnly && !path.OwnerOnly
-				// line := fmt.Sprintf("  audit deny %s rw,\n", path.Path)
-				line := fmt.Sprintf("  deny %s rw,\n", path.Path)
-				fileBlackList = append(fileBlackList, line)
+				if enableAuditd {
+					line := fmt.Sprintf("  audit deny %s rw,\n", path.Path)
+					fileBlackList = append(fileBlackList, line)
+				} else {
+					line := fmt.Sprintf("  deny %s rw,\n", path.Path)
+					fileBlackList = append(fileBlackList, line)
+				}
 			}
 		}
 	}
@@ -291,43 +437,75 @@ func blockedHostFiles(secPolicy tp.HostSecurityPolicy) []string {
 
 			if dir.ReadOnly && dir.OwnerOnly {
 				if dir.Recursive {
-					// line := fmt.Sprintf("  audit owner %s{*,**} r,\n", dir.Directory)
-					line := fmt.Sprintf("  owner %s{*,**} r,\n", dir.Directory)
-					fileBlackList = append(fileBlackList, line)
+					if enableAuditd {
+						line := fmt.Sprintf("  audit owner %s{*,**} r,\n", dir.Directory)
+						fileBlackList = append(fileBlackList, line)
+					} else {
+						line := fmt.Sprintf("  owner %s{*,**} r,\n", dir.Directory)
+						fileBlackList = append(fileBlackList, line)
+					}
 				} else {
-					// line := fmt.Sprintf("  audit owner %s* r,\n", dir.Directory)
-					line := fmt.Sprintf("  owner %s* r,\n", dir.Directory)
-					fileBlackList = append(fileBlackList, line)
+					if enableAuditd {
+						line := fmt.Sprintf("  audit owner %s* r,\n", dir.Directory)
+						fileBlackList = append(fileBlackList, line)
+					} else {
+						line := fmt.Sprintf("  owner %s* r,\n", dir.Directory)
+						fileBlackList = append(fileBlackList, line)
+					}
 				}
 			} else if dir.ReadOnly && !dir.OwnerOnly {
 				if dir.Recursive {
-					// line := fmt.Sprintf("  audit deny %s{*,**} w,\n", dir.Directory)
-					line := fmt.Sprintf("  deny %s{*,**} w,\n", dir.Directory)
-					fileBlackList = append(fileBlackList, line)
+					if enableAuditd {
+						line := fmt.Sprintf("  audit deny %s{*,**} w,\n", dir.Directory)
+						fileBlackList = append(fileBlackList, line)
+					} else {
+						line := fmt.Sprintf("  deny %s{*,**} w,\n", dir.Directory)
+						fileBlackList = append(fileBlackList, line)
+					}
 				} else {
-					// line := fmt.Sprintf("  audit deny %s* w,\n", dir.Directory)
-					line := fmt.Sprintf("  deny %s* w,\n", dir.Directory)
-					fileBlackList = append(fileBlackList, line)
+					if enableAuditd {
+						line := fmt.Sprintf("  audit deny %s* w,\n", dir.Directory)
+						fileBlackList = append(fileBlackList, line)
+					} else {
+						line := fmt.Sprintf("  deny %s* w,\n", dir.Directory)
+						fileBlackList = append(fileBlackList, line)
+					}
 				}
 			} else if !dir.ReadOnly && dir.OwnerOnly {
 				if dir.Recursive {
-					// line := fmt.Sprintf("  audit owner %s{*,**} rw,\n", dir.Directory)
-					line := fmt.Sprintf("  owner %s{*,**} rw,\n", dir.Directory)
-					fileBlackList = append(fileBlackList, line)
+					if enableAuditd {
+						line := fmt.Sprintf("  audit owner %s{*,**} rw,\n", dir.Directory)
+						fileBlackList = append(fileBlackList, line)
+					} else {
+						line := fmt.Sprintf("  owner %s{*,**} rw,\n", dir.Directory)
+						fileBlackList = append(fileBlackList, line)
+					}
 				} else {
-					// line := fmt.Sprintf("  audit owner %s* rw,\n", dir.Directory)
-					line := fmt.Sprintf("  owner %s* rw,\n", dir.Directory)
-					fileBlackList = append(fileBlackList, line)
+					if enableAuditd {
+						line := fmt.Sprintf("  audit owner %s* rw,\n", dir.Directory)
+						fileBlackList = append(fileBlackList, line)
+					} else {
+						line := fmt.Sprintf("  owner %s* rw,\n", dir.Directory)
+						fileBlackList = append(fileBlackList, line)
+					}
 				}
 			} else { // !dir.ReadOnly && !dir.OwnerOnly
 				if dir.Recursive {
-					// line := fmt.Sprintf("  audit deny %s{*,**} rw,\n", dir.Directory)
-					line := fmt.Sprintf("  deny %s{*,**} rw,\n", dir.Directory)
-					fileBlackList = append(fileBlackList, line)
+					if enableAuditd {
+						line := fmt.Sprintf("  audit deny %s{*,**} rw,\n", dir.Directory)
+						fileBlackList = append(fileBlackList, line)
+					} else {
+						line := fmt.Sprintf("  deny %s{*,**} rw,\n", dir.Directory)
+						fileBlackList = append(fileBlackList, line)
+					}
 				} else {
-					// line := fmt.Sprintf("  audit deny %s* rw,\n", dir.Directory)
-					line := fmt.Sprintf("  deny %s* rw,\n", dir.Directory)
-					fileBlackList = append(fileBlackList, line)
+					if enableAuditd {
+						line := fmt.Sprintf("  audit deny %s* rw,\n", dir.Directory)
+						fileBlackList = append(fileBlackList, line)
+					} else {
+						line := fmt.Sprintf("  deny %s* rw,\n", dir.Directory)
+						fileBlackList = append(fileBlackList, line)
+					}
 				}
 			}
 		}
@@ -336,21 +514,37 @@ func blockedHostFiles(secPolicy tp.HostSecurityPolicy) []string {
 	if len(secPolicy.Spec.File.MatchPatterns) > 0 {
 		for _, pat := range secPolicy.Spec.File.MatchPatterns {
 			if pat.ReadOnly && pat.OwnerOnly {
-				// line := fmt.Sprintf("  audit owner %s r,\n", pat.Pattern)
-				line := fmt.Sprintf("  owner %s r,\n", pat.Pattern)
-				fileBlackList = append(fileBlackList, line)
+				if enableAuditd {
+					line := fmt.Sprintf("  audit owner %s r,\n", pat.Pattern)
+					fileBlackList = append(fileBlackList, line)
+				} else {
+					line := fmt.Sprintf("  owner %s r,\n", pat.Pattern)
+					fileBlackList = append(fileBlackList, line)
+				}
 			} else if pat.ReadOnly && !pat.OwnerOnly {
-				// line := fmt.Sprintf("  audit deny %s w,\n", pat.Pattern)
-				line := fmt.Sprintf("  deny %s w,\n", pat.Pattern)
-				fileBlackList = append(fileBlackList, line)
+				if enableAuditd {
+					line := fmt.Sprintf("  audit deny %s w,\n", pat.Pattern)
+					fileBlackList = append(fileBlackList, line)
+				} else {
+					line := fmt.Sprintf("  deny %s w,\n", pat.Pattern)
+					fileBlackList = append(fileBlackList, line)
+				}
 			} else if !pat.ReadOnly && pat.OwnerOnly {
-				// line := fmt.Sprintf("  audit owner %s rw,\n", pat.Pattern)
-				line := fmt.Sprintf("  owner %s rw,\n", pat.Pattern)
-				fileBlackList = append(fileBlackList, line)
+				if enableAuditd {
+					line := fmt.Sprintf("  audit owner %s rw,\n", pat.Pattern)
+					fileBlackList = append(fileBlackList, line)
+				} else {
+					line := fmt.Sprintf("  owner %s rw,\n", pat.Pattern)
+					fileBlackList = append(fileBlackList, line)
+				}
 			} else { // !pat.ReadOnly && !pat.OwnerOnly
-				// line := fmt.Sprintf("  audit deny %s rw,\n", pat.Pattern)
-				line := fmt.Sprintf("  deny %s rw,\n", pat.Pattern)
-				fileBlackList = append(fileBlackList, line)
+				if enableAuditd {
+					line := fmt.Sprintf("  audit deny %s rw,\n", pat.Pattern)
+					fileBlackList = append(fileBlackList, line)
+				} else {
+					line := fmt.Sprintf("  deny %s rw,\n", pat.Pattern)
+					fileBlackList = append(fileBlackList, line)
+				}
 			}
 		}
 	}
@@ -364,7 +558,7 @@ func blockedHostFiles(secPolicy tp.HostSecurityPolicy) []string {
 
 // == //
 
-func allowedHostProcessesFromSource(secPolicy tp.HostSecurityPolicy, fromSources map[string][]string) {
+func allowedHostProcessesFromSource(enableAuditd bool, secPolicy tp.HostSecurityPolicy, fromSources map[string][]string) {
 	if len(secPolicy.Spec.Process.MatchPaths) > 0 {
 		for _, path := range secPolicy.Spec.Process.MatchPaths {
 			if len(path.FromSource) == 0 {
@@ -396,16 +590,28 @@ func allowedHostProcessesFromSource(secPolicy tp.HostSecurityPolicy, fromSources
 				}
 
 				if path.OwnerOnly {
-					// line := fmt.Sprintf("  audit owner %s ix,\n", path.Path)
-					line := fmt.Sprintf("  owner %s ix,\n", path.Path)
-					if !kl.ContainsElement(fromSources[source], line) {
-						fromSources[source] = append(fromSources[source], line)
+					if enableAuditd {
+						line := fmt.Sprintf("  audit owner %s ix,\n", path.Path)
+						if !kl.ContainsElement(fromSources[source], line) {
+							fromSources[source] = append(fromSources[source], line)
+						}
+					} else {
+						line := fmt.Sprintf("  owner %s ix,\n", path.Path)
+						if !kl.ContainsElement(fromSources[source], line) {
+							fromSources[source] = append(fromSources[source], line)
+						}
 					}
 				} else { // !path.OwnerOnly
-					// line := fmt.Sprintf("  audit %s ix,\n", path.Path)
-					line := fmt.Sprintf("  %s ix,\n", path.Path)
-					if !kl.ContainsElement(fromSources[source], line) {
-						fromSources[source] = append(fromSources[source], line)
+					if enableAuditd {
+						line := fmt.Sprintf("  audit %s ix,\n", path.Path)
+						if !kl.ContainsElement(fromSources[source], line) {
+							fromSources[source] = append(fromSources[source], line)
+						}
+					} else {
+						line := fmt.Sprintf("  %s ix,\n", path.Path)
+						if !kl.ContainsElement(fromSources[source], line) {
+							fromSources[source] = append(fromSources[source], line)
+						}
 					}
 				}
 			}
@@ -443,28 +649,52 @@ func allowedHostProcessesFromSource(secPolicy tp.HostSecurityPolicy, fromSources
 				}
 
 				if dir.Recursive && dir.OwnerOnly {
-					// line := fmt.Sprintf("  audit owner %s{*,**} ix,\n", dir.Directory)
-					line := fmt.Sprintf("  owner %s{*,**} ix,\n", dir.Directory)
-					if !kl.ContainsElement(fromSources[source], line) {
-						fromSources[source] = append(fromSources[source], line)
+					if enableAuditd {
+						line := fmt.Sprintf("  audit owner %s{*,**} ix,\n", dir.Directory)
+						if !kl.ContainsElement(fromSources[source], line) {
+							fromSources[source] = append(fromSources[source], line)
+						}
+					} else {
+						line := fmt.Sprintf("  owner %s{*,**} ix,\n", dir.Directory)
+						if !kl.ContainsElement(fromSources[source], line) {
+							fromSources[source] = append(fromSources[source], line)
+						}
 					}
 				} else if dir.Recursive && !dir.OwnerOnly {
-					// line := fmt.Sprintf("  audit %s{*,**} ix,\n", dir.Directory)
-					line := fmt.Sprintf("  %s{*,**} ix,\n", dir.Directory)
-					if !kl.ContainsElement(fromSources[source], line) {
-						fromSources[source] = append(fromSources[source], line)
+					if enableAuditd {
+						line := fmt.Sprintf("  audit %s{*,**} ix,\n", dir.Directory)
+						if !kl.ContainsElement(fromSources[source], line) {
+							fromSources[source] = append(fromSources[source], line)
+						}
+					} else {
+						line := fmt.Sprintf("  %s{*,**} ix,\n", dir.Directory)
+						if !kl.ContainsElement(fromSources[source], line) {
+							fromSources[source] = append(fromSources[source], line)
+						}
 					}
 				} else if !dir.Recursive && dir.OwnerOnly {
-					// line := fmt.Sprintf("  audit owner %s* ix,\n", dir.Directory)
-					line := fmt.Sprintf("  owner %s* ix,\n", dir.Directory)
-					if !kl.ContainsElement(fromSources[source], line) {
-						fromSources[source] = append(fromSources[source], line)
+					if enableAuditd {
+						line := fmt.Sprintf("  audit owner %s* ix,\n", dir.Directory)
+						if !kl.ContainsElement(fromSources[source], line) {
+							fromSources[source] = append(fromSources[source], line)
+						}
+					} else {
+						line := fmt.Sprintf("  owner %s* ix,\n", dir.Directory)
+						if !kl.ContainsElement(fromSources[source], line) {
+							fromSources[source] = append(fromSources[source], line)
+						}
 					}
 				} else { // !dir.Recursive && !dir.OwnerOnly
-					// line := fmt.Sprintf("  audit %s* ix,\n", dir.Directory)
-					line := fmt.Sprintf("  %s* ix,\n", dir.Directory)
-					if !kl.ContainsElement(fromSources[source], line) {
-						fromSources[source] = append(fromSources[source], line)
+					if enableAuditd {
+						line := fmt.Sprintf("  audit %s* ix,\n", dir.Directory)
+						if !kl.ContainsElement(fromSources[source], line) {
+							fromSources[source] = append(fromSources[source], line)
+						}
+					} else {
+						line := fmt.Sprintf("  %s* ix,\n", dir.Directory)
+						if !kl.ContainsElement(fromSources[source], line) {
+							fromSources[source] = append(fromSources[source], line)
+						}
 					}
 				}
 			}
@@ -472,7 +702,7 @@ func allowedHostProcessesFromSource(secPolicy tp.HostSecurityPolicy, fromSources
 	}
 }
 
-func allowedHostFilesFromSource(secPolicy tp.HostSecurityPolicy, fromSources map[string][]string) {
+func allowedHostFilesFromSource(enableAuditd bool, secPolicy tp.HostSecurityPolicy, fromSources map[string][]string) {
 	if len(secPolicy.Spec.File.MatchPaths) > 0 {
 		for _, path := range secPolicy.Spec.File.MatchPaths {
 			if len(path.FromSource) == 0 {
@@ -504,28 +734,52 @@ func allowedHostFilesFromSource(secPolicy tp.HostSecurityPolicy, fromSources map
 				}
 
 				if path.ReadOnly && path.OwnerOnly {
-					// line := fmt.Sprintf("  audit owner %s r,\n", path.Path)
-					line := fmt.Sprintf("  owner %s r,\n", path.Path)
-					if !kl.ContainsElement(fromSources[source], line) {
-						fromSources[source] = append(fromSources[source], line)
+					if enableAuditd {
+						line := fmt.Sprintf("  audit owner %s r,\n", path.Path)
+						if !kl.ContainsElement(fromSources[source], line) {
+							fromSources[source] = append(fromSources[source], line)
+						}
+					} else {
+						line := fmt.Sprintf("  owner %s r,\n", path.Path)
+						if !kl.ContainsElement(fromSources[source], line) {
+							fromSources[source] = append(fromSources[source], line)
+						}
 					}
 				} else if path.ReadOnly && !path.OwnerOnly {
-					// line := fmt.Sprintf("  audit %s r,\n", path.Path)
-					line := fmt.Sprintf("  %s r,\n", path.Path)
-					if !kl.ContainsElement(fromSources[source], line) {
-						fromSources[source] = append(fromSources[source], line)
+					if enableAuditd {
+						line := fmt.Sprintf("  audit %s r,\n", path.Path)
+						if !kl.ContainsElement(fromSources[source], line) {
+							fromSources[source] = append(fromSources[source], line)
+						}
+					} else {
+						line := fmt.Sprintf("  %s r,\n", path.Path)
+						if !kl.ContainsElement(fromSources[source], line) {
+							fromSources[source] = append(fromSources[source], line)
+						}
 					}
 				} else if !path.ReadOnly && path.OwnerOnly {
-					// line := fmt.Sprintf("  audit owner %s rw,\n", path.Path)
-					line := fmt.Sprintf("  owner %s rw,\n", path.Path)
-					if !kl.ContainsElement(fromSources[source], line) {
-						fromSources[source] = append(fromSources[source], line)
+					if enableAuditd {
+						line := fmt.Sprintf("  audit owner %s rw,\n", path.Path)
+						if !kl.ContainsElement(fromSources[source], line) {
+							fromSources[source] = append(fromSources[source], line)
+						}
+					} else {
+						line := fmt.Sprintf("  owner %s rw,\n", path.Path)
+						if !kl.ContainsElement(fromSources[source], line) {
+							fromSources[source] = append(fromSources[source], line)
+						}
 					}
 				} else { // !path.ReadOnly && !path.OwnerOnly
-					// line := fmt.Sprintf("  audit %s rw,\n", path.Path)
-					line := fmt.Sprintf("  %s rw,\n", path.Path)
-					if !kl.ContainsElement(fromSources[source], line) {
-						fromSources[source] = append(fromSources[source], line)
+					if enableAuditd {
+						line := fmt.Sprintf("  audit %s rw,\n", path.Path)
+						if !kl.ContainsElement(fromSources[source], line) {
+							fromSources[source] = append(fromSources[source], line)
+						}
+					} else {
+						line := fmt.Sprintf("  %s rw,\n", path.Path)
+						if !kl.ContainsElement(fromSources[source], line) {
+							fromSources[source] = append(fromSources[source], line)
+						}
 					}
 				}
 			}
@@ -564,58 +818,106 @@ func allowedHostFilesFromSource(secPolicy tp.HostSecurityPolicy, fromSources map
 
 				if dir.ReadOnly && dir.OwnerOnly {
 					if dir.Recursive {
-						// line := fmt.Sprintf("  audit owner %s{*,**} r,\n", dir.Directory)
-						line := fmt.Sprintf("  owner %s{*,**} r,\n", dir.Directory)
-						if !kl.ContainsElement(fromSources[source], line) {
-							fromSources[source] = append(fromSources[source], line)
+						if enableAuditd {
+							line := fmt.Sprintf("  audit owner %s{*,**} r,\n", dir.Directory)
+							if !kl.ContainsElement(fromSources[source], line) {
+								fromSources[source] = append(fromSources[source], line)
+							}
+						} else {
+							line := fmt.Sprintf("  owner %s{*,**} r,\n", dir.Directory)
+							if !kl.ContainsElement(fromSources[source], line) {
+								fromSources[source] = append(fromSources[source], line)
+							}
 						}
 					} else {
-						// line := fmt.Sprintf("  audit owner %s* r,\n", dir.Directory)
-						line := fmt.Sprintf("  owner %s* r,\n", dir.Directory)
-						if !kl.ContainsElement(fromSources[source], line) {
-							fromSources[source] = append(fromSources[source], line)
+						if enableAuditd {
+							line := fmt.Sprintf("  audit owner %s* r,\n", dir.Directory)
+							if !kl.ContainsElement(fromSources[source], line) {
+								fromSources[source] = append(fromSources[source], line)
+							}
+						} else {
+							line := fmt.Sprintf("  owner %s* r,\n", dir.Directory)
+							if !kl.ContainsElement(fromSources[source], line) {
+								fromSources[source] = append(fromSources[source], line)
+							}
 						}
 					}
 				} else if dir.ReadOnly && !dir.OwnerOnly {
 					if dir.Recursive {
-						// line := fmt.Sprintf("  audit %s{*,**} r,\n", dir.Directory)
-						line := fmt.Sprintf("  %s{*,**} r,\n", dir.Directory)
-						if !kl.ContainsElement(fromSources[source], line) {
-							fromSources[source] = append(fromSources[source], line)
+						if enableAuditd {
+							line := fmt.Sprintf("  audit %s{*,**} r,\n", dir.Directory)
+							if !kl.ContainsElement(fromSources[source], line) {
+								fromSources[source] = append(fromSources[source], line)
+							}
+						} else {
+							line := fmt.Sprintf("  %s{*,**} r,\n", dir.Directory)
+							if !kl.ContainsElement(fromSources[source], line) {
+								fromSources[source] = append(fromSources[source], line)
+							}
 						}
 					} else {
-						// line := fmt.Sprintf("  audit %s* r,\n", dir.Directory)
-						line := fmt.Sprintf("  %s* r,\n", dir.Directory)
-						if !kl.ContainsElement(fromSources[source], line) {
-							fromSources[source] = append(fromSources[source], line)
+						if enableAuditd {
+							line := fmt.Sprintf("  audit %s* r,\n", dir.Directory)
+							if !kl.ContainsElement(fromSources[source], line) {
+								fromSources[source] = append(fromSources[source], line)
+							}
+						} else {
+							line := fmt.Sprintf("  %s* r,\n", dir.Directory)
+							if !kl.ContainsElement(fromSources[source], line) {
+								fromSources[source] = append(fromSources[source], line)
+							}
 						}
 					}
 				} else if !dir.ReadOnly && dir.OwnerOnly {
 					if dir.Recursive {
-						// line := fmt.Sprintf("  audit owner %s{*,**} rw,\n", dir.Directory)
-						line := fmt.Sprintf("  owner %s{*,**} rw,\n", dir.Directory)
-						if !kl.ContainsElement(fromSources[source], line) {
-							fromSources[source] = append(fromSources[source], line)
+						if enableAuditd {
+							line := fmt.Sprintf("  audit owner %s{*,**} rw,\n", dir.Directory)
+							if !kl.ContainsElement(fromSources[source], line) {
+								fromSources[source] = append(fromSources[source], line)
+							}
+						} else {
+							line := fmt.Sprintf("  owner %s{*,**} rw,\n", dir.Directory)
+							if !kl.ContainsElement(fromSources[source], line) {
+								fromSources[source] = append(fromSources[source], line)
+							}
 						}
 					} else {
-						// line := fmt.Sprintf("  audit owner %s* rw,\n", dir.Directory)
-						line := fmt.Sprintf("  owner %s* rw,\n", dir.Directory)
-						if !kl.ContainsElement(fromSources[source], line) {
-							fromSources[source] = append(fromSources[source], line)
+						if enableAuditd {
+							line := fmt.Sprintf("  audit owner %s* rw,\n", dir.Directory)
+							if !kl.ContainsElement(fromSources[source], line) {
+								fromSources[source] = append(fromSources[source], line)
+							}
+						} else {
+							line := fmt.Sprintf("  owner %s* rw,\n", dir.Directory)
+							if !kl.ContainsElement(fromSources[source], line) {
+								fromSources[source] = append(fromSources[source], line)
+							}
 						}
 					}
 				} else { // !dir.ReadOnly && !dir.OwnerOnly
 					if dir.Recursive {
-						// line := fmt.Sprintf("  audit %s{*,**} rw,\n", dir.Directory)
-						line := fmt.Sprintf("  %s{*,**} rw,\n", dir.Directory)
-						if !kl.ContainsElement(fromSources[source], line) {
-							fromSources[source] = append(fromSources[source], line)
+						if enableAuditd {
+							line := fmt.Sprintf("  audit %s{*,**} rw,\n", dir.Directory)
+							if !kl.ContainsElement(fromSources[source], line) {
+								fromSources[source] = append(fromSources[source], line)
+							}
+						} else {
+							line := fmt.Sprintf("  %s{*,**} rw,\n", dir.Directory)
+							if !kl.ContainsElement(fromSources[source], line) {
+								fromSources[source] = append(fromSources[source], line)
+							}
 						}
 					} else {
-						// line := fmt.Sprintf("  audit %s* rw,\n", dir.Directory)
-						line := fmt.Sprintf("  %s* rw,\n", dir.Directory)
-						if !kl.ContainsElement(fromSources[source], line) {
-							fromSources[source] = append(fromSources[source], line)
+						if enableAuditd {
+							line := fmt.Sprintf("  audit %s* rw,\n", dir.Directory)
+							if !kl.ContainsElement(fromSources[source], line) {
+								fromSources[source] = append(fromSources[source], line)
+							}
+						} else {
+							line := fmt.Sprintf("  %s* rw,\n", dir.Directory)
+							if !kl.ContainsElement(fromSources[source], line) {
+								fromSources[source] = append(fromSources[source], line)
+							}
 						}
 					}
 				}
@@ -706,7 +1008,7 @@ func allowedHostCapabilitiesFromSource(secPolicy tp.HostSecurityPolicy, fromSour
 
 //
 
-func blockedHostProcessesFromSource(secPolicy tp.HostSecurityPolicy, fromSources map[string][]string) {
+func blockedHostProcessesFromSource(enableAuditd bool, secPolicy tp.HostSecurityPolicy, fromSources map[string][]string) {
 	if len(secPolicy.Spec.Process.MatchPaths) > 0 {
 		for _, path := range secPolicy.Spec.Process.MatchPaths {
 			if len(path.FromSource) == 0 {
@@ -738,16 +1040,28 @@ func blockedHostProcessesFromSource(secPolicy tp.HostSecurityPolicy, fromSources
 				}
 
 				if path.OwnerOnly {
-					// line := fmt.Sprintf("  audit owner %s ix,\n", path.Path)
-					line := fmt.Sprintf("  owner %s ix,\n", path.Path)
-					if !kl.ContainsElement(fromSources[source], line) {
-						fromSources[source] = append(fromSources[source], line)
+					if enableAuditd {
+						line := fmt.Sprintf("  audit owner %s ix,\n", path.Path)
+						if !kl.ContainsElement(fromSources[source], line) {
+							fromSources[source] = append(fromSources[source], line)
+						}
+					} else {
+						line := fmt.Sprintf("  owner %s ix,\n", path.Path)
+						if !kl.ContainsElement(fromSources[source], line) {
+							fromSources[source] = append(fromSources[source], line)
+						}
 					}
 				} else { // !path.OwnerOnly
-					// line := fmt.Sprintf("  audit deny %s x,\n", path.Path)
-					line := fmt.Sprintf("  deny %s x,\n", path.Path)
-					if !kl.ContainsElement(fromSources[source], line) {
-						fromSources[source] = append(fromSources[source], line)
+					if enableAuditd {
+						line := fmt.Sprintf("  audit deny %s x,\n", path.Path)
+						if !kl.ContainsElement(fromSources[source], line) {
+							fromSources[source] = append(fromSources[source], line)
+						}
+					} else {
+						line := fmt.Sprintf("  deny %s x,\n", path.Path)
+						if !kl.ContainsElement(fromSources[source], line) {
+							fromSources[source] = append(fromSources[source], line)
+						}
 					}
 				}
 			}
@@ -785,28 +1099,52 @@ func blockedHostProcessesFromSource(secPolicy tp.HostSecurityPolicy, fromSources
 				}
 
 				if dir.Recursive && dir.OwnerOnly {
-					// line := fmt.Sprintf("  audit owner %s{*,**} ix,\n", dir.Directory)
-					line := fmt.Sprintf("  owner %s{*,**} ix,\n", dir.Directory)
-					if !kl.ContainsElement(fromSources[source], line) {
-						fromSources[source] = append(fromSources[source], line)
+					if enableAuditd {
+						line := fmt.Sprintf("  audit owner %s{*,**} ix,\n", dir.Directory)
+						if !kl.ContainsElement(fromSources[source], line) {
+							fromSources[source] = append(fromSources[source], line)
+						}
+					} else {
+						line := fmt.Sprintf("  owner %s{*,**} ix,\n", dir.Directory)
+						if !kl.ContainsElement(fromSources[source], line) {
+							fromSources[source] = append(fromSources[source], line)
+						}
 					}
 				} else if dir.Recursive && !dir.OwnerOnly {
-					// line := fmt.Sprintf("  audit deny %s{*,**} x,\n", dir.Directory)
-					line := fmt.Sprintf("  deny %s{*,**} x,\n", dir.Directory)
-					if !kl.ContainsElement(fromSources[source], line) {
-						fromSources[source] = append(fromSources[source], line)
+					if enableAuditd {
+						line := fmt.Sprintf("  audit deny %s{*,**} x,\n", dir.Directory)
+						if !kl.ContainsElement(fromSources[source], line) {
+							fromSources[source] = append(fromSources[source], line)
+						}
+					} else {
+						line := fmt.Sprintf("  deny %s{*,**} x,\n", dir.Directory)
+						if !kl.ContainsElement(fromSources[source], line) {
+							fromSources[source] = append(fromSources[source], line)
+						}
 					}
 				} else if !dir.Recursive && dir.OwnerOnly {
-					// line := fmt.Sprintf("  audit owner %s* ix,\n", dir.Directory)
-					line := fmt.Sprintf("  owner %s* ix,\n", dir.Directory)
-					if !kl.ContainsElement(fromSources[source], line) {
-						fromSources[source] = append(fromSources[source], line)
+					if enableAuditd {
+						line := fmt.Sprintf("  audit owner %s* ix,\n", dir.Directory)
+						if !kl.ContainsElement(fromSources[source], line) {
+							fromSources[source] = append(fromSources[source], line)
+						}
+					} else {
+						line := fmt.Sprintf("  owner %s* ix,\n", dir.Directory)
+						if !kl.ContainsElement(fromSources[source], line) {
+							fromSources[source] = append(fromSources[source], line)
+						}
 					}
 				} else { // !dir.Recursive && !dir.OwnerOnly
-					// line := fmt.Sprintf("  audit deny %s* x,\n", dir.Directory)
-					line := fmt.Sprintf("  deny %s* x,\n", dir.Directory)
-					if !kl.ContainsElement(fromSources[source], line) {
-						fromSources[source] = append(fromSources[source], line)
+					if enableAuditd {
+						line := fmt.Sprintf("  audit deny %s* x,\n", dir.Directory)
+						if !kl.ContainsElement(fromSources[source], line) {
+							fromSources[source] = append(fromSources[source], line)
+						}
+					} else {
+						line := fmt.Sprintf("  deny %s* x,\n", dir.Directory)
+						if !kl.ContainsElement(fromSources[source], line) {
+							fromSources[source] = append(fromSources[source], line)
+						}
 					}
 				}
 			}
@@ -814,7 +1152,7 @@ func blockedHostProcessesFromSource(secPolicy tp.HostSecurityPolicy, fromSources
 	}
 }
 
-func blockedHostFilesFromSource(secPolicy tp.HostSecurityPolicy, fromSources map[string][]string) {
+func blockedHostFilesFromSource(enableAuditd bool, secPolicy tp.HostSecurityPolicy, fromSources map[string][]string) {
 	if len(secPolicy.Spec.File.MatchPaths) > 0 {
 		for _, path := range secPolicy.Spec.File.MatchPaths {
 			if len(path.FromSource) == 0 {
@@ -846,28 +1184,52 @@ func blockedHostFilesFromSource(secPolicy tp.HostSecurityPolicy, fromSources map
 				}
 
 				if path.ReadOnly && path.OwnerOnly {
-					// line := fmt.Sprintf("  audit owner %s r,\n", path.Path)
-					line := fmt.Sprintf("  owner %s r,\n", path.Path)
-					if !kl.ContainsElement(fromSources[source], line) {
-						fromSources[source] = append(fromSources[source], line)
+					if enableAuditd {
+						line := fmt.Sprintf("  audit owner %s r,\n", path.Path)
+						if !kl.ContainsElement(fromSources[source], line) {
+							fromSources[source] = append(fromSources[source], line)
+						}
+					} else {
+						line := fmt.Sprintf("  owner %s r,\n", path.Path)
+						if !kl.ContainsElement(fromSources[source], line) {
+							fromSources[source] = append(fromSources[source], line)
+						}
 					}
 				} else if path.ReadOnly && !path.OwnerOnly {
-					// line := fmt.Sprintf("  audit deny %s w,\n", path.Path)
-					line := fmt.Sprintf("  deny %s w,\n", path.Path)
-					if !kl.ContainsElement(fromSources[source], line) {
-						fromSources[source] = append(fromSources[source], line)
+					if enableAuditd {
+						line := fmt.Sprintf("  audit deny %s w,\n", path.Path)
+						if !kl.ContainsElement(fromSources[source], line) {
+							fromSources[source] = append(fromSources[source], line)
+						}
+					} else {
+						line := fmt.Sprintf("  deny %s w,\n", path.Path)
+						if !kl.ContainsElement(fromSources[source], line) {
+							fromSources[source] = append(fromSources[source], line)
+						}
 					}
 				} else if !path.ReadOnly && path.OwnerOnly {
-					// line := fmt.Sprintf("  audit owner %s rw,\n", path.Path)
-					line := fmt.Sprintf("  owner %s rw,\n", path.Path)
-					if !kl.ContainsElement(fromSources[source], line) {
-						fromSources[source] = append(fromSources[source], line)
+					if enableAuditd {
+						line := fmt.Sprintf("  audit owner %s rw,\n", path.Path)
+						if !kl.ContainsElement(fromSources[source], line) {
+							fromSources[source] = append(fromSources[source], line)
+						}
+					} else {
+						line := fmt.Sprintf("  owner %s rw,\n", path.Path)
+						if !kl.ContainsElement(fromSources[source], line) {
+							fromSources[source] = append(fromSources[source], line)
+						}
 					}
 				} else { // !path.ReadOnly && !path.OwnerOnly
-					// line := fmt.Sprintf("  audit deny %s rw,\n", path.Path)
-					line := fmt.Sprintf("  deny %s rw,\n", path.Path)
-					if !kl.ContainsElement(fromSources[source], line) {
-						fromSources[source] = append(fromSources[source], line)
+					if enableAuditd {
+						line := fmt.Sprintf("  audit deny %s rw,\n", path.Path)
+						if !kl.ContainsElement(fromSources[source], line) {
+							fromSources[source] = append(fromSources[source], line)
+						}
+					} else {
+						line := fmt.Sprintf("  deny %s rw,\n", path.Path)
+						if !kl.ContainsElement(fromSources[source], line) {
+							fromSources[source] = append(fromSources[source], line)
+						}
 					}
 				}
 			}
@@ -906,58 +1268,106 @@ func blockedHostFilesFromSource(secPolicy tp.HostSecurityPolicy, fromSources map
 
 				if dir.ReadOnly && dir.OwnerOnly {
 					if dir.Recursive {
-						// line := fmt.Sprintf("  audit owner %s{*,**} r,\n", dir.Directory)
-						line := fmt.Sprintf("  owner %s{*,**} r,\n", dir.Directory)
-						if !kl.ContainsElement(fromSources[source], line) {
-							fromSources[source] = append(fromSources[source], line)
+						if enableAuditd {
+							line := fmt.Sprintf("  audit owner %s{*,**} r,\n", dir.Directory)
+							if !kl.ContainsElement(fromSources[source], line) {
+								fromSources[source] = append(fromSources[source], line)
+							}
+						} else {
+							line := fmt.Sprintf("  owner %s{*,**} r,\n", dir.Directory)
+							if !kl.ContainsElement(fromSources[source], line) {
+								fromSources[source] = append(fromSources[source], line)
+							}
 						}
 					} else {
-						// line := fmt.Sprintf("  audit owner %s* r,\n", dir.Directory)
-						line := fmt.Sprintf("  owner %s* r,\n", dir.Directory)
-						if !kl.ContainsElement(fromSources[source], line) {
-							fromSources[source] = append(fromSources[source], line)
+						if enableAuditd {
+							line := fmt.Sprintf("  audit owner %s* r,\n", dir.Directory)
+							if !kl.ContainsElement(fromSources[source], line) {
+								fromSources[source] = append(fromSources[source], line)
+							}
+						} else {
+							line := fmt.Sprintf("  owner %s* r,\n", dir.Directory)
+							if !kl.ContainsElement(fromSources[source], line) {
+								fromSources[source] = append(fromSources[source], line)
+							}
 						}
 					}
 				} else if dir.ReadOnly && !dir.OwnerOnly {
 					if dir.Recursive {
-						// line := fmt.Sprintf("  audit deny %s{*,**} w,\n", dir.Directory)
-						line := fmt.Sprintf("  deny %s{*,**} w,\n", dir.Directory)
-						if !kl.ContainsElement(fromSources[source], line) {
-							fromSources[source] = append(fromSources[source], line)
+						if enableAuditd {
+							line := fmt.Sprintf("  audit deny %s{*,**} w,\n", dir.Directory)
+							if !kl.ContainsElement(fromSources[source], line) {
+								fromSources[source] = append(fromSources[source], line)
+							}
+						} else {
+							line := fmt.Sprintf("  deny %s{*,**} w,\n", dir.Directory)
+							if !kl.ContainsElement(fromSources[source], line) {
+								fromSources[source] = append(fromSources[source], line)
+							}
 						}
 					} else {
-						// line := fmt.Sprintf("  audit deny %s* w,\n", dir.Directory)
-						line := fmt.Sprintf("  deny %s* w,\n", dir.Directory)
-						if !kl.ContainsElement(fromSources[source], line) {
-							fromSources[source] = append(fromSources[source], line)
+						if enableAuditd {
+							line := fmt.Sprintf("  audit deny %s* w,\n", dir.Directory)
+							if !kl.ContainsElement(fromSources[source], line) {
+								fromSources[source] = append(fromSources[source], line)
+							}
+						} else {
+							line := fmt.Sprintf("  deny %s* w,\n", dir.Directory)
+							if !kl.ContainsElement(fromSources[source], line) {
+								fromSources[source] = append(fromSources[source], line)
+							}
 						}
 					}
 				} else if !dir.ReadOnly && dir.OwnerOnly {
 					if dir.Recursive {
-						// line := fmt.Sprintf("  audit owner %s{*,**} rw,\n", dir.Directory)
-						line := fmt.Sprintf("  owner %s{*,**} rw,\n", dir.Directory)
-						if !kl.ContainsElement(fromSources[source], line) {
-							fromSources[source] = append(fromSources[source], line)
+						if enableAuditd {
+							line := fmt.Sprintf("  audit owner %s{*,**} rw,\n", dir.Directory)
+							if !kl.ContainsElement(fromSources[source], line) {
+								fromSources[source] = append(fromSources[source], line)
+							}
+						} else {
+							line := fmt.Sprintf("  owner %s{*,**} rw,\n", dir.Directory)
+							if !kl.ContainsElement(fromSources[source], line) {
+								fromSources[source] = append(fromSources[source], line)
+							}
 						}
 					} else {
-						// line := fmt.Sprintf("  audit owner %s* rw,\n", dir.Directory)
-						line := fmt.Sprintf("  owner %s* rw,\n", dir.Directory)
-						if !kl.ContainsElement(fromSources[source], line) {
-							fromSources[source] = append(fromSources[source], line)
+						if enableAuditd {
+							line := fmt.Sprintf("  audit owner %s* rw,\n", dir.Directory)
+							if !kl.ContainsElement(fromSources[source], line) {
+								fromSources[source] = append(fromSources[source], line)
+							}
+						} else {
+							line := fmt.Sprintf("  owner %s* rw,\n", dir.Directory)
+							if !kl.ContainsElement(fromSources[source], line) {
+								fromSources[source] = append(fromSources[source], line)
+							}
 						}
 					}
 				} else { // !dir.ReadOnly && !dir.OwnerOnly
 					if dir.Recursive {
-						// line := fmt.Sprintf("  audit deny %s{*,**} rw,\n", dir.Directory)
-						line := fmt.Sprintf("  deny %s{*,**} rw,\n", dir.Directory)
-						if !kl.ContainsElement(fromSources[source], line) {
-							fromSources[source] = append(fromSources[source], line)
+						if enableAuditd {
+							line := fmt.Sprintf("  audit deny %s{*,**} rw,\n", dir.Directory)
+							if !kl.ContainsElement(fromSources[source], line) {
+								fromSources[source] = append(fromSources[source], line)
+							}
+						} else {
+							line := fmt.Sprintf("  deny %s{*,**} rw,\n", dir.Directory)
+							if !kl.ContainsElement(fromSources[source], line) {
+								fromSources[source] = append(fromSources[source], line)
+							}
 						}
 					} else {
-						// line := fmt.Sprintf("  audit deny %s* rw,\n", dir.Directory)
-						line := fmt.Sprintf("  deny %s* rw,\n", dir.Directory)
-						if !kl.ContainsElement(fromSources[source], line) {
-							fromSources[source] = append(fromSources[source], line)
+						if enableAuditd {
+							line := fmt.Sprintf("  audit deny %s* rw,\n", dir.Directory)
+							if !kl.ContainsElement(fromSources[source], line) {
+								fromSources[source] = append(fromSources[source], line)
+							}
+						} else {
+							line := fmt.Sprintf("  deny %s* rw,\n", dir.Directory)
+							if !kl.ContainsElement(fromSources[source], line) {
+								fromSources[source] = append(fromSources[source], line)
+							}
 						}
 					}
 				}
@@ -1082,7 +1492,7 @@ func GenerateHostProfileFoot() string {
 // == //
 
 // GenerateHostProfileBody Function
-func GenerateHostProfileBody(secPolicies []tp.HostSecurityPolicy) (int, string) {
+func GenerateHostProfileBody(enableAuditd bool, secPolicies []tp.HostSecurityPolicy) (int, string) {
 	// preparation
 
 	count := 0
@@ -1102,7 +1512,7 @@ func GenerateHostProfileBody(secPolicies []tp.HostSecurityPolicy) (int, string) 
 			auditList := []string{}
 
 			// process
-			auditList = auditedHostProcesses(secPolicy)
+			auditList = auditedHostProcesses(enableAuditd, secPolicy)
 
 			for _, line := range auditList {
 				if !kl.ContainsElement(processAuditList, line) {
@@ -1111,7 +1521,7 @@ func GenerateHostProfileBody(secPolicies []tp.HostSecurityPolicy) (int, string) 
 			}
 
 			// file
-			auditList = auditedHostFiles(secPolicy)
+			auditList = auditedHostFiles(enableAuditd, secPolicy)
 
 			for _, line := range auditList {
 				if !kl.ContainsElement(fileAuditList, line) {
@@ -1126,7 +1536,7 @@ func GenerateHostProfileBody(secPolicies []tp.HostSecurityPolicy) (int, string) 
 			blackList := []string{}
 
 			// process
-			blackList = blockedHostProcesses(secPolicy)
+			blackList = blockedHostProcesses(enableAuditd, secPolicy)
 
 			for _, line := range blackList {
 				if !kl.ContainsElement(processBlackList, line) {
@@ -1135,7 +1545,7 @@ func GenerateHostProfileBody(secPolicies []tp.HostSecurityPolicy) (int, string) 
 			}
 
 			// file
-			blackList = blockedHostFiles(secPolicy)
+			blackList = blockedHostFiles(enableAuditd, secPolicy)
 
 			for _, line := range blackList {
 				if !kl.ContainsElement(fileBlackList, line) {
@@ -1150,10 +1560,10 @@ func GenerateHostProfileBody(secPolicies []tp.HostSecurityPolicy) (int, string) 
 	for _, secPolicy := range secPolicies {
 		if secPolicy.Spec.Action == "Allow" || secPolicy.Spec.Action == "Audit" || secPolicy.Spec.Action == "AllowWithAudit" {
 			// process
-			allowedHostProcessesFromSource(secPolicy, fromSources)
+			allowedHostProcessesFromSource(enableAuditd, secPolicy, fromSources)
 
 			// file
-			allowedHostFilesFromSource(secPolicy, fromSources)
+			allowedHostFilesFromSource(enableAuditd, secPolicy, fromSources)
 
 			// network
 			allowedHostNetworksFromSource(secPolicy, fromSources)
@@ -1166,10 +1576,10 @@ func GenerateHostProfileBody(secPolicies []tp.HostSecurityPolicy) (int, string) 
 	for _, secPolicy := range secPolicies {
 		if secPolicy.Spec.Action == "Block" || secPolicy.Spec.Action == "BlockWithAudit" {
 			// process
-			blockedHostProcessesFromSource(secPolicy, fromSources)
+			blockedHostProcessesFromSource(enableAuditd, secPolicy, fromSources)
 
 			// file
-			blockedHostFilesFromSource(secPolicy, fromSources)
+			blockedHostFilesFromSource(enableAuditd, secPolicy, fromSources)
 
 			// network
 			blockedHostNetworksFromSource(secPolicy, fromSources)
@@ -1298,7 +1708,7 @@ func (ae *AppArmorEnforcer) GenerateAppArmorHostProfile(secPolicies []tp.HostSec
 
 	// generate a profile body
 
-	count, profileBody := GenerateHostProfileBody(secPolicies)
+	count, profileBody := GenerateHostProfileBody(ae.EnableAuditd, secPolicies)
 
 	// generate a new profile
 

--- a/KubeArmor/enforcer/appArmorProfile.go
+++ b/KubeArmor/enforcer/appArmorProfile.go
@@ -12,7 +12,7 @@ import (
 
 // == //
 
-func allowedProcesses(secPolicy tp.SecurityPolicy) []string {
+func allowedProcesses(enableAuditd bool, secPolicy tp.SecurityPolicy) []string {
 	processWhiteList := []string{}
 
 	if len(secPolicy.Spec.Process.MatchPaths) > 0 {
@@ -22,13 +22,21 @@ func allowedProcesses(secPolicy tp.SecurityPolicy) []string {
 			}
 
 			if path.OwnerOnly {
-				// line := fmt.Sprintf("  audit owner %s ix,\n", path.Path)
-				line := fmt.Sprintf("  owner %s ix,\n", path.Path)
-				processWhiteList = append(processWhiteList, line)
+				if enableAuditd {
+					line := fmt.Sprintf("  audit owner %s ix,\n", path.Path)
+					processWhiteList = append(processWhiteList, line)
+				} else {
+					line := fmt.Sprintf("  owner %s ix,\n", path.Path)
+					processWhiteList = append(processWhiteList, line)
+				}
 			} else { // !path.OwnerOnly
-				// line := fmt.Sprintf("  audit %s ix,\n", path.Path)
-				line := fmt.Sprintf("  %s ix,\n", path.Path)
-				processWhiteList = append(processWhiteList, line)
+				if enableAuditd {
+					line := fmt.Sprintf("  audit %s ix,\n", path.Path)
+					processWhiteList = append(processWhiteList, line)
+				} else {
+					line := fmt.Sprintf("  %s ix,\n", path.Path)
+					processWhiteList = append(processWhiteList, line)
+				}
 			}
 		}
 	}
@@ -40,21 +48,37 @@ func allowedProcesses(secPolicy tp.SecurityPolicy) []string {
 			}
 
 			if dir.Recursive && dir.OwnerOnly {
-				// line := fmt.Sprintf("  audit owner %s{*,**} ix,\n", dir.Directory)
-				line := fmt.Sprintf("  owner %s{*,**} ix,\n", dir.Directory)
-				processWhiteList = append(processWhiteList, line)
+				if enableAuditd {
+					line := fmt.Sprintf("  audit owner %s{*,**} ix,\n", dir.Directory)
+					processWhiteList = append(processWhiteList, line)
+				} else {
+					line := fmt.Sprintf("  owner %s{*,**} ix,\n", dir.Directory)
+					processWhiteList = append(processWhiteList, line)
+				}
 			} else if dir.Recursive && !dir.OwnerOnly {
-				// line := fmt.Sprintf("  audit %s{*,**} ix,\n", dir.Directory)
-				line := fmt.Sprintf("  %s{*,**} ix,\n", dir.Directory)
-				processWhiteList = append(processWhiteList, line)
+				if enableAuditd {
+					line := fmt.Sprintf("  audit %s{*,**} ix,\n", dir.Directory)
+					processWhiteList = append(processWhiteList, line)
+				} else {
+					line := fmt.Sprintf("  %s{*,**} ix,\n", dir.Directory)
+					processWhiteList = append(processWhiteList, line)
+				}
 			} else if !dir.Recursive && dir.OwnerOnly {
-				// line := fmt.Sprintf("  audit owner %s* ix,\n", dir.Directory)
-				line := fmt.Sprintf("  owner %s* ix,\n", dir.Directory)
-				processWhiteList = append(processWhiteList, line)
+				if enableAuditd {
+					line := fmt.Sprintf("  audit owner %s* ix,\n", dir.Directory)
+					processWhiteList = append(processWhiteList, line)
+				} else {
+					line := fmt.Sprintf("  owner %s* ix,\n", dir.Directory)
+					processWhiteList = append(processWhiteList, line)
+				}
 			} else { // !dir.Recursive && !dir.OwnerOnly
-				// line := fmt.Sprintf("  audit %s* ix,\n", dir.Directory)
-				line := fmt.Sprintf("  %s* ix,\n", dir.Directory)
-				processWhiteList = append(processWhiteList, line)
+				if enableAuditd {
+					line := fmt.Sprintf("  audit %s* ix,\n", dir.Directory)
+					processWhiteList = append(processWhiteList, line)
+				} else {
+					line := fmt.Sprintf("  %s* ix,\n", dir.Directory)
+					processWhiteList = append(processWhiteList, line)
+				}
 			}
 		}
 	}
@@ -62,13 +86,21 @@ func allowedProcesses(secPolicy tp.SecurityPolicy) []string {
 	if len(secPolicy.Spec.Process.MatchPatterns) > 0 {
 		for _, pat := range secPolicy.Spec.Process.MatchPatterns {
 			if pat.OwnerOnly {
-				// line := fmt.Sprintf("  audit owner %s ix,\n", pat.Pattern)
-				line := fmt.Sprintf("  owner %s ix,\n", pat.Pattern)
-				processWhiteList = append(processWhiteList, line)
+				if enableAuditd {
+					line := fmt.Sprintf("  audit owner %s ix,\n", pat.Pattern)
+					processWhiteList = append(processWhiteList, line)
+				} else {
+					line := fmt.Sprintf("  owner %s ix,\n", pat.Pattern)
+					processWhiteList = append(processWhiteList, line)
+				}
 			} else { // !pat.OwnerOnly
-				// line := fmt.Sprintf("  audit %s* ix,\n", pat.Pattern)
-				line := fmt.Sprintf("  %s* ix,\n", pat.Pattern)
-				processWhiteList = append(processWhiteList, line)
+				if enableAuditd {
+					line := fmt.Sprintf("  audit %s* ix,\n", pat.Pattern)
+					processWhiteList = append(processWhiteList, line)
+				} else {
+					line := fmt.Sprintf("  %s* ix,\n", pat.Pattern)
+					processWhiteList = append(processWhiteList, line)
+				}
 			}
 		}
 	}
@@ -76,7 +108,7 @@ func allowedProcesses(secPolicy tp.SecurityPolicy) []string {
 	return processWhiteList
 }
 
-func allowedFiles(secPolicy tp.SecurityPolicy) []string {
+func allowedFiles(enableAuditd bool, secPolicy tp.SecurityPolicy) []string {
 	fileWhiteList := []string{}
 
 	if len(secPolicy.Spec.File.MatchPaths) > 0 {
@@ -86,21 +118,37 @@ func allowedFiles(secPolicy tp.SecurityPolicy) []string {
 			}
 
 			if path.ReadOnly && path.OwnerOnly {
-				// line := fmt.Sprintf("  audit owner %s r,\n", path.Path)
-				line := fmt.Sprintf("  owner %s r,\n", path.Path)
-				fileWhiteList = append(fileWhiteList, line)
+				if enableAuditd {
+					line := fmt.Sprintf("  audit owner %s r,\n", path.Path)
+					fileWhiteList = append(fileWhiteList, line)
+				} else {
+					line := fmt.Sprintf("  owner %s r,\n", path.Path)
+					fileWhiteList = append(fileWhiteList, line)
+				}
 			} else if path.ReadOnly && !path.OwnerOnly {
-				// line := fmt.Sprintf("  audit %s r,\n", path.Path)
-				line := fmt.Sprintf("  %s r,\n", path.Path)
-				fileWhiteList = append(fileWhiteList, line)
+				if enableAuditd {
+					line := fmt.Sprintf("  audit %s r,\n", path.Path)
+					fileWhiteList = append(fileWhiteList, line)
+				} else {
+					line := fmt.Sprintf("  %s r,\n", path.Path)
+					fileWhiteList = append(fileWhiteList, line)
+				}
 			} else if !path.ReadOnly && path.OwnerOnly {
-				// line := fmt.Sprintf("  audit owner %s rw,\n", path.Path)
-				line := fmt.Sprintf("  owner %s rw,\n", path.Path)
-				fileWhiteList = append(fileWhiteList, line)
+				if enableAuditd {
+					line := fmt.Sprintf("  audit owner %s rw,\n", path.Path)
+					fileWhiteList = append(fileWhiteList, line)
+				} else {
+					line := fmt.Sprintf("  owner %s rw,\n", path.Path)
+					fileWhiteList = append(fileWhiteList, line)
+				}
 			} else { // !path.ReadOnly && !path.OwnerOnly
-				// line := fmt.Sprintf("  audit %s rw,\n", path.Path)
-				line := fmt.Sprintf("  %s rw,\n", path.Path)
-				fileWhiteList = append(fileWhiteList, line)
+				if enableAuditd {
+					line := fmt.Sprintf("  audit %s rw,\n", path.Path)
+					fileWhiteList = append(fileWhiteList, line)
+				} else {
+					line := fmt.Sprintf("  %s rw,\n", path.Path)
+					fileWhiteList = append(fileWhiteList, line)
+				}
 			}
 		}
 	}
@@ -113,43 +161,75 @@ func allowedFiles(secPolicy tp.SecurityPolicy) []string {
 
 			if dir.ReadOnly && dir.OwnerOnly {
 				if dir.Recursive {
-					// line := fmt.Sprintf("  audit owner %s{*,**} r,\n", dir.Directory)
-					line := fmt.Sprintf("  owner %s{*,**} r,\n", dir.Directory)
-					fileWhiteList = append(fileWhiteList, line)
+					if enableAuditd {
+						line := fmt.Sprintf("  audit owner %s{*,**} r,\n", dir.Directory)
+						fileWhiteList = append(fileWhiteList, line)
+					} else {
+						line := fmt.Sprintf("  owner %s{*,**} r,\n", dir.Directory)
+						fileWhiteList = append(fileWhiteList, line)
+					}
 				} else {
-					// line := fmt.Sprintf("  audit owner %s* r,\n", dir.Directory)
-					line := fmt.Sprintf("  owner %s* r,\n", dir.Directory)
-					fileWhiteList = append(fileWhiteList, line)
+					if enableAuditd {
+						line := fmt.Sprintf("  audit owner %s* r,\n", dir.Directory)
+						fileWhiteList = append(fileWhiteList, line)
+					} else {
+						line := fmt.Sprintf("  owner %s* r,\n", dir.Directory)
+						fileWhiteList = append(fileWhiteList, line)
+					}
 				}
 			} else if dir.ReadOnly && !dir.OwnerOnly {
 				if dir.Recursive {
-					// line := fmt.Sprintf("  audit %s{*,**} r,\n", dir.Directory)
-					line := fmt.Sprintf("  %s{*,**} r,\n", dir.Directory)
-					fileWhiteList = append(fileWhiteList, line)
+					if enableAuditd {
+						line := fmt.Sprintf("  audit %s{*,**} r,\n", dir.Directory)
+						fileWhiteList = append(fileWhiteList, line)
+					} else {
+						line := fmt.Sprintf("  %s{*,**} r,\n", dir.Directory)
+						fileWhiteList = append(fileWhiteList, line)
+					}
 				} else {
-					// line := fmt.Sprintf("  audit %s* r,\n", dir.Directory)
-					line := fmt.Sprintf("  %s* r,\n", dir.Directory)
-					fileWhiteList = append(fileWhiteList, line)
+					if enableAuditd {
+						line := fmt.Sprintf("  audit %s* r,\n", dir.Directory)
+						fileWhiteList = append(fileWhiteList, line)
+					} else {
+						line := fmt.Sprintf("  %s* r,\n", dir.Directory)
+						fileWhiteList = append(fileWhiteList, line)
+					}
 				}
 			} else if !dir.ReadOnly && dir.OwnerOnly {
 				if dir.Recursive {
-					// line := fmt.Sprintf("  audit owner %s{*,**} rw,\n", dir.Directory)
-					line := fmt.Sprintf("  owner %s{*,**} rw,\n", dir.Directory)
-					fileWhiteList = append(fileWhiteList, line)
+					if enableAuditd {
+						line := fmt.Sprintf("  audit owner %s{*,**} rw,\n", dir.Directory)
+						fileWhiteList = append(fileWhiteList, line)
+					} else {
+						line := fmt.Sprintf("  owner %s{*,**} rw,\n", dir.Directory)
+						fileWhiteList = append(fileWhiteList, line)
+					}
 				} else {
-					// line := fmt.Sprintf("  audit owner %s* rw,\n", dir.Directory)
-					line := fmt.Sprintf("  owner %s* rw,\n", dir.Directory)
-					fileWhiteList = append(fileWhiteList, line)
+					if enableAuditd {
+						line := fmt.Sprintf("  audit owner %s* rw,\n", dir.Directory)
+						fileWhiteList = append(fileWhiteList, line)
+					} else {
+						line := fmt.Sprintf("  owner %s* rw,\n", dir.Directory)
+						fileWhiteList = append(fileWhiteList, line)
+					}
 				}
 			} else { // !dir.ReadOnly && !dir.OwnerOnly
 				if dir.Recursive {
-					// line := fmt.Sprintf("  audit %s{*,**} rw,\n", dir.Directory)
-					line := fmt.Sprintf("  %s{*,**} rw,\n", dir.Directory)
-					fileWhiteList = append(fileWhiteList, line)
+					if enableAuditd {
+						line := fmt.Sprintf("  audit %s{*,**} rw,\n", dir.Directory)
+						fileWhiteList = append(fileWhiteList, line)
+					} else {
+						line := fmt.Sprintf("  %s{*,**} rw,\n", dir.Directory)
+						fileWhiteList = append(fileWhiteList, line)
+					}
 				} else {
-					// line := fmt.Sprintf("  audit %s* rw,\n", dir.Directory)
-					line := fmt.Sprintf("  %s* rw,\n", dir.Directory)
-					fileWhiteList = append(fileWhiteList, line)
+					if enableAuditd {
+						line := fmt.Sprintf("  audit %s* rw,\n", dir.Directory)
+						fileWhiteList = append(fileWhiteList, line)
+					} else {
+						line := fmt.Sprintf("  %s* rw,\n", dir.Directory)
+						fileWhiteList = append(fileWhiteList, line)
+					}
 				}
 			}
 		}
@@ -158,21 +238,37 @@ func allowedFiles(secPolicy tp.SecurityPolicy) []string {
 	if len(secPolicy.Spec.File.MatchPatterns) > 0 {
 		for _, pat := range secPolicy.Spec.File.MatchPatterns {
 			if pat.ReadOnly && pat.OwnerOnly {
-				// line := fmt.Sprintf("  audit owner %s r,\n", pat.Pattern)
-				line := fmt.Sprintf("  owner %s r,\n", pat.Pattern)
-				fileWhiteList = append(fileWhiteList, line)
+				if enableAuditd {
+					line := fmt.Sprintf("  audit owner %s r,\n", pat.Pattern)
+					fileWhiteList = append(fileWhiteList, line)
+				} else {
+					line := fmt.Sprintf("  owner %s r,\n", pat.Pattern)
+					fileWhiteList = append(fileWhiteList, line)
+				}
 			} else if pat.ReadOnly && !pat.OwnerOnly {
-				// line := fmt.Sprintf("  audit %s r,\n", pat.Pattern)
-				line := fmt.Sprintf("  %s r,\n", pat.Pattern)
-				fileWhiteList = append(fileWhiteList, line)
+				if enableAuditd {
+					line := fmt.Sprintf("  audit %s r,\n", pat.Pattern)
+					fileWhiteList = append(fileWhiteList, line)
+				} else {
+					line := fmt.Sprintf("  %s r,\n", pat.Pattern)
+					fileWhiteList = append(fileWhiteList, line)
+				}
 			} else if !pat.ReadOnly && pat.OwnerOnly {
-				// line := fmt.Sprintf("  audit owner %s rw,\n", pat.Pattern)
-				line := fmt.Sprintf("  owner %s rw,\n", pat.Pattern)
-				fileWhiteList = append(fileWhiteList, line)
+				if enableAuditd {
+					line := fmt.Sprintf("  audit owner %s rw,\n", pat.Pattern)
+					fileWhiteList = append(fileWhiteList, line)
+				} else {
+					line := fmt.Sprintf("  owner %s rw,\n", pat.Pattern)
+					fileWhiteList = append(fileWhiteList, line)
+				}
 			} else { // !pat.ReadOnly && !pat.OwnerOnly
-				// line := fmt.Sprintf("  audit %s rw,\n", pat.Pattern)
-				line := fmt.Sprintf("  %s rw,\n", pat.Pattern)
-				fileWhiteList = append(fileWhiteList, line)
+				if enableAuditd {
+					line := fmt.Sprintf("  audit %s rw,\n", pat.Pattern)
+					fileWhiteList = append(fileWhiteList, line)
+				} else {
+					line := fmt.Sprintf("  %s rw,\n", pat.Pattern)
+					fileWhiteList = append(fileWhiteList, line)
+				}
 			}
 		}
 	}
@@ -216,7 +312,7 @@ func allowedCapabilities(secPolicy tp.SecurityPolicy) []string {
 
 //
 
-func auditedProcesses(secPolicy tp.SecurityPolicy) []string {
+func auditedProcesses(enableAuditd bool, secPolicy tp.SecurityPolicy) []string {
 	processAuditList := []string{}
 
 	if len(secPolicy.Spec.Process.MatchPaths) > 0 {
@@ -226,13 +322,21 @@ func auditedProcesses(secPolicy tp.SecurityPolicy) []string {
 			}
 
 			if path.OwnerOnly {
-				// line := fmt.Sprintf("  audit owner %s ix,\n", path.Path)
-				line := fmt.Sprintf("  owner %s ix,\n", path.Path)
-				processAuditList = append(processAuditList, line)
+				if enableAuditd {
+					line := fmt.Sprintf("  audit owner %s ix,\n", path.Path)
+					processAuditList = append(processAuditList, line)
+				} else {
+					line := fmt.Sprintf("  owner %s ix,\n", path.Path)
+					processAuditList = append(processAuditList, line)
+				}
 			} else { // !path.OwnerOnly
-				// line := fmt.Sprintf("  audit %s ix,\n", path.Path)
-				line := fmt.Sprintf("  %s ix,\n", path.Path)
-				processAuditList = append(processAuditList, line)
+				if enableAuditd {
+					line := fmt.Sprintf("  audit %s ix,\n", path.Path)
+					processAuditList = append(processAuditList, line)
+				} else {
+					line := fmt.Sprintf("  %s ix,\n", path.Path)
+					processAuditList = append(processAuditList, line)
+				}
 			}
 		}
 	}
@@ -244,21 +348,37 @@ func auditedProcesses(secPolicy tp.SecurityPolicy) []string {
 			}
 
 			if dir.Recursive && dir.OwnerOnly {
-				// line := fmt.Sprintf("  audit owner %s{*,**} ix,\n", dir.Directory)
-				line := fmt.Sprintf("  owner %s{*,**} ix,\n", dir.Directory)
-				processAuditList = append(processAuditList, line)
+				if enableAuditd {
+					line := fmt.Sprintf("  audit owner %s{*,**} ix,\n", dir.Directory)
+					processAuditList = append(processAuditList, line)
+				} else {
+					line := fmt.Sprintf("  owner %s{*,**} ix,\n", dir.Directory)
+					processAuditList = append(processAuditList, line)
+				}
 			} else if dir.Recursive && !dir.OwnerOnly {
-				// line := fmt.Sprintf("  audit %s{*,**} ix,\n", dir.Directory)
-				line := fmt.Sprintf("  %s{*,**} ix,\n", dir.Directory)
-				processAuditList = append(processAuditList, line)
+				if enableAuditd {
+					line := fmt.Sprintf("  audit %s{*,**} ix,\n", dir.Directory)
+					processAuditList = append(processAuditList, line)
+				} else {
+					line := fmt.Sprintf("  %s{*,**} ix,\n", dir.Directory)
+					processAuditList = append(processAuditList, line)
+				}
 			} else if !dir.Recursive && dir.OwnerOnly {
-				// line := fmt.Sprintf("  audit owner %s* ix,\n", dir.Directory)
-				line := fmt.Sprintf("  owner %s* ix,\n", dir.Directory)
-				processAuditList = append(processAuditList, line)
+				if enableAuditd {
+					line := fmt.Sprintf("  audit owner %s* ix,\n", dir.Directory)
+					processAuditList = append(processAuditList, line)
+				} else {
+					line := fmt.Sprintf("  owner %s* ix,\n", dir.Directory)
+					processAuditList = append(processAuditList, line)
+				}
 			} else { // !dir.Recursive && !dir.OwnerOnly
-				// line := fmt.Sprintf("  audit %s* ix,\n", dir.Directory)
-				line := fmt.Sprintf("  %s* ix,\n", dir.Directory)
-				processAuditList = append(processAuditList, line)
+				if enableAuditd {
+					line := fmt.Sprintf("  audit %s* ix,\n", dir.Directory)
+					processAuditList = append(processAuditList, line)
+				} else {
+					line := fmt.Sprintf("  %s* ix,\n", dir.Directory)
+					processAuditList = append(processAuditList, line)
+				}
 			}
 		}
 	}
@@ -266,13 +386,21 @@ func auditedProcesses(secPolicy tp.SecurityPolicy) []string {
 	if len(secPolicy.Spec.Process.MatchPatterns) > 0 {
 		for _, pat := range secPolicy.Spec.Process.MatchPatterns {
 			if pat.OwnerOnly {
-				// line := fmt.Sprintf("  audit owner %s ix,\n", pat.Pattern)
-				line := fmt.Sprintf("  owner %s ix,\n", pat.Pattern)
-				processAuditList = append(processAuditList, line)
+				if enableAuditd {
+					line := fmt.Sprintf("  audit owner %s ix,\n", pat.Pattern)
+					processAuditList = append(processAuditList, line)
+				} else {
+					line := fmt.Sprintf("  owner %s ix,\n", pat.Pattern)
+					processAuditList = append(processAuditList, line)
+				}
 			} else { // !pat.OwnerOnly
-				// line := fmt.Sprintf("  audit %s* ix,\n", pat.Pattern)
-				line := fmt.Sprintf("  %s* ix,\n", pat.Pattern)
-				processAuditList = append(processAuditList, line)
+				if enableAuditd {
+					line := fmt.Sprintf("  audit %s* ix,\n", pat.Pattern)
+					processAuditList = append(processAuditList, line)
+				} else {
+					line := fmt.Sprintf("  %s* ix,\n", pat.Pattern)
+					processAuditList = append(processAuditList, line)
+				}
 			}
 		}
 	}
@@ -280,7 +408,7 @@ func auditedProcesses(secPolicy tp.SecurityPolicy) []string {
 	return processAuditList
 }
 
-func auditedFiles(secPolicy tp.SecurityPolicy) []string {
+func auditedFiles(enableAuditd bool, secPolicy tp.SecurityPolicy) []string {
 	fileAuditList := []string{}
 
 	if len(secPolicy.Spec.File.MatchPaths) > 0 {
@@ -290,21 +418,37 @@ func auditedFiles(secPolicy tp.SecurityPolicy) []string {
 			}
 
 			if path.ReadOnly && path.OwnerOnly {
-				// line := fmt.Sprintf("  audit owner %s r,\n", path.Path)
-				line := fmt.Sprintf("  owner %s r,\n", path.Path)
-				fileAuditList = append(fileAuditList, line)
+				if enableAuditd {
+					line := fmt.Sprintf("  audit owner %s r,\n", path.Path)
+					fileAuditList = append(fileAuditList, line)
+				} else {
+					line := fmt.Sprintf("  owner %s r,\n", path.Path)
+					fileAuditList = append(fileAuditList, line)
+				}
 			} else if path.ReadOnly && !path.OwnerOnly {
-				// line := fmt.Sprintf("  audit %s r,\n", path.Path)
-				line := fmt.Sprintf("  %s r,\n", path.Path)
-				fileAuditList = append(fileAuditList, line)
+				if enableAuditd {
+					line := fmt.Sprintf("  audit %s r,\n", path.Path)
+					fileAuditList = append(fileAuditList, line)
+				} else {
+					line := fmt.Sprintf("  %s r,\n", path.Path)
+					fileAuditList = append(fileAuditList, line)
+				}
 			} else if !path.ReadOnly && path.OwnerOnly {
-				// line := fmt.Sprintf("  audit owner %s rw,\n", path.Path)
-				line := fmt.Sprintf("  owner %s rw,\n", path.Path)
-				fileAuditList = append(fileAuditList, line)
+				if enableAuditd {
+					line := fmt.Sprintf("  audit owner %s rw,\n", path.Path)
+					fileAuditList = append(fileAuditList, line)
+				} else {
+					line := fmt.Sprintf("  owner %s rw,\n", path.Path)
+					fileAuditList = append(fileAuditList, line)
+				}
 			} else { // !path.ReadOnly && !path.OwnerOnly
-				// line := fmt.Sprintf("  audit %s rw,\n", path.Path)
-				line := fmt.Sprintf("  %s rw,\n", path.Path)
-				fileAuditList = append(fileAuditList, line)
+				if enableAuditd {
+					line := fmt.Sprintf("  audit %s rw,\n", path.Path)
+					fileAuditList = append(fileAuditList, line)
+				} else {
+					line := fmt.Sprintf("  %s rw,\n", path.Path)
+					fileAuditList = append(fileAuditList, line)
+				}
 			}
 		}
 	}
@@ -317,43 +461,75 @@ func auditedFiles(secPolicy tp.SecurityPolicy) []string {
 
 			if dir.ReadOnly && dir.OwnerOnly {
 				if dir.Recursive {
-					// line := fmt.Sprintf("  audit owner %s{*,**} r,\n", dir.Directory)
-					line := fmt.Sprintf("  owner %s{*,**} r,\n", dir.Directory)
-					fileAuditList = append(fileAuditList, line)
+					if enableAuditd {
+						line := fmt.Sprintf("  audit owner %s{*,**} r,\n", dir.Directory)
+						fileAuditList = append(fileAuditList, line)
+					} else {
+						line := fmt.Sprintf("  owner %s{*,**} r,\n", dir.Directory)
+						fileAuditList = append(fileAuditList, line)
+					}
 				} else {
-					// line := fmt.Sprintf("  audit owner %s* r,\n", dir.Directory)
-					line := fmt.Sprintf("  owner %s* r,\n", dir.Directory)
-					fileAuditList = append(fileAuditList, line)
+					if enableAuditd {
+						line := fmt.Sprintf("  audit owner %s* r,\n", dir.Directory)
+						fileAuditList = append(fileAuditList, line)
+					} else {
+						line := fmt.Sprintf("  owner %s* r,\n", dir.Directory)
+						fileAuditList = append(fileAuditList, line)
+					}
 				}
 			} else if dir.ReadOnly && !dir.OwnerOnly {
 				if dir.Recursive {
-					// line := fmt.Sprintf("  audit %s{*,**} r,\n", dir.Directory)
-					line := fmt.Sprintf("  %s{*,**} r,\n", dir.Directory)
-					fileAuditList = append(fileAuditList, line)
+					if enableAuditd {
+						line := fmt.Sprintf("  audit %s{*,**} r,\n", dir.Directory)
+						fileAuditList = append(fileAuditList, line)
+					} else {
+						line := fmt.Sprintf("  %s{*,**} r,\n", dir.Directory)
+						fileAuditList = append(fileAuditList, line)
+					}
 				} else {
-					// line := fmt.Sprintf("  audit %s* r,\n", dir.Directory)
-					line := fmt.Sprintf("  %s* r,\n", dir.Directory)
-					fileAuditList = append(fileAuditList, line)
+					if enableAuditd {
+						line := fmt.Sprintf("  audit %s* r,\n", dir.Directory)
+						fileAuditList = append(fileAuditList, line)
+					} else {
+						line := fmt.Sprintf("  %s* r,\n", dir.Directory)
+						fileAuditList = append(fileAuditList, line)
+					}
 				}
 			} else if !dir.ReadOnly && dir.OwnerOnly {
 				if dir.Recursive {
-					// line := fmt.Sprintf("  audit owner %s{*,**} rw,\n", dir.Directory)
-					line := fmt.Sprintf("  owner %s{*,**} rw,\n", dir.Directory)
-					fileAuditList = append(fileAuditList, line)
+					if enableAuditd {
+						line := fmt.Sprintf("  audit owner %s{*,**} rw,\n", dir.Directory)
+						fileAuditList = append(fileAuditList, line)
+					} else {
+						line := fmt.Sprintf("  owner %s{*,**} rw,\n", dir.Directory)
+						fileAuditList = append(fileAuditList, line)
+					}
 				} else {
-					// line := fmt.Sprintf("  audit owner %s* rw,\n", dir.Directory)
-					line := fmt.Sprintf("  owner %s* rw,\n", dir.Directory)
-					fileAuditList = append(fileAuditList, line)
+					if enableAuditd {
+						line := fmt.Sprintf("  audit owner %s* rw,\n", dir.Directory)
+						fileAuditList = append(fileAuditList, line)
+					} else {
+						line := fmt.Sprintf("  owner %s* rw,\n", dir.Directory)
+						fileAuditList = append(fileAuditList, line)
+					}
 				}
 			} else { // !dir.ReadOnly && !dir.OwnerOnly
 				if dir.Recursive {
-					// line := fmt.Sprintf("  audit %s{*,**} rw,\n", dir.Directory)
-					line := fmt.Sprintf("  %s{*,**} rw,\n", dir.Directory)
-					fileAuditList = append(fileAuditList, line)
+					if enableAuditd {
+						line := fmt.Sprintf("  audit %s{*,**} rw,\n", dir.Directory)
+						fileAuditList = append(fileAuditList, line)
+					} else {
+						line := fmt.Sprintf("  %s{*,**} rw,\n", dir.Directory)
+						fileAuditList = append(fileAuditList, line)
+					}
 				} else {
-					// line := fmt.Sprintf("  audit %s* rw,\n", dir.Directory)
-					line := fmt.Sprintf("  %s* rw,\n", dir.Directory)
-					fileAuditList = append(fileAuditList, line)
+					if enableAuditd {
+						line := fmt.Sprintf("  audit %s* rw,\n", dir.Directory)
+						fileAuditList = append(fileAuditList, line)
+					} else {
+						line := fmt.Sprintf("  %s* rw,\n", dir.Directory)
+						fileAuditList = append(fileAuditList, line)
+					}
 				}
 			}
 		}
@@ -362,21 +538,37 @@ func auditedFiles(secPolicy tp.SecurityPolicy) []string {
 	if len(secPolicy.Spec.File.MatchPatterns) > 0 {
 		for _, pat := range secPolicy.Spec.File.MatchPatterns {
 			if pat.ReadOnly && pat.OwnerOnly {
-				// line := fmt.Sprintf("  audit owner %s r,\n", pat.Pattern)
-				line := fmt.Sprintf("  owner %s r,\n", pat.Pattern)
-				fileAuditList = append(fileAuditList, line)
+				if enableAuditd {
+					line := fmt.Sprintf("  audit owner %s r,\n", pat.Pattern)
+					fileAuditList = append(fileAuditList, line)
+				} else {
+					line := fmt.Sprintf("  owner %s r,\n", pat.Pattern)
+					fileAuditList = append(fileAuditList, line)
+				}
 			} else if pat.ReadOnly && !pat.OwnerOnly {
-				// line := fmt.Sprintf("  audit %s r,\n", pat.Pattern)
-				line := fmt.Sprintf("  %s r,\n", pat.Pattern)
-				fileAuditList = append(fileAuditList, line)
+				if enableAuditd {
+					line := fmt.Sprintf("  audit %s r,\n", pat.Pattern)
+					fileAuditList = append(fileAuditList, line)
+				} else {
+					line := fmt.Sprintf("  %s r,\n", pat.Pattern)
+					fileAuditList = append(fileAuditList, line)
+				}
 			} else if !pat.ReadOnly && pat.OwnerOnly {
-				// line := fmt.Sprintf("  audit owner %s rw,\n", pat.Pattern)
-				line := fmt.Sprintf("  owner %s rw,\n", pat.Pattern)
-				fileAuditList = append(fileAuditList, line)
+				if enableAuditd {
+					line := fmt.Sprintf("  audit owner %s rw,\n", pat.Pattern)
+					fileAuditList = append(fileAuditList, line)
+				} else {
+					line := fmt.Sprintf("  owner %s rw,\n", pat.Pattern)
+					fileAuditList = append(fileAuditList, line)
+				}
 			} else { // !pat.ReadOnly && !pat.OwnerOnly
-				// line := fmt.Sprintf("  audit %s rw,\n", pat.Pattern)
-				line := fmt.Sprintf("  %s rw,\n", pat.Pattern)
-				fileAuditList = append(fileAuditList, line)
+				if enableAuditd {
+					line := fmt.Sprintf("  audit %s rw,\n", pat.Pattern)
+					fileAuditList = append(fileAuditList, line)
+				} else {
+					line := fmt.Sprintf("  %s rw,\n", pat.Pattern)
+					fileAuditList = append(fileAuditList, line)
+				}
 			}
 		}
 	}
@@ -386,7 +578,7 @@ func auditedFiles(secPolicy tp.SecurityPolicy) []string {
 
 //
 
-func blockedProcesses(secPolicy tp.SecurityPolicy) []string {
+func blockedProcesses(enableAuditd bool, secPolicy tp.SecurityPolicy) []string {
 	processBlackList := []string{}
 
 	if len(secPolicy.Spec.Process.MatchPaths) > 0 {
@@ -396,13 +588,21 @@ func blockedProcesses(secPolicy tp.SecurityPolicy) []string {
 			}
 
 			if path.OwnerOnly {
-				// line := fmt.Sprintf("  audit owner %s ix,\n", path.Path)
-				line := fmt.Sprintf("  owner %s ix,\n", path.Path)
-				processBlackList = append(processBlackList, line)
+				if enableAuditd {
+					line := fmt.Sprintf("  audit owner %s ix,\n", path.Path)
+					processBlackList = append(processBlackList, line)
+				} else {
+					line := fmt.Sprintf("  owner %s ix,\n", path.Path)
+					processBlackList = append(processBlackList, line)
+				}
 			} else { // !path.OwnerOnly
-				// line := fmt.Sprintf("  audit deny %s x,\n", path.Path)
-				line := fmt.Sprintf("  deny %s x,\n", path.Path)
-				processBlackList = append(processBlackList, line)
+				if enableAuditd {
+					line := fmt.Sprintf("  audit deny %s x,\n", path.Path)
+					processBlackList = append(processBlackList, line)
+				} else {
+					line := fmt.Sprintf("  deny %s x,\n", path.Path)
+					processBlackList = append(processBlackList, line)
+				}
 			}
 		}
 	}
@@ -414,21 +614,37 @@ func blockedProcesses(secPolicy tp.SecurityPolicy) []string {
 			}
 
 			if dir.Recursive && dir.OwnerOnly {
-				// line := fmt.Sprintf("  audit owner %s{*,**} ix,\n", dir.Directory)
-				line := fmt.Sprintf("  owner %s{*,**} ix,\n", dir.Directory)
-				processBlackList = append(processBlackList, line)
+				if enableAuditd {
+					line := fmt.Sprintf("  audit owner %s{*,**} ix,\n", dir.Directory)
+					processBlackList = append(processBlackList, line)
+				} else {
+					line := fmt.Sprintf("  owner %s{*,**} ix,\n", dir.Directory)
+					processBlackList = append(processBlackList, line)
+				}
 			} else if dir.Recursive && !dir.OwnerOnly {
-				// line := fmt.Sprintf("  audit deny %s{*,**} x,\n", dir.Directory)
-				line := fmt.Sprintf("  deny %s{*,**} x,\n", dir.Directory)
-				processBlackList = append(processBlackList, line)
+				if enableAuditd {
+					line := fmt.Sprintf("  audit deny %s{*,**} x,\n", dir.Directory)
+					processBlackList = append(processBlackList, line)
+				} else {
+					line := fmt.Sprintf("  deny %s{*,**} x,\n", dir.Directory)
+					processBlackList = append(processBlackList, line)
+				}
 			} else if !dir.Recursive && dir.OwnerOnly {
-				// line := fmt.Sprintf("  audit owner %s* ix,\n", dir.Directory)
-				line := fmt.Sprintf("  owner %s* ix,\n", dir.Directory)
-				processBlackList = append(processBlackList, line)
+				if enableAuditd {
+					line := fmt.Sprintf("  audit owner %s* ix,\n", dir.Directory)
+					processBlackList = append(processBlackList, line)
+				} else {
+					line := fmt.Sprintf("  owner %s* ix,\n", dir.Directory)
+					processBlackList = append(processBlackList, line)
+				}
 			} else { // !dir.Recursive && !dir.OwnerOnly
-				// line := fmt.Sprintf("  audit deny %s* x,\n", dir.Directory)
-				line := fmt.Sprintf("  deny %s* x,\n", dir.Directory)
-				processBlackList = append(processBlackList, line)
+				if enableAuditd {
+					line := fmt.Sprintf("  audit deny %s* x,\n", dir.Directory)
+					processBlackList = append(processBlackList, line)
+				} else {
+					line := fmt.Sprintf("  deny %s* x,\n", dir.Directory)
+					processBlackList = append(processBlackList, line)
+				}
 			}
 		}
 	}
@@ -436,13 +652,21 @@ func blockedProcesses(secPolicy tp.SecurityPolicy) []string {
 	if len(secPolicy.Spec.Process.MatchPatterns) > 0 {
 		for _, pat := range secPolicy.Spec.Process.MatchPatterns {
 			if pat.OwnerOnly {
-				// line := fmt.Sprintf("  audit owner %s ix,\n", pat.Pattern)
-				line := fmt.Sprintf("  owner %s ix,\n", pat.Pattern)
-				processBlackList = append(processBlackList, line)
+				if enableAuditd {
+					line := fmt.Sprintf("  audit owner %s ix,\n", pat.Pattern)
+					processBlackList = append(processBlackList, line)
+				} else {
+					line := fmt.Sprintf("  owner %s ix,\n", pat.Pattern)
+					processBlackList = append(processBlackList, line)
+				}
 			} else { // !path.OwnerOnly
-				// line := fmt.Sprintf("  audit deny %s x,\n", pat.Pattern)
-				line := fmt.Sprintf("  deny %s x,\n", pat.Pattern)
-				processBlackList = append(processBlackList, line)
+				if enableAuditd {
+					line := fmt.Sprintf("  audit deny %s x,\n", pat.Pattern)
+					processBlackList = append(processBlackList, line)
+				} else {
+					line := fmt.Sprintf("  deny %s x,\n", pat.Pattern)
+					processBlackList = append(processBlackList, line)
+				}
 			}
 		}
 	}
@@ -450,7 +674,7 @@ func blockedProcesses(secPolicy tp.SecurityPolicy) []string {
 	return processBlackList
 }
 
-func blockedFiles(secPolicy tp.SecurityPolicy) []string {
+func blockedFiles(enableAuditd bool, secPolicy tp.SecurityPolicy) []string {
 	fileBlackList := []string{}
 
 	if len(secPolicy.Spec.File.MatchPaths) > 0 {
@@ -460,21 +684,37 @@ func blockedFiles(secPolicy tp.SecurityPolicy) []string {
 			}
 
 			if path.ReadOnly && path.OwnerOnly {
-				// line := fmt.Sprintf("  audit owner %s r,\n", path.Path)
-				line := fmt.Sprintf("  owner %s r,\n", path.Path)
-				fileBlackList = append(fileBlackList, line)
+				if enableAuditd {
+					line := fmt.Sprintf("  audit owner %s r,\n", path.Path)
+					fileBlackList = append(fileBlackList, line)
+				} else {
+					line := fmt.Sprintf("  owner %s r,\n", path.Path)
+					fileBlackList = append(fileBlackList, line)
+				}
 			} else if path.ReadOnly && !path.OwnerOnly {
-				// line := fmt.Sprintf("  audit deny %s w,\n", path.Path)
-				line := fmt.Sprintf("  deny %s w,\n", path.Path)
-				fileBlackList = append(fileBlackList, line)
+				if enableAuditd {
+					line := fmt.Sprintf("  audit deny %s w,\n", path.Path)
+					fileBlackList = append(fileBlackList, line)
+				} else {
+					line := fmt.Sprintf("  deny %s w,\n", path.Path)
+					fileBlackList = append(fileBlackList, line)
+				}
 			} else if !path.ReadOnly && path.OwnerOnly {
-				// line := fmt.Sprintf("  audit owner %s rw,\n", path.Path)
-				line := fmt.Sprintf("  owner %s rw,\n", path.Path)
-				fileBlackList = append(fileBlackList, line)
+				if enableAuditd {
+					line := fmt.Sprintf("  audit owner %s rw,\n", path.Path)
+					fileBlackList = append(fileBlackList, line)
+				} else {
+					line := fmt.Sprintf("  owner %s rw,\n", path.Path)
+					fileBlackList = append(fileBlackList, line)
+				}
 			} else { // !path.ReadOnly && !path.OwnerOnly
-				// line := fmt.Sprintf("  audit deny %s rw,\n", path.Path)
-				line := fmt.Sprintf("  deny %s rw,\n", path.Path)
-				fileBlackList = append(fileBlackList, line)
+				if enableAuditd {
+					line := fmt.Sprintf("  audit deny %s rw,\n", path.Path)
+					fileBlackList = append(fileBlackList, line)
+				} else {
+					line := fmt.Sprintf("  deny %s rw,\n", path.Path)
+					fileBlackList = append(fileBlackList, line)
+				}
 			}
 		}
 	}
@@ -487,43 +727,75 @@ func blockedFiles(secPolicy tp.SecurityPolicy) []string {
 
 			if dir.ReadOnly && dir.OwnerOnly {
 				if dir.Recursive {
-					// line := fmt.Sprintf("  audit owner %s{*,**} r,\n", dir.Directory)
-					line := fmt.Sprintf("  owner %s{*,**} r,\n", dir.Directory)
-					fileBlackList = append(fileBlackList, line)
+					if enableAuditd {
+						line := fmt.Sprintf("  audit owner %s{*,**} r,\n", dir.Directory)
+						fileBlackList = append(fileBlackList, line)
+					} else {
+						line := fmt.Sprintf("  owner %s{*,**} r,\n", dir.Directory)
+						fileBlackList = append(fileBlackList, line)
+					}
 				} else {
-					// line := fmt.Sprintf("  audit owner %s* r,\n", dir.Directory)
-					line := fmt.Sprintf("  owner %s* r,\n", dir.Directory)
-					fileBlackList = append(fileBlackList, line)
+					if enableAuditd {
+						line := fmt.Sprintf("  audit owner %s* r,\n", dir.Directory)
+						fileBlackList = append(fileBlackList, line)
+					} else {
+						line := fmt.Sprintf("  owner %s* r,\n", dir.Directory)
+						fileBlackList = append(fileBlackList, line)
+					}
 				}
 			} else if dir.ReadOnly && !dir.OwnerOnly {
 				if dir.Recursive {
-					// line := fmt.Sprintf("  audit deny %s{*,**} w,\n", dir.Directory)
-					line := fmt.Sprintf("  deny %s{*,**} w,\n", dir.Directory)
-					fileBlackList = append(fileBlackList, line)
+					if enableAuditd {
+						line := fmt.Sprintf("  audit deny %s{*,**} w,\n", dir.Directory)
+						fileBlackList = append(fileBlackList, line)
+					} else {
+						line := fmt.Sprintf("  deny %s{*,**} w,\n", dir.Directory)
+						fileBlackList = append(fileBlackList, line)
+					}
 				} else {
-					// line := fmt.Sprintf("  audit deny %s* w,\n", dir.Directory)
-					line := fmt.Sprintf("  deny %s* w,\n", dir.Directory)
-					fileBlackList = append(fileBlackList, line)
+					if enableAuditd {
+						line := fmt.Sprintf("  audit deny %s* w,\n", dir.Directory)
+						fileBlackList = append(fileBlackList, line)
+					} else {
+						line := fmt.Sprintf("  deny %s* w,\n", dir.Directory)
+						fileBlackList = append(fileBlackList, line)
+					}
 				}
 			} else if !dir.ReadOnly && dir.OwnerOnly {
 				if dir.Recursive {
-					// line := fmt.Sprintf("  audit owner %s{*,**} rw,\n", dir.Directory)
-					line := fmt.Sprintf("  owner %s{*,**} rw,\n", dir.Directory)
-					fileBlackList = append(fileBlackList, line)
+					if enableAuditd {
+						line := fmt.Sprintf("  audit owner %s{*,**} rw,\n", dir.Directory)
+						fileBlackList = append(fileBlackList, line)
+					} else {
+						line := fmt.Sprintf("  owner %s{*,**} rw,\n", dir.Directory)
+						fileBlackList = append(fileBlackList, line)
+					}
 				} else {
-					// line := fmt.Sprintf("  audit owner %s* rw,\n", dir.Directory)
-					line := fmt.Sprintf("  owner %s* rw,\n", dir.Directory)
-					fileBlackList = append(fileBlackList, line)
+					if enableAuditd {
+						line := fmt.Sprintf("  audit owner %s* rw,\n", dir.Directory)
+						fileBlackList = append(fileBlackList, line)
+					} else {
+						line := fmt.Sprintf("  owner %s* rw,\n", dir.Directory)
+						fileBlackList = append(fileBlackList, line)
+					}
 				}
 			} else { // !dir.ReadOnly && !dir.OwnerOnly
 				if dir.Recursive {
-					// line := fmt.Sprintf("  audit deny %s{*,**} rw,\n", dir.Directory)
-					line := fmt.Sprintf("  deny %s{*,**} rw,\n", dir.Directory)
-					fileBlackList = append(fileBlackList, line)
+					if enableAuditd {
+						line := fmt.Sprintf("  audit deny %s{*,**} rw,\n", dir.Directory)
+						fileBlackList = append(fileBlackList, line)
+					} else {
+						line := fmt.Sprintf("  deny %s{*,**} rw,\n", dir.Directory)
+						fileBlackList = append(fileBlackList, line)
+					}
 				} else {
-					// line := fmt.Sprintf("  audit deny %s* rw,\n", dir.Directory)
-					line := fmt.Sprintf("  deny %s* rw,\n", dir.Directory)
-					fileBlackList = append(fileBlackList, line)
+					if enableAuditd {
+						line := fmt.Sprintf("  audit deny %s* rw,\n", dir.Directory)
+						fileBlackList = append(fileBlackList, line)
+					} else {
+						line := fmt.Sprintf("  deny %s* rw,\n", dir.Directory)
+						fileBlackList = append(fileBlackList, line)
+					}
 				}
 			}
 		}
@@ -532,21 +804,37 @@ func blockedFiles(secPolicy tp.SecurityPolicy) []string {
 	if len(secPolicy.Spec.File.MatchPatterns) > 0 {
 		for _, pat := range secPolicy.Spec.File.MatchPatterns {
 			if pat.ReadOnly && pat.OwnerOnly {
-				// line := fmt.Sprintf("  audit owner %s r,\n", pat.Pattern)
-				line := fmt.Sprintf("  owner %s r,\n", pat.Pattern)
-				fileBlackList = append(fileBlackList, line)
+				if enableAuditd {
+					line := fmt.Sprintf("  audit owner %s r,\n", pat.Pattern)
+					fileBlackList = append(fileBlackList, line)
+				} else {
+					line := fmt.Sprintf("  owner %s r,\n", pat.Pattern)
+					fileBlackList = append(fileBlackList, line)
+				}
 			} else if pat.ReadOnly && !pat.OwnerOnly {
-				// line := fmt.Sprintf("  audit deny %s w,\n", pat.Pattern)
-				line := fmt.Sprintf("  deny %s w,\n", pat.Pattern)
-				fileBlackList = append(fileBlackList, line)
+				if enableAuditd {
+					line := fmt.Sprintf("  audit deny %s w,\n", pat.Pattern)
+					fileBlackList = append(fileBlackList, line)
+				} else {
+					line := fmt.Sprintf("  deny %s w,\n", pat.Pattern)
+					fileBlackList = append(fileBlackList, line)
+				}
 			} else if !pat.ReadOnly && pat.OwnerOnly {
-				// line := fmt.Sprintf("  audit owner %s rw,\n", pat.Pattern)
-				line := fmt.Sprintf("  owner %s rw,\n", pat.Pattern)
-				fileBlackList = append(fileBlackList, line)
+				if enableAuditd {
+					line := fmt.Sprintf("  audit owner %s rw,\n", pat.Pattern)
+					fileBlackList = append(fileBlackList, line)
+				} else {
+					line := fmt.Sprintf("  owner %s rw,\n", pat.Pattern)
+					fileBlackList = append(fileBlackList, line)
+				}
 			} else { // !pat.ReadOnly && !pat.OwnerOnly
-				// line := fmt.Sprintf("  audit deny %s rw,\n", pat.Pattern)
-				line := fmt.Sprintf("  deny %s rw,\n", pat.Pattern)
-				fileBlackList = append(fileBlackList, line)
+				if enableAuditd {
+					line := fmt.Sprintf("  audit deny %s rw,\n", pat.Pattern)
+					fileBlackList = append(fileBlackList, line)
+				} else {
+					line := fmt.Sprintf("  deny %s rw,\n", pat.Pattern)
+					fileBlackList = append(fileBlackList, line)
+				}
 			}
 		}
 	}
@@ -590,7 +878,7 @@ func blockedCapabilities(secPolicy tp.SecurityPolicy) []string {
 
 // == //
 
-func allowedProcessesFromSource(secPolicy tp.SecurityPolicy, fromSources map[string][]string) {
+func allowedProcessesFromSource(enableAuditd bool, secPolicy tp.SecurityPolicy, fromSources map[string][]string) {
 	if len(secPolicy.Spec.Process.MatchPaths) > 0 {
 		for _, path := range secPolicy.Spec.Process.MatchPaths {
 			if len(path.FromSource) == 0 {
@@ -622,16 +910,28 @@ func allowedProcessesFromSource(secPolicy tp.SecurityPolicy, fromSources map[str
 				}
 
 				if path.OwnerOnly {
-					// line := fmt.Sprintf("  audit owner %s ix,\n", path.Path)
-					line := fmt.Sprintf("  owner %s ix,\n", path.Path)
-					if !kl.ContainsElement(fromSources[source], line) {
-						fromSources[source] = append(fromSources[source], line)
+					if enableAuditd {
+						line := fmt.Sprintf("  audit owner %s ix,\n", path.Path)
+						if !kl.ContainsElement(fromSources[source], line) {
+							fromSources[source] = append(fromSources[source], line)
+						}
+					} else {
+						line := fmt.Sprintf("  owner %s ix,\n", path.Path)
+						if !kl.ContainsElement(fromSources[source], line) {
+							fromSources[source] = append(fromSources[source], line)
+						}
 					}
 				} else { // !path.OwnerOnly
-					// line := fmt.Sprintf("  audit %s ix,\n", path.Path)
-					line := fmt.Sprintf("  %s ix,\n", path.Path)
-					if !kl.ContainsElement(fromSources[source], line) {
-						fromSources[source] = append(fromSources[source], line)
+					if enableAuditd {
+						line := fmt.Sprintf("  audit %s ix,\n", path.Path)
+						if !kl.ContainsElement(fromSources[source], line) {
+							fromSources[source] = append(fromSources[source], line)
+						}
+					} else {
+						line := fmt.Sprintf("  %s ix,\n", path.Path)
+						if !kl.ContainsElement(fromSources[source], line) {
+							fromSources[source] = append(fromSources[source], line)
+						}
 					}
 				}
 			}
@@ -669,28 +969,52 @@ func allowedProcessesFromSource(secPolicy tp.SecurityPolicy, fromSources map[str
 				}
 
 				if dir.Recursive && dir.OwnerOnly {
-					// line := fmt.Sprintf("  audit owner %s{*,**} ix,\n", dir.Directory)
-					line := fmt.Sprintf("  owner %s{*,**} ix,\n", dir.Directory)
-					if !kl.ContainsElement(fromSources[source], line) {
-						fromSources[source] = append(fromSources[source], line)
+					if enableAuditd {
+						line := fmt.Sprintf("  audit owner %s{*,**} ix,\n", dir.Directory)
+						if !kl.ContainsElement(fromSources[source], line) {
+							fromSources[source] = append(fromSources[source], line)
+						}
+					} else {
+						line := fmt.Sprintf("  owner %s{*,**} ix,\n", dir.Directory)
+						if !kl.ContainsElement(fromSources[source], line) {
+							fromSources[source] = append(fromSources[source], line)
+						}
 					}
 				} else if dir.Recursive && !dir.OwnerOnly {
-					// line := fmt.Sprintf("  audit %s{*,**} ix,\n", dir.Directory)
-					line := fmt.Sprintf("  %s{*,**} ix,\n", dir.Directory)
-					if !kl.ContainsElement(fromSources[source], line) {
-						fromSources[source] = append(fromSources[source], line)
+					if enableAuditd {
+						line := fmt.Sprintf("  audit %s{*,**} ix,\n", dir.Directory)
+						if !kl.ContainsElement(fromSources[source], line) {
+							fromSources[source] = append(fromSources[source], line)
+						}
+					} else {
+						line := fmt.Sprintf("  %s{*,**} ix,\n", dir.Directory)
+						if !kl.ContainsElement(fromSources[source], line) {
+							fromSources[source] = append(fromSources[source], line)
+						}
 					}
 				} else if !dir.Recursive && dir.OwnerOnly {
-					// line := fmt.Sprintf("  audit owner %s* ix,\n", dir.Directory)
-					line := fmt.Sprintf("  owner %s* ix,\n", dir.Directory)
-					if !kl.ContainsElement(fromSources[source], line) {
-						fromSources[source] = append(fromSources[source], line)
+					if enableAuditd {
+						line := fmt.Sprintf("  audit owner %s* ix,\n", dir.Directory)
+						if !kl.ContainsElement(fromSources[source], line) {
+							fromSources[source] = append(fromSources[source], line)
+						}
+					} else {
+						line := fmt.Sprintf("  owner %s* ix,\n", dir.Directory)
+						if !kl.ContainsElement(fromSources[source], line) {
+							fromSources[source] = append(fromSources[source], line)
+						}
 					}
 				} else { // !dir.Recursive && !dir.OwnerOnly
-					// line := fmt.Sprintf("  audit %s* ix,\n", dir.Directory)
-					line := fmt.Sprintf("  %s* ix,\n", dir.Directory)
-					if !kl.ContainsElement(fromSources[source], line) {
-						fromSources[source] = append(fromSources[source], line)
+					if enableAuditd {
+						line := fmt.Sprintf("  audit %s* ix,\n", dir.Directory)
+						if !kl.ContainsElement(fromSources[source], line) {
+							fromSources[source] = append(fromSources[source], line)
+						}
+					} else {
+						line := fmt.Sprintf("  %s* ix,\n", dir.Directory)
+						if !kl.ContainsElement(fromSources[source], line) {
+							fromSources[source] = append(fromSources[source], line)
+						}
 					}
 				}
 			}
@@ -698,7 +1022,7 @@ func allowedProcessesFromSource(secPolicy tp.SecurityPolicy, fromSources map[str
 	}
 }
 
-func allowedFilesFromSource(secPolicy tp.SecurityPolicy, fromSources map[string][]string) {
+func allowedFilesFromSource(enableAuditd bool, secPolicy tp.SecurityPolicy, fromSources map[string][]string) {
 	if len(secPolicy.Spec.File.MatchPaths) > 0 {
 		for _, path := range secPolicy.Spec.File.MatchPaths {
 			if len(path.FromSource) == 0 {
@@ -730,28 +1054,52 @@ func allowedFilesFromSource(secPolicy tp.SecurityPolicy, fromSources map[string]
 				}
 
 				if path.ReadOnly && path.OwnerOnly {
-					// line := fmt.Sprintf("  audit owner %s r,\n", path.Path)
-					line := fmt.Sprintf("  owner %s r,\n", path.Path)
-					if !kl.ContainsElement(fromSources[source], line) {
-						fromSources[source] = append(fromSources[source], line)
+					if enableAuditd {
+						line := fmt.Sprintf("  audit owner %s r,\n", path.Path)
+						if !kl.ContainsElement(fromSources[source], line) {
+							fromSources[source] = append(fromSources[source], line)
+						}
+					} else {
+						line := fmt.Sprintf("  owner %s r,\n", path.Path)
+						if !kl.ContainsElement(fromSources[source], line) {
+							fromSources[source] = append(fromSources[source], line)
+						}
 					}
 				} else if path.ReadOnly && !path.OwnerOnly {
-					// line := fmt.Sprintf("  audit %s r,\n", path.Path)
-					line := fmt.Sprintf("  %s r,\n", path.Path)
-					if !kl.ContainsElement(fromSources[source], line) {
-						fromSources[source] = append(fromSources[source], line)
+					if enableAuditd {
+						line := fmt.Sprintf("  audit %s r,\n", path.Path)
+						if !kl.ContainsElement(fromSources[source], line) {
+							fromSources[source] = append(fromSources[source], line)
+						}
+					} else {
+						line := fmt.Sprintf("  %s r,\n", path.Path)
+						if !kl.ContainsElement(fromSources[source], line) {
+							fromSources[source] = append(fromSources[source], line)
+						}
 					}
 				} else if !path.ReadOnly && path.OwnerOnly {
-					// line := fmt.Sprintf("  audit owner %s rw,\n", path.Path)
-					line := fmt.Sprintf("  owner %s rw,\n", path.Path)
-					if !kl.ContainsElement(fromSources[source], line) {
-						fromSources[source] = append(fromSources[source], line)
+					if enableAuditd {
+						line := fmt.Sprintf("  audit owner %s rw,\n", path.Path)
+						if !kl.ContainsElement(fromSources[source], line) {
+							fromSources[source] = append(fromSources[source], line)
+						}
+					} else {
+						line := fmt.Sprintf("  owner %s rw,\n", path.Path)
+						if !kl.ContainsElement(fromSources[source], line) {
+							fromSources[source] = append(fromSources[source], line)
+						}
 					}
 				} else { // !path.ReadOnly && !path.OwnerOnly
-					// line := fmt.Sprintf("  audit %s rw,\n", path.Path)
-					line := fmt.Sprintf("  %s rw,\n", path.Path)
-					if !kl.ContainsElement(fromSources[source], line) {
-						fromSources[source] = append(fromSources[source], line)
+					if enableAuditd {
+						line := fmt.Sprintf("  audit %s rw,\n", path.Path)
+						if !kl.ContainsElement(fromSources[source], line) {
+							fromSources[source] = append(fromSources[source], line)
+						}
+					} else {
+						line := fmt.Sprintf("  %s rw,\n", path.Path)
+						if !kl.ContainsElement(fromSources[source], line) {
+							fromSources[source] = append(fromSources[source], line)
+						}
 					}
 				}
 			}
@@ -790,58 +1138,106 @@ func allowedFilesFromSource(secPolicy tp.SecurityPolicy, fromSources map[string]
 
 				if dir.ReadOnly && dir.OwnerOnly {
 					if dir.Recursive {
-						// line := fmt.Sprintf("  audit owner %s{*,**} r,\n", dir.Directory)
-						line := fmt.Sprintf("  owner %s{*,**} r,\n", dir.Directory)
-						if !kl.ContainsElement(fromSources[source], line) {
-							fromSources[source] = append(fromSources[source], line)
+						if enableAuditd {
+							line := fmt.Sprintf("  audit owner %s{*,**} r,\n", dir.Directory)
+							if !kl.ContainsElement(fromSources[source], line) {
+								fromSources[source] = append(fromSources[source], line)
+							}
+						} else {
+							line := fmt.Sprintf("  owner %s{*,**} r,\n", dir.Directory)
+							if !kl.ContainsElement(fromSources[source], line) {
+								fromSources[source] = append(fromSources[source], line)
+							}
 						}
 					} else {
-						// line := fmt.Sprintf("  audit owner %s* r,\n", dir.Directory)
-						line := fmt.Sprintf("  owner %s* r,\n", dir.Directory)
-						if !kl.ContainsElement(fromSources[source], line) {
-							fromSources[source] = append(fromSources[source], line)
+						if enableAuditd {
+							line := fmt.Sprintf("  audit owner %s* r,\n", dir.Directory)
+							if !kl.ContainsElement(fromSources[source], line) {
+								fromSources[source] = append(fromSources[source], line)
+							}
+						} else {
+							line := fmt.Sprintf("  owner %s* r,\n", dir.Directory)
+							if !kl.ContainsElement(fromSources[source], line) {
+								fromSources[source] = append(fromSources[source], line)
+							}
 						}
 					}
 				} else if dir.ReadOnly && !dir.OwnerOnly {
 					if dir.Recursive {
-						// line := fmt.Sprintf("  audit %s{*,**} r,\n", dir.Directory)
-						line := fmt.Sprintf("  %s{*,**} r,\n", dir.Directory)
-						if !kl.ContainsElement(fromSources[source], line) {
-							fromSources[source] = append(fromSources[source], line)
+						if enableAuditd {
+							line := fmt.Sprintf("  audit %s{*,**} r,\n", dir.Directory)
+							if !kl.ContainsElement(fromSources[source], line) {
+								fromSources[source] = append(fromSources[source], line)
+							}
+						} else {
+							line := fmt.Sprintf("  %s{*,**} r,\n", dir.Directory)
+							if !kl.ContainsElement(fromSources[source], line) {
+								fromSources[source] = append(fromSources[source], line)
+							}
 						}
 					} else {
-						// line := fmt.Sprintf("  audit %s* r,\n", dir.Directory)
-						line := fmt.Sprintf("  %s* r,\n", dir.Directory)
-						if !kl.ContainsElement(fromSources[source], line) {
-							fromSources[source] = append(fromSources[source], line)
+						if enableAuditd {
+							line := fmt.Sprintf("  audit %s* r,\n", dir.Directory)
+							if !kl.ContainsElement(fromSources[source], line) {
+								fromSources[source] = append(fromSources[source], line)
+							}
+						} else {
+							line := fmt.Sprintf("  %s* r,\n", dir.Directory)
+							if !kl.ContainsElement(fromSources[source], line) {
+								fromSources[source] = append(fromSources[source], line)
+							}
 						}
 					}
 				} else if !dir.ReadOnly && dir.OwnerOnly {
 					if dir.Recursive {
-						// line := fmt.Sprintf("  audit owner %s{*,**} rw,\n", dir.Directory)
-						line := fmt.Sprintf("  owner %s{*,**} rw,\n", dir.Directory)
-						if !kl.ContainsElement(fromSources[source], line) {
-							fromSources[source] = append(fromSources[source], line)
+						if enableAuditd {
+							line := fmt.Sprintf("  audit owner %s{*,**} rw,\n", dir.Directory)
+							if !kl.ContainsElement(fromSources[source], line) {
+								fromSources[source] = append(fromSources[source], line)
+							}
+						} else {
+							line := fmt.Sprintf("  owner %s{*,**} rw,\n", dir.Directory)
+							if !kl.ContainsElement(fromSources[source], line) {
+								fromSources[source] = append(fromSources[source], line)
+							}
 						}
 					} else {
-						// line := fmt.Sprintf("  audit owner %s* rw,\n", dir.Directory)
-						line := fmt.Sprintf("  owner %s* rw,\n", dir.Directory)
-						if !kl.ContainsElement(fromSources[source], line) {
-							fromSources[source] = append(fromSources[source], line)
+						if enableAuditd {
+							line := fmt.Sprintf("  audit owner %s* rw,\n", dir.Directory)
+							if !kl.ContainsElement(fromSources[source], line) {
+								fromSources[source] = append(fromSources[source], line)
+							}
+						} else {
+							line := fmt.Sprintf("  owner %s* rw,\n", dir.Directory)
+							if !kl.ContainsElement(fromSources[source], line) {
+								fromSources[source] = append(fromSources[source], line)
+							}
 						}
 					}
 				} else { // !dir.ReadOnly && !dir.OwnerOnly
 					if dir.Recursive {
-						// line := fmt.Sprintf("  audit %s{*,**} rw,\n", dir.Directory)
-						line := fmt.Sprintf("  %s{*,**} rw,\n", dir.Directory)
-						if !kl.ContainsElement(fromSources[source], line) {
-							fromSources[source] = append(fromSources[source], line)
+						if enableAuditd {
+							line := fmt.Sprintf("  audit %s{*,**} rw,\n", dir.Directory)
+							if !kl.ContainsElement(fromSources[source], line) {
+								fromSources[source] = append(fromSources[source], line)
+							}
+						} else {
+							line := fmt.Sprintf("  %s{*,**} rw,\n", dir.Directory)
+							if !kl.ContainsElement(fromSources[source], line) {
+								fromSources[source] = append(fromSources[source], line)
+							}
 						}
 					} else {
-						// line := fmt.Sprintf("  audit %s* rw,\n", dir.Directory)
-						line := fmt.Sprintf("  %s* rw,\n", dir.Directory)
-						if !kl.ContainsElement(fromSources[source], line) {
-							fromSources[source] = append(fromSources[source], line)
+						if enableAuditd {
+							line := fmt.Sprintf("  audit %s* rw,\n", dir.Directory)
+							if !kl.ContainsElement(fromSources[source], line) {
+								fromSources[source] = append(fromSources[source], line)
+							}
+						} else {
+							line := fmt.Sprintf("  %s* rw,\n", dir.Directory)
+							if !kl.ContainsElement(fromSources[source], line) {
+								fromSources[source] = append(fromSources[source], line)
+							}
 						}
 					}
 				}
@@ -932,7 +1328,7 @@ func allowedCapabilitiesFromSource(secPolicy tp.SecurityPolicy, fromSources map[
 
 //
 
-func blockedProcessesFromSource(secPolicy tp.SecurityPolicy, fromSources map[string][]string) {
+func blockedProcessesFromSource(enableAuditd bool, secPolicy tp.SecurityPolicy, fromSources map[string][]string) {
 	if len(secPolicy.Spec.Process.MatchPaths) > 0 {
 		for _, path := range secPolicy.Spec.Process.MatchPaths {
 			if len(path.FromSource) == 0 {
@@ -964,16 +1360,28 @@ func blockedProcessesFromSource(secPolicy tp.SecurityPolicy, fromSources map[str
 				}
 
 				if path.OwnerOnly {
-					// line := fmt.Sprintf("  audit owner %s ix,\n", path.Path)
-					line := fmt.Sprintf("  owner %s ix,\n", path.Path)
-					if !kl.ContainsElement(fromSources[source], line) {
-						fromSources[source] = append(fromSources[source], line)
+					if enableAuditd {
+						line := fmt.Sprintf("  audit owner %s ix,\n", path.Path)
+						if !kl.ContainsElement(fromSources[source], line) {
+							fromSources[source] = append(fromSources[source], line)
+						}
+					} else {
+						line := fmt.Sprintf("  owner %s ix,\n", path.Path)
+						if !kl.ContainsElement(fromSources[source], line) {
+							fromSources[source] = append(fromSources[source], line)
+						}
 					}
 				} else { // !path.OwnerOnly
-					// line := fmt.Sprintf("  audit deny %s x,\n", path.Path)
-					line := fmt.Sprintf("  deny %s x,\n", path.Path)
-					if !kl.ContainsElement(fromSources[source], line) {
-						fromSources[source] = append(fromSources[source], line)
+					if enableAuditd {
+						line := fmt.Sprintf("  audit deny %s x,\n", path.Path)
+						if !kl.ContainsElement(fromSources[source], line) {
+							fromSources[source] = append(fromSources[source], line)
+						}
+					} else {
+						line := fmt.Sprintf("  deny %s x,\n", path.Path)
+						if !kl.ContainsElement(fromSources[source], line) {
+							fromSources[source] = append(fromSources[source], line)
+						}
 					}
 				}
 			}
@@ -1011,28 +1419,52 @@ func blockedProcessesFromSource(secPolicy tp.SecurityPolicy, fromSources map[str
 				}
 
 				if dir.Recursive && dir.OwnerOnly {
-					// line := fmt.Sprintf("  audit owner %s{*,**} ix,\n", dir.Directory)
-					line := fmt.Sprintf("  owner %s{*,**} ix,\n", dir.Directory)
-					if !kl.ContainsElement(fromSources[source], line) {
-						fromSources[source] = append(fromSources[source], line)
+					if enableAuditd {
+						line := fmt.Sprintf("  audit owner %s{*,**} ix,\n", dir.Directory)
+						if !kl.ContainsElement(fromSources[source], line) {
+							fromSources[source] = append(fromSources[source], line)
+						}
+					} else {
+						line := fmt.Sprintf("  owner %s{*,**} ix,\n", dir.Directory)
+						if !kl.ContainsElement(fromSources[source], line) {
+							fromSources[source] = append(fromSources[source], line)
+						}
 					}
 				} else if dir.Recursive && !dir.OwnerOnly {
-					// line := fmt.Sprintf("  audit deny %s{*,**} x,\n", dir.Directory)
-					line := fmt.Sprintf("  deny %s{*,**} x,\n", dir.Directory)
-					if !kl.ContainsElement(fromSources[source], line) {
-						fromSources[source] = append(fromSources[source], line)
+					if enableAuditd {
+						line := fmt.Sprintf("  audit deny %s{*,**} x,\n", dir.Directory)
+						if !kl.ContainsElement(fromSources[source], line) {
+							fromSources[source] = append(fromSources[source], line)
+						}
+					} else {
+						line := fmt.Sprintf("  deny %s{*,**} x,\n", dir.Directory)
+						if !kl.ContainsElement(fromSources[source], line) {
+							fromSources[source] = append(fromSources[source], line)
+						}
 					}
 				} else if !dir.Recursive && dir.OwnerOnly {
-					// line := fmt.Sprintf("  audit owner %s* ix,\n", dir.Directory)
-					line := fmt.Sprintf("  owner %s* ix,\n", dir.Directory)
-					if !kl.ContainsElement(fromSources[source], line) {
-						fromSources[source] = append(fromSources[source], line)
+					if enableAuditd {
+						line := fmt.Sprintf("  audit owner %s* ix,\n", dir.Directory)
+						if !kl.ContainsElement(fromSources[source], line) {
+							fromSources[source] = append(fromSources[source], line)
+						}
+					} else {
+						line := fmt.Sprintf("  owner %s* ix,\n", dir.Directory)
+						if !kl.ContainsElement(fromSources[source], line) {
+							fromSources[source] = append(fromSources[source], line)
+						}
 					}
 				} else { // !dir.Recursive && !dir.OwnerOnly
-					// line := fmt.Sprintf("  audit deny %s* x,\n", dir.Directory)
-					line := fmt.Sprintf("  deny %s* x,\n", dir.Directory)
-					if !kl.ContainsElement(fromSources[source], line) {
-						fromSources[source] = append(fromSources[source], line)
+					if enableAuditd {
+						line := fmt.Sprintf("  audit deny %s* x,\n", dir.Directory)
+						if !kl.ContainsElement(fromSources[source], line) {
+							fromSources[source] = append(fromSources[source], line)
+						}
+					} else {
+						line := fmt.Sprintf("  deny %s* x,\n", dir.Directory)
+						if !kl.ContainsElement(fromSources[source], line) {
+							fromSources[source] = append(fromSources[source], line)
+						}
 					}
 				}
 			}
@@ -1040,7 +1472,7 @@ func blockedProcessesFromSource(secPolicy tp.SecurityPolicy, fromSources map[str
 	}
 }
 
-func blockedFilesFromSource(secPolicy tp.SecurityPolicy, fromSources map[string][]string) {
+func blockedFilesFromSource(enableAuditd bool, secPolicy tp.SecurityPolicy, fromSources map[string][]string) {
 	if len(secPolicy.Spec.File.MatchPaths) > 0 {
 		for _, path := range secPolicy.Spec.File.MatchPaths {
 			if len(path.FromSource) == 0 {
@@ -1072,28 +1504,52 @@ func blockedFilesFromSource(secPolicy tp.SecurityPolicy, fromSources map[string]
 				}
 
 				if path.ReadOnly && path.OwnerOnly {
-					// line := fmt.Sprintf("  audit owner %s r,\n", path.Path)
-					line := fmt.Sprintf("  owner %s r,\n", path.Path)
-					if !kl.ContainsElement(fromSources[source], line) {
-						fromSources[source] = append(fromSources[source], line)
+					if enableAuditd {
+						line := fmt.Sprintf("  audit owner %s r,\n", path.Path)
+						if !kl.ContainsElement(fromSources[source], line) {
+							fromSources[source] = append(fromSources[source], line)
+						}
+					} else {
+						line := fmt.Sprintf("  owner %s r,\n", path.Path)
+						if !kl.ContainsElement(fromSources[source], line) {
+							fromSources[source] = append(fromSources[source], line)
+						}
 					}
 				} else if path.ReadOnly && !path.OwnerOnly {
-					// line := fmt.Sprintf("  audit deny %s w,\n", path.Path)
-					line := fmt.Sprintf("  deny %s w,\n", path.Path)
-					if !kl.ContainsElement(fromSources[source], line) {
-						fromSources[source] = append(fromSources[source], line)
+					if enableAuditd {
+						line := fmt.Sprintf("  audit deny %s w,\n", path.Path)
+						if !kl.ContainsElement(fromSources[source], line) {
+							fromSources[source] = append(fromSources[source], line)
+						}
+					} else {
+						line := fmt.Sprintf("  deny %s w,\n", path.Path)
+						if !kl.ContainsElement(fromSources[source], line) {
+							fromSources[source] = append(fromSources[source], line)
+						}
 					}
 				} else if !path.ReadOnly && path.OwnerOnly {
-					// line := fmt.Sprintf("  audit owner %s rw,\n", path.Path)
-					line := fmt.Sprintf("  owner %s rw,\n", path.Path)
-					if !kl.ContainsElement(fromSources[source], line) {
-						fromSources[source] = append(fromSources[source], line)
+					if enableAuditd {
+						line := fmt.Sprintf("  audit owner %s rw,\n", path.Path)
+						if !kl.ContainsElement(fromSources[source], line) {
+							fromSources[source] = append(fromSources[source], line)
+						}
+					} else {
+						line := fmt.Sprintf("  owner %s rw,\n", path.Path)
+						if !kl.ContainsElement(fromSources[source], line) {
+							fromSources[source] = append(fromSources[source], line)
+						}
 					}
 				} else { // !path.ReadOnly && !path.OwnerOnly
-					// line := fmt.Sprintf("  audit deny %s rw,\n", path.Path)
-					line := fmt.Sprintf("  deny %s rw,\n", path.Path)
-					if !kl.ContainsElement(fromSources[source], line) {
-						fromSources[source] = append(fromSources[source], line)
+					if enableAuditd {
+						line := fmt.Sprintf("  audit deny %s rw,\n", path.Path)
+						if !kl.ContainsElement(fromSources[source], line) {
+							fromSources[source] = append(fromSources[source], line)
+						}
+					} else {
+						line := fmt.Sprintf("  deny %s rw,\n", path.Path)
+						if !kl.ContainsElement(fromSources[source], line) {
+							fromSources[source] = append(fromSources[source], line)
+						}
 					}
 				}
 			}
@@ -1132,58 +1588,106 @@ func blockedFilesFromSource(secPolicy tp.SecurityPolicy, fromSources map[string]
 
 				if dir.ReadOnly && dir.OwnerOnly {
 					if dir.Recursive {
-						// line := fmt.Sprintf("  audit owner %s{*,**} r,\n", dir.Directory)
-						line := fmt.Sprintf("  owner %s{*,**} r,\n", dir.Directory)
-						if !kl.ContainsElement(fromSources[source], line) {
-							fromSources[source] = append(fromSources[source], line)
+						if enableAuditd {
+							line := fmt.Sprintf("  audit owner %s{*,**} r,\n", dir.Directory)
+							if !kl.ContainsElement(fromSources[source], line) {
+								fromSources[source] = append(fromSources[source], line)
+							}
+						} else {
+							line := fmt.Sprintf("  owner %s{*,**} r,\n", dir.Directory)
+							if !kl.ContainsElement(fromSources[source], line) {
+								fromSources[source] = append(fromSources[source], line)
+							}
 						}
 					} else {
-						// line := fmt.Sprintf("  audit owner %s* r,\n", dir.Directory)
-						line := fmt.Sprintf("  owner %s* r,\n", dir.Directory)
-						if !kl.ContainsElement(fromSources[source], line) {
-							fromSources[source] = append(fromSources[source], line)
+						if enableAuditd {
+							line := fmt.Sprintf("  audit owner %s* r,\n", dir.Directory)
+							if !kl.ContainsElement(fromSources[source], line) {
+								fromSources[source] = append(fromSources[source], line)
+							}
+						} else {
+							line := fmt.Sprintf("  owner %s* r,\n", dir.Directory)
+							if !kl.ContainsElement(fromSources[source], line) {
+								fromSources[source] = append(fromSources[source], line)
+							}
 						}
 					}
 				} else if dir.ReadOnly && !dir.OwnerOnly {
 					if dir.Recursive {
-						// line := fmt.Sprintf("  audit deny %s{*,**} w,\n", dir.Directory)
-						line := fmt.Sprintf("  deny %s{*,**} w,\n", dir.Directory)
-						if !kl.ContainsElement(fromSources[source], line) {
-							fromSources[source] = append(fromSources[source], line)
+						if enableAuditd {
+							line := fmt.Sprintf("  audit deny %s{*,**} w,\n", dir.Directory)
+							if !kl.ContainsElement(fromSources[source], line) {
+								fromSources[source] = append(fromSources[source], line)
+							}
+						} else {
+							line := fmt.Sprintf("  deny %s{*,**} w,\n", dir.Directory)
+							if !kl.ContainsElement(fromSources[source], line) {
+								fromSources[source] = append(fromSources[source], line)
+							}
 						}
 					} else {
-						// line := fmt.Sprintf("  audit deny %s* w,\n", dir.Directory)
-						line := fmt.Sprintf("  deny %s* w,\n", dir.Directory)
-						if !kl.ContainsElement(fromSources[source], line) {
-							fromSources[source] = append(fromSources[source], line)
+						if enableAuditd {
+							line := fmt.Sprintf("  audit deny %s* w,\n", dir.Directory)
+							if !kl.ContainsElement(fromSources[source], line) {
+								fromSources[source] = append(fromSources[source], line)
+							}
+						} else {
+							line := fmt.Sprintf("  deny %s* w,\n", dir.Directory)
+							if !kl.ContainsElement(fromSources[source], line) {
+								fromSources[source] = append(fromSources[source], line)
+							}
 						}
 					}
 				} else if !dir.ReadOnly && dir.OwnerOnly {
 					if dir.Recursive {
-						// line := fmt.Sprintf("  audit owner %s{*,**} rw,\n", dir.Directory)
-						line := fmt.Sprintf("  owner %s{*,**} rw,\n", dir.Directory)
-						if !kl.ContainsElement(fromSources[source], line) {
-							fromSources[source] = append(fromSources[source], line)
+						if enableAuditd {
+							line := fmt.Sprintf("  audit owner %s{*,**} rw,\n", dir.Directory)
+							if !kl.ContainsElement(fromSources[source], line) {
+								fromSources[source] = append(fromSources[source], line)
+							}
+						} else {
+							line := fmt.Sprintf("  owner %s{*,**} rw,\n", dir.Directory)
+							if !kl.ContainsElement(fromSources[source], line) {
+								fromSources[source] = append(fromSources[source], line)
+							}
 						}
 					} else {
-						// line := fmt.Sprintf("  audit owner %s* rw,\n", dir.Directory)
-						line := fmt.Sprintf("  owner %s* rw,\n", dir.Directory)
-						if !kl.ContainsElement(fromSources[source], line) {
-							fromSources[source] = append(fromSources[source], line)
+						if enableAuditd {
+							line := fmt.Sprintf("  audit owner %s* rw,\n", dir.Directory)
+							if !kl.ContainsElement(fromSources[source], line) {
+								fromSources[source] = append(fromSources[source], line)
+							}
+						} else {
+							line := fmt.Sprintf("  owner %s* rw,\n", dir.Directory)
+							if !kl.ContainsElement(fromSources[source], line) {
+								fromSources[source] = append(fromSources[source], line)
+							}
 						}
 					}
 				} else { // !dir.ReadOnly && !dir.OwnerOnly
 					if dir.Recursive {
-						// line := fmt.Sprintf("  audit deny %s{*,**} rw,\n", dir.Directory)
-						line := fmt.Sprintf("  deny %s{*,**} rw,\n", dir.Directory)
-						if !kl.ContainsElement(fromSources[source], line) {
-							fromSources[source] = append(fromSources[source], line)
+						if enableAuditd {
+							line := fmt.Sprintf("  audit deny %s{*,**} rw,\n", dir.Directory)
+							if !kl.ContainsElement(fromSources[source], line) {
+								fromSources[source] = append(fromSources[source], line)
+							}
+						} else {
+							line := fmt.Sprintf("  deny %s{*,**} rw,\n", dir.Directory)
+							if !kl.ContainsElement(fromSources[source], line) {
+								fromSources[source] = append(fromSources[source], line)
+							}
 						}
 					} else {
-						// line := fmt.Sprintf("  audit deny %s* rw,\n", dir.Directory)
-						line := fmt.Sprintf("  deny %s* rw,\n", dir.Directory)
-						if !kl.ContainsElement(fromSources[source], line) {
-							fromSources[source] = append(fromSources[source], line)
+						if enableAuditd {
+							line := fmt.Sprintf("  audit deny %s* rw,\n", dir.Directory)
+							if !kl.ContainsElement(fromSources[source], line) {
+								fromSources[source] = append(fromSources[source], line)
+							}
+						} else {
+							line := fmt.Sprintf("  deny %s* rw,\n", dir.Directory)
+							if !kl.ContainsElement(fromSources[source], line) {
+								fromSources[source] = append(fromSources[source], line)
+							}
 						}
 					}
 				}
@@ -1320,7 +1824,7 @@ func GenerateProfileFoot() string {
 // == //
 
 // GenerateProfileBody Function
-func GenerateProfileBody(oldContentsPreMid, oldConetntsMidPost []string, securityPolicies []tp.SecurityPolicy) (int, string) {
+func GenerateProfileBody(enableAuditd bool, oldContentsPreMid, oldConetntsMidPost []string, securityPolicies []tp.SecurityPolicy) (int, string) {
 	// preparation
 
 	count := 0
@@ -1348,7 +1852,7 @@ func GenerateProfileBody(oldContentsPreMid, oldConetntsMidPost []string, securit
 			whiteList := []string{}
 
 			// process
-			whiteList = allowedProcesses(secPolicy)
+			whiteList = allowedProcesses(enableAuditd, secPolicy)
 
 			for _, line := range whiteList {
 				if !kl.ContainsElement(processWhiteList, line) {
@@ -1357,7 +1861,7 @@ func GenerateProfileBody(oldContentsPreMid, oldConetntsMidPost []string, securit
 			}
 
 			// file
-			whiteList = allowedFiles(secPolicy)
+			whiteList = allowedFiles(enableAuditd, secPolicy)
 
 			for _, line := range whiteList {
 				if !kl.ContainsElement(fileWhiteList, line) {
@@ -1390,7 +1894,7 @@ func GenerateProfileBody(oldContentsPreMid, oldConetntsMidPost []string, securit
 			auditList := []string{}
 
 			// process
-			auditList = auditedProcesses(secPolicy)
+			auditList = auditedProcesses(enableAuditd, secPolicy)
 
 			for _, line := range auditList {
 				if !kl.ContainsElement(processAuditList, line) {
@@ -1399,7 +1903,7 @@ func GenerateProfileBody(oldContentsPreMid, oldConetntsMidPost []string, securit
 			}
 
 			// file
-			auditList = auditedFiles(secPolicy)
+			auditList = auditedFiles(enableAuditd, secPolicy)
 
 			for _, line := range auditList {
 				if !kl.ContainsElement(fileAuditList, line) {
@@ -1414,7 +1918,7 @@ func GenerateProfileBody(oldContentsPreMid, oldConetntsMidPost []string, securit
 			blackList := []string{}
 
 			// process
-			blackList = blockedProcesses(secPolicy)
+			blackList = blockedProcesses(enableAuditd, secPolicy)
 
 			for _, line := range blackList {
 				if !kl.ContainsElement(processBlackList, line) {
@@ -1423,7 +1927,7 @@ func GenerateProfileBody(oldContentsPreMid, oldConetntsMidPost []string, securit
 			}
 
 			// file
-			blackList = blockedFiles(secPolicy)
+			blackList = blockedFiles(enableAuditd, secPolicy)
 
 			for _, line := range blackList {
 				if !kl.ContainsElement(fileBlackList, line) {
@@ -1456,10 +1960,10 @@ func GenerateProfileBody(oldContentsPreMid, oldConetntsMidPost []string, securit
 	for _, secPolicy := range securityPolicies {
 		if secPolicy.Spec.Action == "Allow" || secPolicy.Spec.Action == "Audit" || secPolicy.Spec.Action == "AllowWithAudit" {
 			// process
-			allowedProcessesFromSource(secPolicy, fromSources)
+			allowedProcessesFromSource(enableAuditd, secPolicy, fromSources)
 
 			// file
-			allowedFilesFromSource(secPolicy, fromSources)
+			allowedFilesFromSource(enableAuditd, secPolicy, fromSources)
 
 			// network
 			allowedNetworksFromSource(secPolicy, fromSources)
@@ -1472,10 +1976,10 @@ func GenerateProfileBody(oldContentsPreMid, oldConetntsMidPost []string, securit
 	for _, secPolicy := range securityPolicies {
 		if secPolicy.Spec.Action == "Block" || secPolicy.Spec.Action == "BlockWithAudit" {
 			// process
-			blockedProcessesFromSource(secPolicy, fromSources)
+			blockedProcessesFromSource(enableAuditd, secPolicy, fromSources)
 
 			// file
-			blockedFilesFromSource(secPolicy, fromSources)
+			blockedFilesFromSource(enableAuditd, secPolicy, fromSources)
 
 			// network
 			blockedNetworksFromSource(secPolicy, fromSources)
@@ -1740,7 +2244,7 @@ func (ae *AppArmorEnforcer) GenerateAppArmorProfile(appArmorProfile string, secu
 
 	// generate a profile body
 
-	count, profileBody := GenerateProfileBody(oldContentsPreMid, oldConetntsMidPost, securityPolicies)
+	count, profileBody := GenerateProfileBody(ae.EnableAuditd, oldContentsPreMid, oldConetntsMidPost, securityPolicies)
 
 	// generate a new profile
 

--- a/KubeArmor/enforcer/runtimeEnforcer.go
+++ b/KubeArmor/enforcer/runtimeEnforcer.go
@@ -26,7 +26,7 @@ type RuntimeEnforcer struct {
 }
 
 // NewRuntimeEnforcer Function
-func NewRuntimeEnforcer(feeder *fd.Feeder, enableHostPolicy bool) *RuntimeEnforcer {
+func NewRuntimeEnforcer(feeder *fd.Feeder, enableAuditd, enableHostPolicy bool) *RuntimeEnforcer {
 	re := &RuntimeEnforcer{}
 
 	re.LogFeeder = feeder
@@ -54,7 +54,7 @@ func NewRuntimeEnforcer(feeder *fd.Feeder, enableHostPolicy bool) *RuntimeEnforc
 	}
 
 	if strings.Contains(re.enforcerType, "apparmor") {
-		re.appArmorEnforcer = NewAppArmorEnforcer(feeder, enableHostPolicy)
+		re.appArmorEnforcer = NewAppArmorEnforcer(feeder, enableAuditd, enableHostPolicy)
 		if re.appArmorEnforcer != nil {
 			re.LogFeeder.Print("Initialized AppArmor Enforcer")
 			re.enableLSM = true

--- a/KubeArmor/feeder/feeder.go
+++ b/KubeArmor/feeder/feeder.go
@@ -238,11 +238,14 @@ type Feeder struct {
 
 	// namespace name + container group name / host name -> corresponding security policies
 	SecurityPolicies     map[string]tp.MatchPolicies
-	SecurityPoliciesLock *sync.Mutex
+	SecurityPoliciesLock *sync.RWMutex
+
+	// options
+	EnableSystemLog bool
 }
 
 // NewFeeder Function
-func NewFeeder(port, output string) *Feeder {
+func NewFeeder(port, output string, enableSystemLog bool) *Feeder {
 	fd := &Feeder{}
 
 	fd.port = fmt.Sprintf(":%s", port)
@@ -297,7 +300,10 @@ func NewFeeder(port, output string) *Feeder {
 
 	// initialize security policies
 	fd.SecurityPolicies = map[string]tp.MatchPolicies{}
-	fd.SecurityPoliciesLock = &sync.Mutex{}
+	fd.SecurityPoliciesLock = new(sync.RWMutex)
+
+	// options
+	fd.EnableSystemLog = enableSystemLog
 
 	return fd
 }

--- a/KubeArmor/feeder/feeder_test.go
+++ b/KubeArmor/feeder/feeder_test.go
@@ -6,7 +6,7 @@ import (
 
 func TestFeeder(t *testing.T) {
 	// create Feeder
-	feeder := NewFeeder("32767", "none")
+	feeder := NewFeeder("32767", "none", false)
 	if feeder == nil {
 		t.Log("[FAIL] Failed to create Feeder")
 		return

--- a/KubeArmor/main.go
+++ b/KubeArmor/main.go
@@ -37,7 +37,9 @@ func main() {
 	// options
 	gRPCPtr := flag.String("gRPC", "32767", "gRPC port number")
 	logPathPtr := flag.String("logPath", "none", "log file path")
+	enableAuditdPtr := flag.Bool("enableAuditd", false, "enabling Auditd")
 	enableHostPolicyPtr := flag.Bool("enableHostPolicy", false, "enabling host policies")
+	enableSystemLogPtr := flag.Bool("enableSystemLog", false, "enabling system logs")
 
 	// profile option
 	pprofPtr := flag.String("pprof", "none", "pprof port number")
@@ -52,7 +54,7 @@ func main() {
 
 	// == //
 
-	core.KubeArmor(*gRPCPtr, *logPathPtr, *enableHostPolicyPtr)
+	core.KubeArmor(*gRPCPtr, *logPathPtr, *enableAuditdPtr, *enableHostPolicyPtr, *enableSystemLogPtr)
 
 	// == //
 }

--- a/KubeArmor/monitor/hostProcessTree.go
+++ b/KubeArmor/monitor/hostProcessTree.go
@@ -1,0 +1,62 @@
+package monitor
+
+import (
+	"time"
+
+	tp "github.com/accuknox/KubeArmor/KubeArmor/types"
+)
+
+// ================== //
+// == Process Tree == //
+// ================== //
+
+// AddActiveHostPid Function
+func (mon *SystemMonitor) AddActiveHostPid(hostPid uint32, node tp.PidNode) {
+	ActiveHostMap := *(mon.ActiveHostMap)
+	ActiveHostMapLock := *(mon.ActiveHostMapLock)
+
+	ActiveHostMapLock.Lock()
+	defer ActiveHostMapLock.Unlock()
+
+	// add pid node to ActiveHostMap
+	if pidMap, ok := ActiveHostMap[hostPid]; ok {
+		pidMap[hostPid] = node
+	} else {
+		newPidMap := tp.PidMap{node.HostPID: node}
+		ActiveHostMap[hostPid] = newPidMap
+	}
+}
+
+// GetHostExecPath Function
+func (mon *SystemMonitor) GetHostExecPath(hostPid uint32) string {
+	ActiveHostMap := *(mon.ActiveHostMap)
+	ActiveHostMapLock := *(mon.ActiveHostMapLock)
+
+	ActiveHostMapLock.RLock()
+	defer ActiveHostMapLock.RUnlock()
+
+	if pidMap, ok := ActiveHostMap[hostPid]; ok {
+		if node, ok := pidMap[hostPid]; ok {
+			return node.ExecPath
+		}
+	}
+
+	return ""
+}
+
+// DeleteActiveHostPid Function
+func (mon *SystemMonitor) DeleteActiveHostPid(hostPid uint32) {
+	ActiveHostMap := *(mon.ActiveHostMap)
+	ActiveHostMapLock := *(mon.ActiveHostMapLock)
+
+	ActiveHostMapLock.Lock()
+	defer ActiveHostMapLock.Unlock()
+
+	// delete execve(at) host pid
+	if pidMap, ok := ActiveHostMap[hostPid]; ok {
+		if node, ok := pidMap[hostPid]; ok {
+			node.Exited = true
+			node.ExitedTime = time.Now()
+		}
+	}
+}

--- a/KubeArmor/monitor/processTree.go
+++ b/KubeArmor/monitor/processTree.go
@@ -1,0 +1,367 @@
+package monitor
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	tp "github.com/accuknox/KubeArmor/KubeArmor/types"
+)
+
+// ============================ //
+// == PID-to-ContainerID Map == //
+// ============================ //
+
+// LookupContainerID Function
+func (mon *SystemMonitor) LookupContainerID(pidns uint32, mntns uint32, pid uint32, newProcess bool) string {
+	key := NsKey{PidNS: pidns, MntNS: mntns}
+
+	if pid == 1 {
+		containerID := "None"
+
+		// first shot: look up container id from cgroup
+
+		cgroup, err := os.Open(fmt.Sprintf("/proc/%d/cgroup", pid))
+		if err != nil {
+			return "" // this is nature, just meaning that the PID no longer exists
+		}
+
+		cgroupScanner := bufio.NewScanner(cgroup)
+		for cgroupScanner.Scan() {
+			line := cgroupScanner.Text()
+
+			// k8s
+			parts := kubePattern.FindStringSubmatch(line)
+			if parts != nil {
+				containerID = parts[1]
+				break
+			}
+
+			// docker
+			parts = dockerPattern.FindStringSubmatch(line)
+			if parts != nil {
+				containerID = parts[1]
+				break
+			}
+		}
+
+		cgroup.Close()
+
+		// update newly found container id
+		if containerID != "None" {
+			mon.NsMapLock.Lock()
+			mon.NsMap[key] = containerID
+			mon.NsMapLock.Unlock()
+			return containerID
+		}
+
+		// alternative shot: look up container id from cmdline
+
+		cmdline, err := os.Open(fmt.Sprintf("/proc/%d/cmdline", pid))
+		if err != nil {
+			return "" // this is nature, just meaning that the PID no longer exists
+		}
+
+		cmdScanner := bufio.NewScanner(cmdline)
+		for cmdScanner.Scan() {
+			line := cmdScanner.Text()
+
+			parts := strings.Split(line, "-id")
+			if len(parts) < 2 {
+				break
+			}
+
+			parts = strings.Split(parts[1], "-addr")
+			if len(parts) < 2 {
+				break
+			}
+
+			containerID = parts[0]
+			break
+		}
+
+		cmdline.Close()
+
+		// update newly found container id
+		if containerID != "None" {
+			mon.NsMapLock.Lock()
+			mon.NsMap[key] = containerID
+			mon.NsMapLock.Unlock()
+			return containerID
+		}
+	} else {
+		mon.NsMapLock.RLock()
+		if val, ok := mon.NsMap[key]; ok {
+			mon.NsMapLock.RUnlock()
+			return val
+		}
+		mon.NsMapLock.RUnlock()
+
+		if newProcess { // if new process, look up container id
+			containerID := "None"
+
+			// first shot: look up container id from cgroup
+
+			cgroup, err := os.Open(fmt.Sprintf("/proc/%d/cgroup", pid))
+			if err != nil {
+				return "" // this is nature, just meaning that the PID no longer exists
+			}
+
+			cgroupScanner := bufio.NewScanner(cgroup)
+			for cgroupScanner.Scan() {
+				line := cgroupScanner.Text()
+
+				// k8s
+				parts := kubePattern.FindStringSubmatch(line)
+				if parts != nil {
+					containerID = parts[1]
+					break
+				}
+
+				// docker
+				parts = dockerPattern.FindStringSubmatch(line)
+				if parts != nil {
+					containerID = parts[1]
+					break
+				}
+			}
+
+			cgroup.Close()
+
+			// update newly found container id
+			if containerID != "None" {
+				mon.NsMapLock.Lock()
+				mon.NsMap[key] = containerID
+				mon.NsMapLock.Unlock()
+				return containerID
+			}
+
+			// alternative shot: look up container id from cmdline
+
+			cmdline, err := os.Open(fmt.Sprintf("/proc/%d/cmdline", pid))
+			if err != nil {
+				return "" // this is nature, just meaning that the PID no longer exists
+			}
+
+			cmdScanner := bufio.NewScanner(cmdline)
+			for cmdScanner.Scan() {
+				line := cmdScanner.Text()
+
+				parts := strings.Split(line, "-id")
+				if len(parts) < 2 {
+					break
+				}
+
+				parts = strings.Split(parts[1], "-addr")
+				if len(parts) < 2 {
+					break
+				}
+
+				containerID = parts[0]
+				break
+			}
+
+			cmdline.Close()
+
+			// update newly found container id
+			if containerID != "None" {
+				mon.NsMapLock.Lock()
+				mon.NsMap[key] = containerID
+				mon.NsMapLock.Unlock()
+				return containerID
+			}
+		}
+	}
+
+	return ""
+}
+
+func (mon *SystemMonitor) DeleteContainerIDFromNsMap(containerID string) {
+	ns := NsKey{}
+
+	mon.NsMapLock.RLock()
+	defer mon.NsMapLock.RUnlock()
+
+	for key, val := range mon.NsMap {
+		if containerID == val {
+			ns = key
+			break
+		}
+	}
+
+	if ns.PidNS != 0 && ns.MntNS != 0 {
+		delete(mon.NsMap, ns)
+	}
+}
+
+// ================== //
+// == Process Tree == //
+// ================== //
+
+// BuildPidNode Function
+func (mon *SystemMonitor) BuildPidNode(ctx SyscallContext, execPath string, args []string) tp.PidNode {
+	node := tp.PidNode{}
+
+	node.HostPID = ctx.HostPID
+	node.PPID = ctx.PPID
+	node.PID = ctx.PID
+	node.UID = ctx.UID
+
+	node.Comm = string(ctx.Comm[:])
+	node.ExecPath = execPath
+
+	for idx, arg := range args {
+		if idx == 0 {
+			continue
+		} else {
+			node.ExecPath = node.ExecPath + " " + arg
+		}
+	}
+
+	node.Exited = false
+
+	return node
+}
+
+// AddActivePid Function
+func (mon *SystemMonitor) AddActivePid(containerID string, node tp.PidNode) {
+	ActivePidMap := *(mon.ActivePidMap)
+	ActivePidMapLock := *(mon.ActivePidMapLock)
+
+	ActivePidMapLock.Lock()
+	defer ActivePidMapLock.Unlock()
+
+	// add pid node to ActivePidMap
+	if pidMap, ok := ActivePidMap[containerID]; ok {
+		pidMap[node.PID] = node
+	} else {
+		newPidMap := tp.PidMap{node.PID: node}
+		ActivePidMap[containerID] = newPidMap
+	}
+
+	ActiveHostPidMap := *(mon.ActiveHostPidMap)
+
+	// add pid node to ActiveHostPidMap
+	if pidMap, ok := ActiveHostPidMap[containerID]; ok {
+		pidMap[node.HostPID] = node
+	} else {
+		newPidMap := tp.PidMap{node.HostPID: node}
+		ActiveHostPidMap[containerID] = newPidMap
+	}
+}
+
+// GetExecPath Function
+func (mon *SystemMonitor) GetExecPath(containerID string, pid uint32) string {
+	ActivePidMap := *(mon.ActivePidMap)
+	ActivePidMapLock := *(mon.ActivePidMapLock)
+
+	ActivePidMapLock.RLock()
+	defer ActivePidMapLock.RUnlock()
+
+	if pidMap, ok := ActivePidMap[containerID]; ok {
+		if node, ok := pidMap[pid]; ok {
+			return node.ExecPath
+		}
+	}
+
+	return ""
+}
+
+// GetExecPathWithHostPID Function
+func (mon *SystemMonitor) GetExecPathWithHostPID(containerID string, hostPid uint32) string {
+	ActiveHostPidMap := *(mon.ActiveHostPidMap)
+	ActivePidMapLock := *(mon.ActivePidMapLock)
+
+	ActivePidMapLock.RLock()
+	defer ActivePidMapLock.RUnlock()
+
+	if pidMap, ok := ActiveHostPidMap[containerID]; ok {
+		if node, ok := pidMap[hostPid]; ok {
+			return node.ExecPath
+		}
+	}
+
+	return ""
+}
+
+// DeleteActivePid Function
+func (mon *SystemMonitor) DeleteActivePid(containerID string, ctx SyscallContext) {
+	ActivePidMap := *(mon.ActivePidMap)
+	ActivePidMapLock := *(mon.ActivePidMapLock)
+
+	ActivePidMapLock.Lock()
+	defer ActivePidMapLock.Unlock()
+
+	// delete execve(at) pid
+	if pidMap, ok := ActivePidMap[containerID]; ok {
+		if node, ok := pidMap[ctx.PID]; ok {
+			node.Exited = true
+			node.ExitedTime = time.Now()
+		}
+	}
+
+	ActiveHostPidMap := *(mon.ActiveHostPidMap)
+
+	// delete execve(at) host pid
+	if pidMap, ok := ActiveHostPidMap[containerID]; ok {
+		if node, ok := pidMap[ctx.HostPID]; ok {
+			node.Exited = true
+			node.ExitedTime = time.Now()
+		}
+	}
+}
+
+// CleanUpExitedHostPids Function
+func (mon *SystemMonitor) CleanUpExitedHostPids() {
+	for range mon.Ticker.C {
+		now := time.Now()
+
+		ActivePidMap := *(mon.ActivePidMap)
+		ActivePidMapLock := *(mon.ActivePidMapLock)
+
+		ActivePidMapLock.Lock()
+
+		for _, pidMap := range ActivePidMap {
+			for pid, pidNode := range pidMap {
+				if pidNode.Exited {
+					if now.After(pidNode.ExitedTime.Add(time.Second * 5)) {
+						delete(pidMap, pid)
+					}
+				}
+			}
+		}
+
+		ActiveHostPidMap := *(mon.ActiveHostPidMap)
+
+		for _, pidMap := range ActiveHostPidMap {
+			for pid, pidNode := range pidMap {
+				if pidNode.Exited {
+					if now.After(pidNode.ExitedTime.Add(time.Second * 5)) {
+						delete(pidMap, pid)
+					}
+				}
+			}
+		}
+
+		ActivePidMapLock.Unlock()
+
+		ActiveHostMap := *(mon.ActiveHostMap)
+		ActiveHostMapLock := *(mon.ActiveHostMapLock)
+
+		ActiveHostMapLock.Lock()
+
+		for _, pidMap := range ActiveHostMap {
+			for pid, pidNode := range pidMap {
+				if pidNode.Exited {
+					if now.After(pidNode.ExitedTime.Add(time.Second * 10)) {
+						delete(pidMap, pid)
+					}
+				}
+			}
+		}
+
+		ActiveHostMapLock.Unlock()
+	}
+}

--- a/deployments/GKE/kubearmor.yaml
+++ b/deployments/GKE/kubearmor.yaml
@@ -60,8 +60,8 @@ spec:
         imagePullPolicy: Always
         securityContext:
           privileged: true
-        # args: ["-gRPC=32767", "-logPath=/tmp/kubearmor.log"]
-        args: ["-gRPC=32767", "-logPath=/tmp/kubearmor.log", "-enableHostPolicy"]
+        args: ["-gRPC=32767", "-logPath=/tmp/kubearmor.log"]
+        # args: ["-gRPC=32767", "-logPath=/tmp/kubearmor.log", "-enableHostPolicy"]
         ports:
         - containerPort: 32767
         volumeMounts:
@@ -80,9 +80,9 @@ spec:
           mountPath: /sys/kernel/debug
         - name: etc-apparmor-d-path # AppArmor (read-write)
           mountPath: /etc/apparmor.d
-        # - name: var-log-audit-path # GKE-Auditd (read-only)
-        #   mountPath: /var/log/audit
-        #   readOnly: true
+        - name: var-log-audit-path # GKE-Auditd (read-only)
+          mountPath: /var/log/audit
+          readOnly: true
         - name: os-release-path # OS (read-only)
           mountPath: /media/root/etc/os-release
           readOnly: true
@@ -132,92 +132,92 @@ spec:
         hostPath:
           path: /etc/apparmor.d
           type: Directory
-      # - name: var-log-audit-path # GKE-Auditd
-      #   hostPath:
-      #     path: /var/log/audit
-      #     type: Directory
+      - name: var-log-audit-path # GKE-Auditd
+        hostPath:
+          path: /var/log/audit
+          type: Directory
       - name: os-release-path # OS
         hostPath:
           path: /etc/os-release
           type: File
-# ---
-# apiVersion: apps/v1
-# kind: DaemonSet
-# metadata:
-#   name: kubearmor-cos-auditd
-#   namespace: kube-system
-#   labels:
-#     daemonset: kubearmor-cos-auditd
-# spec:
-#   selector:
-#     matchLabels:
-#       container: kubearmor-cos-auditd
-#   template:
-#     metadata:
-#       labels:
-#         container: kubearmor-cos-auditd
-#       annotations:
-#         scheduler.alpha.kubernetes.io/critical-pod: ""
-#     spec:
-#       nodeSelector:
-#         cloud.google.com/gke-os-distribution: cos
-#       hostPID: true
-#       hostNetwork: true
-#       restartPolicy: Always
-#       initContainers:
-#       - name: kubearmor-cos-auditd-setup
-#         image: ubuntu
-#         command: ["chroot", "/host", "systemctl", "start", "cloud-audit-setup"]
-#         securityContext:
-#           privileged: true
-#         volumeMounts:
-#         - name: host-path
-#           mountPath: /host
-#         resources:
-#           requests:
-#             memory: "10Mi"
-#             cpu: "10m"
-#       containers:
-#       - name: kubearmor-cos-auditd
-#         image: accuknox/kubearmor-cos-auditd:latest
-#         imagePullPolicy: Always
-#         env:
-#         - name: NODE_NAME
-#           valueFrom:
-#             fieldRef:
-#               apiVersion: v1
-#               fieldPath: spec.nodeName
-#         volumeMounts:
-#         - name: lib-systemd-path
-#           mountPath: /host/lib
-#           readOnly: true
-#         - name: var-log-path
-#           mountPath: /var/log
-#         # resources:
-#         #   limits:
-#         #     cpu: "1"
-#         #     memory: 500Mi
-#         #   requests:
-#         #     cpu: 100m
-#         #     memory: 200Mi
-#         terminationMessagePolicy: File
-#         terminationMessagePath: /dev/termination-log
-#       terminationGracePeriodSeconds: 30
-#       tolerations:
-#       - effect: NoSchedule
-#         key: node.alpha.kubernetes.io/ismaster
-#       - effect: NoExecute
-#         operator: Exists
-#       volumes:
-#       - name: host-path
-#         hostPath:
-#           path: /
-#           type: Directory
-#       - name: lib-systemd-path
-#         hostPath:
-#           path: /usr/lib64
-#           type: Directory
-#       - name: var-log-path
-#         hostPath:
-#           path: /var/log
-#           type: Directory
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: kubearmor-cos-auditd
+  namespace: kube-system
+  labels:
+    daemonset: kubearmor-cos-auditd
+spec:
+  selector:
+    matchLabels:
+      container: kubearmor-cos-auditd
+  template:
+    metadata:
+      labels:
+        container: kubearmor-cos-auditd
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ""
+    spec:
+      nodeSelector:
+        cloud.google.com/gke-os-distribution: cos
+      hostPID: true
+      hostNetwork: true
+      restartPolicy: Always
+      initContainers:
+      - name: kubearmor-cos-auditd-setup
+        image: ubuntu
+        command: ["chroot", "/host", "systemctl", "start", "cloud-audit-setup"]
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - name: host-path
+          mountPath: /host
+        resources:
+          requests:
+            memory: "10Mi"
+            cpu: "10m"
+      containers:
+      - name: kubearmor-cos-auditd
+        image: accuknox/kubearmor-cos-auditd:latest
+        imagePullPolicy: Always
+        env:
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: spec.nodeName
+        volumeMounts:
+        - name: lib-systemd-path
+          mountPath: /host/lib
+          readOnly: true
+        - name: var-log-path
+          mountPath: /var/log
+        # resources:
+        #   limits:
+        #     cpu: "1"
+        #     memory: 500Mi
+        #   requests:
+        #     cpu: 100m
+        #     memory: 200Mi
+        terminationMessagePolicy: File
+        terminationMessagePath: /dev/termination-log
+      terminationGracePeriodSeconds: 30
+      tolerations:
+      - effect: NoSchedule
+        key: node.alpha.kubernetes.io/ismaster
+      - effect: NoExecute
+        operator: Exists
+      volumes:
+      - name: host-path
+        hostPath:
+          path: /
+          type: Directory
+      - name: lib-systemd-path
+        hostPath:
+          path: /usr/lib64
+          type: Directory
+      - name: var-log-path
+        hostPath:
+          path: /var/log
+          type: Directory

--- a/deployments/generic-containerd/kubearmor.yaml
+++ b/deployments/generic-containerd/kubearmor.yaml
@@ -80,9 +80,9 @@ spec:
           mountPath: /sys/kernel/debug
         - name: etc-apparmor-d-path # AppArmor (read-write)
           mountPath: /etc/apparmor.d
-        # - name: var-log-audit-path # Auditd (read-only)
-        #   mountPath: /var/log/audit
-        #   readOnly: true
+        - name: var-log-audit-path # Auditd (read-only)
+          mountPath: /var/log/audit
+          readOnly: true
         - name: os-release-path # OS (read-only)
           mountPath: /media/root/etc/os-release
           readOnly: true
@@ -132,10 +132,10 @@ spec:
         hostPath:
           path: /etc/apparmor.d
           type: Directory
-      # - name: var-log-audit-path # Auditd
-      #   hostPath:
-      #     path: /var/log/audit
-      #     type: Directory
+      - name: var-log-audit-path # Auditd
+        hostPath:
+          path: /var/log/audit
+          type: Directory
       - name: os-release-path # OS
         hostPath:
           path: /etc/os-release

--- a/deployments/generic-docker/kubearmor.yaml
+++ b/deployments/generic-docker/kubearmor.yaml
@@ -60,8 +60,8 @@ spec:
         imagePullPolicy: Always
         securityContext:
           privileged: true
-        # args: ["-gRPC=32767", "-logPath=/tmp/kubearmor.log"]
-        args: ["-gRPC=32767", "-logPath=/tmp/kubearmor.log", "-enableHostPolicy"]
+        args: ["-gRPC=32767", "-logPath=/tmp/kubearmor.log"]
+        # args: ["-gRPC=32767", "-logPath=/tmp/kubearmor.log", "-enableHostPolicy"]
         ports:
         - containerPort: 32767
         volumeMounts:
@@ -80,9 +80,9 @@ spec:
           mountPath: /sys/kernel/debug
         - name: etc-apparmor-d-path # AppArmor (read-write)
           mountPath: /etc/apparmor.d
-        # - name: var-log-audit-path # Auditd (read-only)
-        #   mountPath: /var/log/audit
-        #   readOnly: true
+        - name: var-log-audit-path # Auditd (read-only)
+          mountPath: /var/log/audit
+          readOnly: true
         - name: os-release-path # OS (read-only)
           mountPath: /media/root/etc/os-release
           readOnly: true
@@ -132,10 +132,10 @@ spec:
         hostPath:
           path: /etc/apparmor.d
           type: Directory
-      # - name: var-log-audit-path # Auditd
-      #   hostPath:
-      #     path: /var/log/audit
-      #     type: Directory
+      - name: var-log-audit-path # Auditd
+        hostPath:
+          path: /var/log/audit
+          type: Directory
       - name: os-release-path # OS
         hostPath:
           path: /etc/os-release

--- a/deployments/microk8s/kubearmor.yaml
+++ b/deployments/microk8s/kubearmor.yaml
@@ -80,9 +80,9 @@ spec:
           mountPath: /sys/kernel/debug
         - name: etc-apparmor-d-path # AppArmor (read-write)
           mountPath: /etc/apparmor.d
-        # - name: var-log-audit-path # Auditd (read-only)
-        #   mountPath: /var/log/audit
-        #   readOnly: true
+        - name: var-log-audit-path # Auditd (read-only)
+          mountPath: /var/log/audit
+          readOnly: true
         - name: os-release-path # OS (read-only)
           mountPath: /media/root/etc/os-release
           readOnly: true
@@ -132,10 +132,10 @@ spec:
         hostPath:
           path: /etc/apparmor.d
           type: Directory
-      # - name: var-log-audit-path # Auditd
-      #   hostPath:
-      #     path: /var/log/audit
-      #     type: Directory
+      - name: var-log-audit-path # Auditd
+        hostPath:
+          path: /var/log/audit
+          type: Directory
       - name: os-release-path # OS
         hostPath:
           path: /etc/os-release

--- a/tests/test-scenarios-in-runtime.sh
+++ b/tests/test-scenarios-in-runtime.sh
@@ -100,16 +100,16 @@ function should_not_find_any_log() {
     NODE=$(kubectl get pods -A -o wide | grep $1 | awk '{print $8}')
     KUBEARMOR=$(kubectl get pods -n kube-system -o wide | grep $NODE | grep kubearmor | grep -v cos | awk '{print $1}')
 
-    sleep 2
+    sleep 3
 
     echo -e "${GREEN}[INFO] Finding the corresponding log${NC}"
 
     if [ "$KUBEARMOR" != "" ]; then
-        audit_log=$(kubectl -n kube-system exec -it $KUBEARMOR -- bash -c "grep MatchedPolicy $ARMOR_LOG | tail | grep $1 | grep $2 | grep $3 | grep $4")
+        audit_log=$(kubectl -n kube-system exec -it $KUBEARMOR -- bash -c "grep MatchedPolicy $ARMOR_LOG | tail | grep $1 | grep $2 | grep $3 | grep $4 | grep -v Passed")
         if [ $? == 0 ]; then
             sleep 2
 
-            audit_log=$(kubectl -n kube-system exec -it $KUBEARMOR -- bash -c "grep MatchedPolicy $ARMOR_LOG | tail | grep $1 | grep $2 | grep $3 | grep $4")
+            audit_log=$(kubectl -n kube-system exec -it $KUBEARMOR -- bash -c "grep MatchedPolicy $ARMOR_LOG | tail | grep $1 | grep $2 | grep $3 | grep $4 | grep -v Passed")
             if [ $? == 0 ]; then
                 echo $audit_log
                 echo -e "${RED}[FAIL] Found the log from logs${NC}"
@@ -123,11 +123,11 @@ function should_not_find_any_log() {
             echo "[INFO] Found no log from logs"
         fi
     else # local
-        audit_log=$(grep MatchedPolicy $ARMOR_LOG | tail | grep $1 | grep $2 | grep $3 | grep $4)
+        audit_log=$(grep MatchedPolicy $ARMOR_LOG | tail | grep $1 | grep $2 | grep $3 | grep $4 | grep -v Passed)
         if [ $? == 0 ]; then
             sleep 2
 
-            audit_log=$(grep MatchedPolicy $ARMOR_LOG | tail | grep $1 | grep $2 | grep $3 | grep $4)
+            audit_log=$(grep MatchedPolicy $ARMOR_LOG | tail | grep $1 | grep $2 | grep $3 | grep $4 | grep -v Passed)
             if [ $? == 0 ]; then
                 echo $audit_log
                 echo -e "${RED}[FAIL] Found the log from logs${NC}"
@@ -147,7 +147,7 @@ function should_find_passed_log() {
     NODE=$(kubectl get pods -A -o wide | grep $1 | awk '{print $8}')
     KUBEARMOR=$(kubectl get pods -n kube-system -o wide | grep $NODE | grep kubearmor | grep -v cos | awk '{print $1}')
 
-    sleep 2
+    sleep 3
 
     echo -e "${GREEN}[INFO] Finding the corresponding log${NC}"
 
@@ -194,7 +194,7 @@ function should_find_blocked_log() {
     NODE=$(kubectl get pods -A -o wide | grep $1 | awk '{print $8}')
     KUBEARMOR=$(kubectl get pods -n kube-system -o wide | grep $NODE | grep kubearmor | grep -v cos | awk '{print $1}')
 
-    sleep 2
+    sleep 3
 
     echo -e "${GREEN}[INFO] Finding the corresponding log${NC}"
 

--- a/tests/test-scenarios-local.sh
+++ b/tests/test-scenarios-local.sh
@@ -4,11 +4,7 @@ TEST_HOME=`dirname $(realpath "$0")`
 CRD_HOME=`dirname $(realpath "$0")`/../deployments/CRD
 ARMOR_HOME=`dirname $(realpath "$0")`/../KubeArmor
 
-ARMOR_OPTIONS=""
-
-if [ ! -z $1 ]; then
-    ARMOR_OPTIONS=$1
-fi
+ARMOR_OPTIONS=$@
 
 ARMOR_MSG=/tmp/kubearmor.msg
 ARMOR_LOG=/tmp/kubearmor.log
@@ -40,7 +36,8 @@ function start_and_wait_for_kubearmor_initialization() {
 
     cd $ARMOR_HOME
 
-    sudo -E ./kubearmor -logPath=$ARMOR_LOG $ARMOR_OPTION > $ARMOR_MSG &
+    echo "Options: -logPath=$ARMOR_LOG $ARMOR_OPTIONS"
+    sudo -E ./kubearmor -logPath=$ARMOR_LOG $ARMOR_OPTIONS > $ARMOR_MSG &
 
     for (( ; ; ))
     do
@@ -105,13 +102,13 @@ function delete_and_wait_for_microserivce_deletion() {
 function should_not_find_any_log() {
     echo -e "${GREEN}[INFO] Finding the corresponding log${NC}"
 
-    sleep 2
+    sleep 3
 
-    audit_log=$(grep MatchedPolicy $ARMOR_LOG | tail | grep $1 | grep $2 | grep $3 | grep $4)
+    audit_log=$(grep MatchedPolicy $ARMOR_LOG | tail | grep $1 | grep $2 | grep $3 | grep $4 | grep -v Passed)
     if [ $? == 0 ]; then
         sleep 2
 
-        audit_log=$(grep MatchedPolicy $ARMOR_LOG | tail | grep $1 | grep $2 | grep $3 | grep $4)
+        audit_log=$(grep MatchedPolicy $ARMOR_LOG | tail | grep $1 | grep $2 | grep $3 | grep $4 | grep -v Passed)
         if [ $? == 0 ]; then
             echo $audit_log
             echo -e "${RED}[FAIL] Found the log from logs${NC}"
@@ -129,7 +126,7 @@ function should_not_find_any_log() {
 function should_find_passed_log() {
     echo -e "${GREEN}[INFO] Finding the corresponding log${NC}"
 
-    sleep 2
+    sleep 3
 
     audit_log=$(grep MatchedPolicy $ARMOR_LOG | tail | grep $1 | grep $2 | grep $3 | grep $4 | grep Passed)
     if [ $? != 0 ]; then
@@ -153,7 +150,7 @@ function should_find_passed_log() {
 function should_find_blocked_log() {
     echo -e "${GREEN}[INFO] Finding the corresponding log${NC}"
 
-    sleep 2
+    sleep 3
 
     audit_log=$(grep MatchedPolicy $ARMOR_LOG | tail | grep $1 | grep $2 | grep $3 | grep $4 | grep -v Passed)
     if [ $? != 0 ]; then

--- a/tests/test-scenarios-with-microk8s.sh
+++ b/tests/test-scenarios-with-microk8s.sh
@@ -123,15 +123,15 @@ function delete_and_wait_for_microserivce_deletion() {
 function should_not_find_any_log() {
     KUBEARMOR=$(kubectl get pods -n kube-system | grep kubearmor | awk '{print $1}')
 
-    sleep 2
+    sleep 3
 
     echo -e "${GREEN}[INFO] Finding the corresponding log${NC}"
 
-    audit_log=$(kubectl -n kube-system exec -it $KUBEARMOR -- bash -c "grep MatchedPolicy $ARMOR_LOG | tail | grep $1 | grep $2 | grep $3 | grep $4")
+    audit_log=$(kubectl -n kube-system exec -it $KUBEARMOR -- bash -c "grep MatchedPolicy $ARMOR_LOG | tail | grep $1 | grep $2 | grep $3 | grep $4 | grep -v Passed")
     if [ $? == 0 ]; then
         sleep 2
 
-        audit_log=$(kubectl -n kube-system exec -it $KUBEARMOR -- bash -c "grep MatchedPolicy $ARMOR_LOG | tail | grep $1 | grep $2 | grep $3 | grep $4")
+        audit_log=$(kubectl -n kube-system exec -it $KUBEARMOR -- bash -c "grep MatchedPolicy $ARMOR_LOG | tail | grep $1 | grep $2 | grep $3 | grep $4 | grep -v Passed")
         if [ $? == 0 ]; then
             echo $audit_log
             echo -e "${RED}[FAIL] Found the log from logs${NC}"
@@ -149,7 +149,7 @@ function should_not_find_any_log() {
 function should_find_passed_log() {
     KUBEARMOR=$(kubectl get pods -n kube-system | grep kubearmor | awk '{print $1}')
 
-    sleep 2
+    sleep 3
 
     echo -e "${GREEN}[INFO] Finding the corresponding log${NC}"
 
@@ -175,7 +175,7 @@ function should_find_passed_log() {
 function should_find_blocked_log() {
     KUBEARMOR=$(kubectl get pods -n kube-system | grep kubearmor | awk '{print $1}')
 
-    sleep 2
+    sleep 3
 
     echo -e "${GREEN}[INFO] Finding the corresponding log${NC}"
 


### PR DESCRIPTION
Improve the performance of the system monitor

- Replace Mutex with RWMutex
- Optimize the lookup functions for container contexts, PIDs, host PIDs, etc.

Add options

- Add "enableAuditd" -> an option to use Auditd instead of eBPF
- Add "enableSystemLog" -> an option to record all behaviors of containers