### PR TITLE
policyMatcher: types: adds matchPatterns logging logic, changes Match…

### DIFF
--- a/KubeArmor/types/types.go
+++ b/KubeArmor/types/types.go
@@ -181,9 +181,10 @@ type MatchPolicy struct {
 	Tags     []string
 	Message  string
 
-	Source    string
-	Operation string
-	Resource  string
+	Source       string
+	Operation    string
+	Resource     string
+	ResourceType string
 
 	Regexp *regexp.Regexp
 	Native bool


### PR DESCRIPTION
…Policy struct

Continuing PR #152 this:

- Adds logging logic for matchPatterns to `UpdateMatchedPolicy()`.
- Adds the field `ResourceType` to `MatchPolicy` structure.
- Changes `newMatchPolicy` to set the new `ResourceType` field accordingly.
- Refactors `switch ... case "Process", "File":` reducing block indentation.

For matchPatterns policies, "Glob" is the type set as default.
The "path/filepath" Glob syntax has similarities with the AppArmor's.

Fixes #143

---

Output log after a pattern matching:

```json
{"timestamp":1625586503,"updatedTime":"2021-07-06T15:48:23.026182Z","hostName":"kubearmor-dev","namespaceName":"multiubuntu","podName":"ubuntu-1-deployment-5c475fb4fb-2vqrm","containerID":"74cf77e5fb29dc0cf6ccbf263a0e772cf7c5b774d96951272a14c1e7668159d7","containerName":"ubuntu-1-container","hostPid":7922,"ppid":98,"pid":120,"uid":0,"policyName":"ksp-ubuntu-1-file-pattern-block","severity":"5","message":"block files following a pattern","type":"MatchedPolicy","source":"/bin/cat /etc/gshadow","operation":"File","resource":"/etc/gshadow","data":"syscall=SYS_OPENAT fd=-100 flags=O_RDONLY","action":"Block","result":"Permission denied"}
```

![image](https://user-images.githubusercontent.com/3372117/124639993-2d6a4580-de63-11eb-81fd-2be0f03ffb43.png)


