### PR TITLE
Add native AppArmor policy support in KubeArmorPolicy

### DIFF
--- a/KubeArmor/types/types.go
+++ b/KubeArmor/types/types.go
@@ -392,6 +392,8 @@ type SecuritySpec struct {
 	Capabilities CapabilitiesType `json:"capabilities,omitempty"`
 	Resource     ResourceType     `json:"resource,omitempty"`
 
+	Apparmor string `json:"apparmor,omitempty"`
+
 	Action string `json:"action"`
 }
 

--- a/helm/templates/security.accuknox.com_kubearmorpolicies.yaml
+++ b/helm/templates/security.accuknox.com_kubearmorpolicies.yaml
@@ -46,6 +46,8 @@ spec:
                 - AllowWithAudit
                 - BlockWithAudit
                 type: string
+              apparmor:
+                type: string
               capabilities:
                 properties:
                   action:

--- a/pkg/KubeArmorPolicy/api/v1/kubearmorpolicy_types.go
+++ b/pkg/KubeArmorPolicy/api/v1/kubearmorpolicy_types.go
@@ -304,6 +304,8 @@ type KubeArmorPolicySpec struct {
 	Capabilities CapabilitiesType `json:"capabilities,omitempty"`
 	Resource     ResourceType     `json:"resource,omitempty"`
 
+	Apparmor string `json:"apparmor,omitempty"`
+
 	// +kubebuilder:validation:optional
 	Severity SeverityType `json:"severity,omitempty"`
 	// +kubebuilder:validation:optional

--- a/pkg/KubeArmorPolicy/config/crd/bases/security.accuknox.com_kubearmorpolicies.yaml
+++ b/pkg/KubeArmorPolicy/config/crd/bases/security.accuknox.com_kubearmorpolicies.yaml
@@ -46,6 +46,8 @@ spec:
                 - AllowWithAudit
                 - BlockWithAudit
                 type: string
+              apparmor:
+                type: string
               capabilities:
                 properties:
                   action:


### PR DESCRIPTION
This commit makes it possible for us to embed native apparmor rules in the YAML policy. It
adds a new field in the spec called apparmor of type string.

Fixes: #54