### PR TITLE
Improving Development Environment functionalities - Makefile and Vagrantfile

### DIFF
--- a/KubeArmor/Makefile
+++ b/KubeArmor/Makefile
@@ -3,6 +3,9 @@ CONTRIBDIR      := $(realpath $(CURDIR)/../contribution)
 GO_EXEC         := $(shell which go)
 LOGNAME         := $(shell logname)
 NETNEXT         := 0
+DLV_EXEC         = $(GOPATH)/bin/dlv
+DLV_LPORT       := 2345
+KUBEARMOR_PID    = $(shell pgrep kubearmor)
 
 .PHONY: build
 build:
@@ -61,3 +64,13 @@ vagrant-ssh: vagrant-check
 .PHONY: vagrant-destroy
 vagrant-destroy: vagrant-check
 	cd $(CONTRIBDIR)/vagrant; NETNEXT=$(NETNEXT) vagrant destroy; true
+
+$(DLV_EXEC):
+	go get -u github.com/go-delve/delve/cmd/dlv
+
+.PHONY: debug-attach
+debug-attach: $(DLV_EXEC)
+ifeq ($(KUBEARMOR_PID), )
+	$(error kubearmor must be running - execute 'make run' first)
+endif
+	sudo $(DLV_EXEC) attach $(KUBEARMOR_PID) --headless -l=:$(DLV_LPORT) --log --api-version 2 $(CURDIR)

--- a/KubeArmor/Makefile
+++ b/KubeArmor/Makefile
@@ -1,5 +1,8 @@
-CURDIR=$(shell pwd)
-GO_EXEC=$(shell which go)
+CURDIR          := $(shell pwd)
+CONTRIBDIR      := $(realpath $(CURDIR)/../contribution)
+GO_EXEC         := $(shell which go)
+LOGNAME         := $(shell logname)
+NETNEXT         := 0
 
 .PHONY: build
 build:
@@ -36,3 +39,25 @@ clean:
 	cd $(CURDIR); sudo rm -f kubearmor /tmp/kubearmor.log
 	cd $(CURDIR); find . -name go.sum | xargs -I {} rm -f {}
 	$(CURDIR)/build/clean_source_files.sh
+
+.PHONY: vagrant-check
+vagrant-check:
+ifeq ($(LOGNAME), vagrant)
+	$(error rule must be called from outside the vagrant environment)
+endif
+
+.PHONY: vagrant-up
+vagrant-up: vagrant-check
+	cd $(CONTRIBDIR)/vagrant; NETNEXT=$(NETNEXT) vagrant up; true
+
+.PHONY: vagrant-reload
+vagrant-reload: vagrant-check
+	cd $(CONTRIBDIR)/vagrant; NETNEXT=$(NETNEXT) vagrant reload; true
+
+.PHONY: vagrant-ssh
+vagrant-ssh: vagrant-check
+	cd $(CONTRIBDIR)/vagrant; NETNEXT=$(NETNEXT) vagrant ssh; true
+
+.PHONY: vagrant-destroy
+vagrant-destroy: vagrant-check
+	cd $(CONTRIBDIR)/vagrant; NETNEXT=$(NETNEXT) vagrant destroy; true

--- a/contribution/vagrant/Vagrantfile
+++ b/contribution/vagrant/Vagrantfile
@@ -26,6 +26,9 @@ Vagrant.configure("2") do |config|
   # vagrant@VM_NAME
   config.vm.hostname = VM_NAME
 
+  # forward port for debug
+  config.vm.network "forwarded_port", guest: 2345, host: 2345
+
   # sync directories
   kubearmor_home = "../.."
   config.vm.synced_folder kubearmor_home, "/home/vagrant/KubeArmor", owner:"vagrant", group:"vagrant"


### PR DESCRIPTION
- [x] New Makefile rules for vagrant usage: `make vagrant-up`, `vagrant-ssh`, `vagrant-reload`, `vagrant-destroy`.
- [x] New Makefile rule to attach dlv debugger to KubeArmor: `make debug-attach`
  - [x] New Vagrantfile port forwarding to be used by dlv debugger: `2345` 

Fix #165 

Kudos for @rscampos and @trvll who shared information about the dlv debugger. :handshake: 