### PR TITLE
feeder: policyMatcher: Refactoring SecurityPolices functions and adding matchPatterns logic

### DIFF
--- a/KubeArmor/feeder/policyMatcher.go
+++ b/KubeArmor/feeder/policyMatcher.go
@@ -1,6 +1,7 @@
 package feeder
 
 import (
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -195,8 +196,29 @@ func (fd *Feeder) UpdateSecurityPolicies(action string, conGroup tp.ContainerGro
 			}
 		}
 
-		// for _, patt := range secPolicy.Spec.Process.MatchPatterns {
-		// }
+		for _, patt := range secPolicy.Spec.Process.MatchPatterns {
+			if len(patt.Pattern) == 0 {
+				continue
+			}
+
+			regexpComp, err := regexp.Compile(patt.Pattern)
+			if err != nil {
+				continue
+			}
+
+			match := tp.MatchPolicy{
+				PolicyName: policyName,
+				Severity:   strconv.Itoa(patt.Severity),
+				Tags:       patt.Tags,
+				Message:    patt.Message,
+				Source:     "",
+				Operation:  "Process",
+				Resource:   patt.Pattern,
+				Regexp:     regexpComp,
+				Action:     patt.Action,
+			}
+			matches.Policies = append(matches.Policies, match)
+		}
 
 		for _, path := range secPolicy.Spec.File.MatchPaths {
 			fromSource := ""
@@ -244,8 +266,29 @@ func (fd *Feeder) UpdateSecurityPolicies(action string, conGroup tp.ContainerGro
 			}
 		}
 
-		// for _, patt := range secPolicy.Spec.File.MatchPatterns {
-		// }
+		for _, patt := range secPolicy.Spec.File.MatchPatterns {
+			if len(patt.Pattern) == 0 {
+				continue
+			}
+
+			regexpComp, err := regexp.Compile(patt.Pattern)
+			if err != nil {
+				continue
+			}
+
+			match := tp.MatchPolicy{
+				PolicyName: policyName,
+				Severity:   strconv.Itoa(patt.Severity),
+				Tags:       patt.Tags,
+				Message:    patt.Message,
+				Source:     "",
+				Operation:  "File",
+				Resource:   patt.Pattern,
+				Regexp:     regexpComp,
+				Action:     patt.Action,
+			}
+			matches.Policies = append(matches.Policies, match)
+		}
 
 		for _, proto := range secPolicy.Spec.Network.MatchProtocols {
 			res := getProtocolFromName(proto.Protocol)

--- a/KubeArmor/feeder/policyMatcher.go
+++ b/KubeArmor/feeder/policyMatcher.go
@@ -13,6 +13,7 @@ import (
 // == Security Policies == //
 // ======================= //
 
+// newMatchPolicy Function
 func newMatchPolicy(policyName, src string, mp interface{}) tp.MatchPolicy {
 	match := tp.MatchPolicy{
 		PolicyName: policyName,
@@ -76,7 +77,6 @@ func newMatchPolicy(policyName, src string, mp interface{}) tp.MatchPolicy {
 		match.Operation = op
 		match.Resource = cap
 		match.Action = cct.Action
-
 	} else {
 		return tp.MatchPolicy{}
 	}
@@ -84,6 +84,7 @@ func newMatchPolicy(policyName, src string, mp interface{}) tp.MatchPolicy {
 	return match
 }
 
+// getProtocolFromName Function
 func getProtocolFromName(proto string) string {
 	switch strings.ToLower(proto) {
 	case "tcp":
@@ -97,6 +98,7 @@ func getProtocolFromName(proto string) string {
 	}
 }
 
+// getOperationAndCapabilityFromName
 func getOperationAndCapabilityFromName(capName string) (op, cap string) {
 	switch strings.ToLower(capName) {
 	case "net_raw":

--- a/KubeArmor/types/types.go
+++ b/KubeArmor/types/types.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"regexp"
 	"time"
 
 	v1 "k8s.io/api/core/v1"
@@ -183,6 +184,7 @@ type MatchPolicy struct {
 	Source    string
 	Operation string
 	Resource  string
+	Regexp    *regexp.Regexp
 
 	Native bool
 

--- a/examples/multiubuntu/security-policies/ksp-ubuntu-1-file-pattern-block.yaml
+++ b/examples/multiubuntu/security-policies/ksp-ubuntu-1-file-pattern-block.yaml
@@ -1,0 +1,16 @@
+apiVersion: security.accuknox.com/v1
+kind: KubeArmorPolicy
+metadata:
+  name: ksp-ubuntu-1-file-pattern-block
+  namespace: multiubuntu
+spec:
+  severity: 5
+  message: "block files following a pattern"
+  selector:
+    matchLabels:
+      container: ubuntu-1
+  file:
+    matchPatterns:
+    - pattern: /etc/*hado? # try open /etc/shadow or /etc/gshadow (permission denied)
+  action:
+    Block


### PR DESCRIPTION
This refactors the `UpdateSecurityPolicies()` and  `UpdateHostSecurityPolicies()` providing the same logic
with less code through helper functions, reducing checking and execution.

This also includes logic for `matchPatterns` and adds the `ksp-ubuntu-1-file-pattern-block.yaml` security policy example.

As an additional implementation, this proposes changes to the `KubeArmor/types/types.go:MatchPolicy` structure by adding a `Regexp` pointer field to it.

Fixes #143 