### PR TITLE
Add policy match support for native AppArmor policies

### DIFF
--- a/KubeArmor/feeder/feeder.go
+++ b/KubeArmor/feeder/feeder.go
@@ -473,7 +473,7 @@ func (fd *Feeder) PushLog(log tp.Log) error {
 
 	// gRPC output
 
-	if log.Type == "MatchedPolicy" || log.Type == "MatchedHostPolicy" {
+	if log.Type == "MatchedPolicy" || log.Type == "MatchedNativePolicy" || log.Type == "MatchedHostPolicy" {
 		pbAlert := pb.Alert{}
 
 		pbAlert.Timestamp = log.Timestamp

--- a/KubeArmor/feeder/policyMatcher.go
+++ b/KubeArmor/feeder/policyMatcher.go
@@ -20,6 +20,18 @@ func (fd *Feeder) UpdateSecurityPolicies(action string, conGroup tp.ContainerGro
 		matches := tp.MatchPolicies{}
 
 		for _, secPolicy := range conGroup.SecurityPolicies {
+			if len(secPolicy.Spec.Apparmor) > 0 {
+				match := tp.MatchPolicy{}
+				match.PolicyName = secPolicy.Metadata["policyName"]
+
+				match.Severity = strconv.Itoa(secPolicy.Spec.Severity)
+				match.Message = secPolicy.Spec.Message
+
+				match.Native = true
+				matches.Policies = append(matches.Policies, match)
+				continue
+			}
+
 			if len(secPolicy.Spec.Process.MatchPaths) > 0 {
 				for _, path := range secPolicy.Spec.Process.MatchPaths {
 					if len(path.FromSource) == 0 {
@@ -850,6 +862,8 @@ func (fd *Feeder) UpdateMatchedPolicy(log tp.Log) tp.Log {
 	allowNetworkTags := []string{}
 	allowNetworkMessage := ""
 
+	mightBeNative := false
+
 	if log.Result == "Passed" || log.Result == "Operation not permitted" || log.Result == "Permission denied" {
 		fd.SecurityPoliciesLock.RLock()
 
@@ -861,6 +875,11 @@ func (fd *Feeder) UpdateMatchedPolicy(log tp.Log) tp.Log {
 
 		secPolicies := fd.SecurityPolicies[key].Policies
 		for _, secPolicy := range secPolicies {
+			if secPolicy.Native && log.Result != "Passed" {
+				mightBeNative = true
+				continue
+			}
+
 			if secPolicy.Source == "" || strings.Contains(secPolicy.Source, log.Source) {
 				if secPolicy.Action == "Allow" || secPolicy.Action == "AllowWithAudit" {
 					if secPolicy.Operation == "Process" {
@@ -1073,6 +1092,17 @@ func (fd *Feeder) UpdateMatchedPolicy(log tp.Log) tp.Log {
 
 					log.Type = "MatchedPolicy"
 					log.Action = "Allow"
+
+					return log
+
+				}
+
+				if mightBeNative {
+					log.PolicyName = "unknown"
+					log.Severity = ""
+
+					log.Type = "MatchedNativePolicy"
+					log.Action = "unknown"
 
 					return log
 

--- a/KubeArmor/types/types.go
+++ b/KubeArmor/types/types.go
@@ -187,6 +187,7 @@ type MatchPolicy struct {
 	Operation string
 	Resource  string
 
+	Native bool
 	Action string
 }
 


### PR DESCRIPTION
This makes it possible for native AppArmor policy logs to be dumped to kubearmor logs.
The logs are only weakly matched so unrelated denied events might be dumped marked as MatchedNativePolicy.

Fixes: #151