### PR TITLE
KubeArmor: Fixes the creation of the development environment

### DIFF
--- a/KafkaClient/Makefile
+++ b/KafkaClient/Makefile
@@ -9,6 +9,7 @@ TOPIC_LOG=kubearmor-syslogs
 
 .PHONY: build
 build:
+	cd $(CURDIR); go mod tidy
 	cd $(CURDIR); go build -o kubearmor-kafka-client main.go
 
 .PHONY: run

--- a/KubeArmor-relay-server/Makefile
+++ b/KubeArmor-relay-server/Makefile
@@ -2,6 +2,7 @@ CURDIR=$(shell pwd)
 
 .PHONY: build
 build:
+	cd $(CURDIR); go mod tidy
 	cd $(CURDIR); go build -o kubearmor-relay-server main.go
 
 .PHONY: run

--- a/KubeArmor/Makefile
+++ b/KubeArmor/Makefile
@@ -4,6 +4,7 @@ GO_EXEC=$(shell which go)
 .PHONY: build
 build:
 	$(CURDIR)/patch.sh
+	cd $(CURDIR); go mod tidy
 	cd $(CURDIR); go build -o kubearmor main.go
 
 .PHONY: run
@@ -18,12 +19,16 @@ run-per-pod: $(CURDIR)/kubearmor
 
 .PHONY: test
 test:
+	cd $(CURDIR)/feeder; go mod tidy
 	cd $(CURDIR)/feeder; go clean -testcache .; go test -v .
 
 .PHONY: testall
 testall:
+	cd $(CURDIR)/feeder; go mod tidy
 	cd $(CURDIR)/feeder; go clean -testcache .; go test -v .
+	cd $(CURDIR)/enforcer; go mod tidy
 	cd $(CURDIR)/enforcer; go clean -testcache .; sudo -E $(GO_EXEC) test -v .
+	cd $(CURDIR)/monitor; go mod tidy
 	cd $(CURDIR)/monitor; go clean -testcache .; sudo -E $(GO_EXEC) test -v .
 
 .PHONY: clean

--- a/LogClient/Makefile
+++ b/LogClient/Makefile
@@ -2,6 +2,7 @@ CURDIR=$(shell pwd)
 
 .PHONY: build
 build:
+	cd $(CURDIR); go mod tidy
 	cd $(CURDIR); go build -o kubearmor-log-client main.go
 
 .PHONY: run

--- a/MySQLClient/Makefile
+++ b/MySQLClient/Makefile
@@ -13,6 +13,7 @@ TABLE_LOG=syslogs
 
 .PHONY: build
 build:
+	cd $(CURDIR); go mod tidy
 	cd $(CURDIR); go build -o kubearmor-mysql-client main.go
 
 .PHONY: run

--- a/contribution/vagrant/Vagrantfile
+++ b/contribution/vagrant/Vagrantfile
@@ -30,6 +30,9 @@ Vagrant.configure("2") do |config|
   config.vm.provision :shell, path: kubearmor_home + "/contribution/self-managed-k8s/docker/install_docker.sh"
   config.vm.provision :shell, path: kubearmor_home + "/contribution/self-managed-k8s/k8s/install_kubernetes.sh"
 
+  # Provision inline
+  config.vm.provision :shell, inline: "chown -R vagrant:vagrant /home/vagrant/go"
+
   # Initialize Kubernetes
   config.vm.provision :shell, path: kubearmor_home + "/contribution/self-managed-k8s/k8s/initialize_kubernetes.sh"
 end

--- a/pkg/KubeArmorHostPolicy/Makefile
+++ b/pkg/KubeArmorHostPolicy/Makefile
@@ -53,6 +53,7 @@ vet:
 
 # Generate code
 generate: controller-gen
+	go mod tidy
 	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./..."
 
 # Build the docker image

--- a/pkg/KubeArmorPolicy/Makefile
+++ b/pkg/KubeArmorPolicy/Makefile
@@ -52,6 +52,7 @@ vet:
 
 # Generate code
 generate: controller-gen
+	go mod tidy
 	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./..."
 
 # Build the docker image


### PR DESCRIPTION
This set /home/vagrant/go path ownership to vagrant and fixes Makefile
adding `go mod tidy` execution before `go build`.

Fixes: #146

Signed-off-by: Geyslan G. Bem <geyslan@accuknox.com>