### PR TITLE
Add function to get already-deployed containerInfo in dockerHandler

### DIFF
--- a/KubeArmor/core/kubeArmor.go
+++ b/KubeArmor/core/kubeArmor.go
@@ -443,6 +443,9 @@ func KubeArmor(clusterName, gRPCPort, logPath string, enableAuditd, enableHostPo
 				}
 
 				if sockFile {
+					// update already deployed containers
+					dm.GetAlreadyDeployedDockerContainers()
+
 					// monitor docker events
 					go dm.MonitorDockerEvents()
 				} else {


### PR DESCRIPTION
This change would be used for older versions of Docker(v18.x and earlier).

Fixes: #163