### PR TITLE
Added security policy validator in custom controller by [VenkataReddy]

### DIFF
--- a/KubeArmor/core/kubeUpdate.go
+++ b/KubeArmor/core/kubeUpdate.go
@@ -589,7 +589,7 @@ func (dm *KubeArmorDaemon) GetSecurityPolicies(identities []string) []tp.Securit
 }
 
 // UpdateSecurityPolicy Function
-func (dm *KubeArmorDaemon) UpdateSecurityPolicy(action string, secPolicy tp.SecurityPolicy) {
+func (dm *KubeArmorDaemon) UpdateSecurityPolicy(action string, secPolicy tp.SecurityPolicy, status string) {
 	dm.ContainerGroupsLock.Lock()
 	defer dm.ContainerGroupsLock.Unlock()
 
@@ -626,7 +626,9 @@ func (dm *KubeArmorDaemon) UpdateSecurityPolicy(action string, secPolicy tp.Secu
 			dm.LogFeeder.UpdateSecurityPolicies("UPDATED", dm.ContainerGroups[idx])
 
 			// enforce security policies
-			dm.RuntimeEnforcer.UpdateSecurityPolicies(dm.ContainerGroups[idx])
+			if status == "OK" {
+				dm.RuntimeEnforcer.UpdateSecurityPolicies(dm.ContainerGroups[idx])
+			}
 		}
 	}
 }
@@ -670,7 +672,7 @@ func (dm *KubeArmorDaemon) WatchSecurityPolicies() {
 						if policy.Metadata["policyName"] == secPolicy.Metadata["policyName"] &&
 							policy.Metadata["namespaceName"] == secPolicy.Metadata["namespaceName"] &&
 							policy.Metadata["generation"] == secPolicy.Metadata["generation"] {
-							exist = true
+							//exist = true
 							break
 						}
 					}
@@ -1042,7 +1044,7 @@ func (dm *KubeArmorDaemon) WatchSecurityPolicies() {
 				dm.LogFeeder.Printf("Detected a Security Policy (%s/%s/%s)", strings.ToLower(event.Type), secPolicy.Metadata["namespaceName"], secPolicy.Metadata["policyName"])
 
 				// apply security policies to containers
-				dm.UpdateSecurityPolicy(event.Type, secPolicy)
+				dm.UpdateSecurityPolicy(event.Type, secPolicy, event.Object.Status.PolicyStatus)
 			}
 		}
 	}

--- a/KubeArmor/types/types.go
+++ b/KubeArmor/types/types.go
@@ -92,10 +92,15 @@ type K8sKubeArmorPolicyEvent struct {
 	Object K8sKubeArmorPolicy `json:"object"`
 }
 
+type SecurityPolicyStatus struct {
+	PolicyStatus string `json:"status,omitempty"`
+}
+
 // K8sKubeArmorPolicy Structure
 type K8sKubeArmorPolicy struct {
-	Metadata metav1.ObjectMeta `json:"metadata"`
-	Spec     SecuritySpec      `json:"spec"`
+	Metadata metav1.ObjectMeta    `json:"metadata"`
+	Spec     SecuritySpec         `json:"spec"`
+	Status   SecurityPolicyStatus `json:"status,omitempty"`
 }
 
 // K8sKubeArmorPolicies Structure

--- a/deployments/controllers/kubearmor-controller.yaml
+++ b/deployments/controllers/kubearmor-controller.yaml
@@ -1,4 +1,9 @@
-
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    control-plane: controller-manager
+  name: k8s-system
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -499,3 +504,191 @@ status:
     plural: ""
   conditions: []
   storedVersions: []
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: k8s-leader-election-role
+  namespace: k8s-system
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - configmaps/status
+  verbs:
+  - get
+  - update
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: k8s-manager-role
+rules:
+- apiGroups:
+  - security.kubearmor.com
+  resources:
+  - kubearmorpolicies
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - security.kubearmor.com
+  resources:
+  - kubearmorpolicies/status
+  verbs:
+  - get
+  - patch
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: k8s-proxy-role
+rules:
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: k8s-metrics-reader
+rules:
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: k8s-leader-election-rolebinding
+  namespace: k8s-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: k8s-leader-election-role
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: k8s-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: k8s-manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: k8s-manager-role
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: k8s-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: k8s-proxy-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: k8s-proxy-role
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: k8s-system
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    control-plane: controller-manager
+  name: k8s-controller-manager-metrics-service
+  namespace: k8s-system
+spec:
+  ports:
+  - name: https
+    port: 8443
+    targetPort: https
+  selector:
+    control-plane: controller-manager
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    control-plane: controller-manager
+  name: k8s-controller-manager
+  namespace: k8s-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      control-plane: controller-manager
+  template:
+    metadata:
+      labels:
+        control-plane: controller-manager
+    spec:
+      containers:
+      - args:
+        - --secure-listen-address=0.0.0.0:8443
+        - --upstream=http://127.0.0.1:8080/
+        - --logtostderr=true
+        - --v=10
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0
+        name: kube-rbac-proxy
+        ports:
+        - containerPort: 8443
+          name: https
+      - args:
+        - --metrics-addr=127.0.0.1:8080
+        - --enable-leader-election
+        command:
+        - /manager
+        image: kubearmor/kubearmor-controller:latest
+        imagePullPolicy: Never
+        name: manager
+        resources:
+          limits:
+            cpu: 100m
+            memory: 30Mi
+          requests:
+            cpu: 100m
+            memory: 20Mi
+      terminationGracePeriodSeconds: 10

--- a/deployments/controllers/kubearmor-host-controller.yaml
+++ b/deployments/controllers/kubearmor-host-controller.yaml
@@ -1,4 +1,9 @@
-
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    control-plane: controller-manager
+  name: k8s-system
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -6,22 +11,23 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.2.5
   creationTimestamp: null
-  name: kubearmorpolicies.security.kubearmor.com
+  name: kubearmorhostpolicies.security.kubearmor.com
 spec:
   group: security.kubearmor.com
   names:
-    kind: KubeArmorPolicy
-    listKind: KubeArmorPolicyList
-    plural: kubearmorpolicies
+    kind: KubeArmorHostPolicy
+    listKind: KubeArmorHostPolicyList
+    plural: kubearmorhostpolicies
     shortNames:
-    - ksp
-    singular: kubearmorpolicy
-  scope: Namespaced
+    - khp
+    singular: kubearmorhostpolicy
+  scope: Cluster
   versions:
   - name: v1
     schema:
       openAPIV3Schema:
-        description: KubeArmorPolicy is the Schema for the kubearmorpolicies API
+        description: KubeArmorHostPolicy is the Schema for the kubearmorhostpolicies
+          API
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -36,7 +42,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: KubeArmorPolicySpec defines the desired state of KubeArmorPolicy
+            description: KubeArmorHostPolicySpec defines the desired state of KubeArmorHostPolicy
             properties:
               action:
                 enum:
@@ -97,6 +103,7 @@ spec:
                           type: array
                       required:
                       - capability
+                      - fromSource
                       type: object
                     type: array
                   message:
@@ -306,6 +313,7 @@ spec:
                             type: string
                           type: array
                       required:
+                      - fromSource
                       - protocol
                       type: object
                     type: array
@@ -321,6 +329,17 @@ spec:
                     type: array
                 required:
                 - matchProtocols
+                type: object
+              nodeSelector:
+                properties:
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  matchNames:
+                    additionalProperties:
+                      type: string
+                    type: object
                 type: object
               process:
                 properties:
@@ -460,17 +479,6 @@ spec:
                       type: string
                     type: array
                 type: object
-              selector:
-                properties:
-                  matchLabels:
-                    additionalProperties:
-                      type: string
-                    type: object
-                  matchNames:
-                    additionalProperties:
-                      type: string
-                    type: object
-                type: object
               severity:
                 maximum: 10
                 minimum: 1
@@ -480,12 +488,12 @@ spec:
                   type: string
                 type: array
             required:
-            - selector
+            - nodeSelector
             type: object
           status:
-            description: KubeArmorPolicyStatus defines the observed state of KubeArmorPolicy
+            description: KubeArmorHostPolicyStatus defines the observed state of KubeArmorHostPolicy
             properties:
-              status:
+              message:
                 type: string
             type: object
         type: object
@@ -499,3 +507,191 @@ status:
     plural: ""
   conditions: []
   storedVersions: []
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: k8s-leader-election-role
+  namespace: k8s-system
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - configmaps/status
+  verbs:
+  - get
+  - update
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: k8s-manager-role
+rules:
+- apiGroups:
+  - security.kubearmor.com
+  resources:
+  - kubearmorhostpolicies
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - security.kubearmor.com
+  resources:
+  - kubearmorhostpolicies/status
+  verbs:
+  - get
+  - patch
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: k8s-proxy-role
+rules:
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: k8s-metrics-reader
+rules:
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: k8s-leader-election-rolebinding
+  namespace: k8s-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: k8s-leader-election-role
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: k8s-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: k8s-manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: k8s-manager-role
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: k8s-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: k8s-proxy-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: k8s-proxy-role
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: k8s-system
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    control-plane: controller-manager
+  name: k8s-controller-manager-metrics-service
+  namespace: k8s-system
+spec:
+  ports:
+  - name: https
+    port: 8443
+    targetPort: https
+  selector:
+    control-plane: controller-manager
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    control-plane: controller-manager
+  name: k8s-controller-manager
+  namespace: k8s-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      control-plane: controller-manager
+  template:
+    metadata:
+      labels:
+        control-plane: controller-manager
+    spec:
+      containers:
+      - args:
+        - --secure-listen-address=0.0.0.0:8443
+        - --upstream=http://127.0.0.1:8080/
+        - --logtostderr=true
+        - --v=10
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0
+        name: kube-rbac-proxy
+        ports:
+        - containerPort: 8443
+          name: https
+      - args:
+        - --metrics-addr=127.0.0.1:8080
+        - --enable-leader-election
+        command:
+        - /manager
+        image: kubearmor/kubearmor-host-controller:latest
+        imagePullPolicy: Never
+        name: manager
+        resources:
+          limits:
+            cpu: 100m
+            memory: 30Mi
+          requests:
+            cpu: 100m
+            memory: 20Mi
+      terminationGracePeriodSeconds: 10

--- a/helm/templates/security.kubearmor.com_kubearmorhostpolicies.yaml
+++ b/helm/templates/security.kubearmor.com_kubearmorhostpolicies.yaml
@@ -487,10 +487,15 @@ spec:
             type: object
           status:
             description: KubeArmorHostPolicyStatus defines the observed state of KubeArmorHostPolicy
+            properties:
+              message:
+                type: string
             type: object
         type: object
     served: true
     storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""

--- a/pkg/KubeArmorHostPolicy/api/v1/kubearmorhostpolicy_types.go
+++ b/pkg/KubeArmorHostPolicy/api/v1/kubearmorhostpolicy_types.go
@@ -283,14 +283,14 @@ type KubeArmorHostPolicySpec struct {
 
 // KubeArmorHostPolicyStatus defines the observed state of KubeArmorHostPolicy
 type KubeArmorHostPolicyStatus struct {
-	// INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
-	// Important: Run "make" to regenerate code after modifying this file
+	PolicyStatus string `json:"message,omitempty"`
 }
 
 // +kubebuilder:object:root=true
 
 // KubeArmorHostPolicy is the Schema for the kubearmorhostpolicies API
 // +kubebuilder:resource:shortName=khp
+// +kubebuilder:subresource:status
 type KubeArmorHostPolicy struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/KubeArmorHostPolicy/config/crd/bases/security.kubearmor.com_kubearmorhostpolicies.yaml
+++ b/pkg/KubeArmorHostPolicy/config/crd/bases/security.kubearmor.com_kubearmorhostpolicies.yaml
@@ -487,10 +487,15 @@ spec:
             type: object
           status:
             description: KubeArmorHostPolicyStatus defines the observed state of KubeArmorHostPolicy
+            properties:
+              message:
+                type: string
             type: object
         type: object
     served: true
     storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""

--- a/pkg/KubeArmorHostPolicy/config/manager/kustomization.yaml
+++ b/pkg/KubeArmorHostPolicy/config/manager/kustomization.yaml
@@ -1,2 +1,8 @@
 resources:
 - manager.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+images:
+- name: controller
+  newName: kubearmor/kubearmor-host-controller
+  newTag: latest

--- a/pkg/KubeArmorHostPolicy/config/manager/manager.yaml
+++ b/pkg/KubeArmorHostPolicy/config/manager/manager.yaml
@@ -27,8 +27,9 @@ spec:
         - /manager
         args:
         - --enable-leader-election
-        image: controller:latest
+        image: kubearmor/kubearmor-host-controller:latest
         name: manager
+        imagePullPolicy: Never
         resources:
           limits:
             cpu: 100m

--- a/pkg/KubeArmorHostPolicy/controllers/kubearmorhostpolicy_controller.go
+++ b/pkg/KubeArmorHostPolicy/controllers/kubearmorhostpolicy_controller.go
@@ -18,12 +18,14 @@ package controllers
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/go-logr/logr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	securityv1 "github.com/kubearmor/KubeArmor/pkg/KubeArmorHostPolicy/api/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -41,14 +43,54 @@ func (r *KubeArmorHostPolicyReconciler) Reconcile(req ctrl.Request) (ctrl.Result
 	ctx := context.Background()
 	log := r.Log.WithValues("kubearmorhostpolicy", req.NamespacedName)
 
-	policy := securityv1.KubeArmorHostPolicy{}
+	policy := &securityv1.KubeArmorHostPolicy{}
 
-	if err := r.Get(ctx, req.NamespacedName, &policy); err != nil {
-		return ctrl.Result{}, client.IgnoreNotFound(err)
+	if err := r.Get(ctx, req.NamespacedName, policy); err != nil {
+		if errors.IsNotFound(err) {
+			return ctrl.Result{}, client.IgnoreNotFound(err)
+		}
+		return ctrl.Result{}, err
 	}
 
-	log.Info("Fetched KubeArmorHostPolicy")
+	var policyErr error
 
+	// Validate KubeArmorPolicy
+	// if there are some issues in the policy the delete the policy and return failure code
+	policyErr = validateProcessSchema(policy, req)
+	if policyErr != nil {
+		goto POLICYERROR
+	}
+
+	policyErr = validateFileSchema(policy, req)
+	if policyErr != nil {
+		goto POLICYERROR
+	}
+
+	policyErr = validateNetworkSchema(policy, req)
+	if policyErr != nil {
+		goto POLICYERROR
+	}
+
+	policyErr = validateCapabilitiesSchema(policy, req)
+	if policyErr != nil {
+		goto POLICYERROR
+	}
+
+POLICYERROR:
+	if policyErr != nil {
+		//Update PolicyStatus
+		policy.Status.PolicyStatus = "Not OK"
+		err := r.Status().Update(ctx, policy)
+		log.Info("Invalid KubeArmorHostPolicy")
+		// delete the invalid KubeArmorPolicy
+		// err := r.Delete(ctx, policy)
+		return ctrl.Result{}, err
+	}
+
+	//Update PolicyStatus
+	policy.Status.PolicyStatus = "OK"
+	_ = r.Status().Update(ctx, policy)
+	log.Info("Fetched KubeArmorHostPolicy")
 	return ctrl.Result{}, nil
 }
 
@@ -56,4 +98,108 @@ func (r *KubeArmorHostPolicyReconciler) SetupWithManager(mgr ctrl.Manager) error
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&securityv1.KubeArmorHostPolicy{}).
 		Complete(r)
+}
+
+func validateProcessSchema(policy *securityv1.KubeArmorHostPolicy, req ctrl.Request) error {
+	var policyErr error
+	for _, matchPaths := range policy.Spec.Process.MatchPaths {
+		if policy.Spec.Action != "Allow" {
+			if matchPaths.OwnerOnly {
+				policyErr = fmt.Errorf("ownerOnly works with the Allow action %v", req.NamespacedName)
+				return policyErr
+			}
+		}
+		for _, fromSource := range matchPaths.FromSource {
+			if fromSource.Path != "" {
+				if fromSource.Recursive || !fromSource.Recursive {
+					policyErr = fmt.Errorf("recursive is only effective with directories, not paths %v", req.NamespacedName)
+					return policyErr
+				}
+			}
+		}
+	}
+	for _, matchDirectories := range policy.Spec.Process.MatchDirectories {
+		if policy.Spec.Action != "Allow" {
+			if matchDirectories.OwnerOnly {
+				policyErr = fmt.Errorf("ownerOnly works with the Allow action %v", req.NamespacedName)
+				return policyErr
+			}
+		}
+	}
+	for _, matchPatterns := range policy.Spec.Process.MatchPatterns {
+		if policy.Spec.Action != "Allow" {
+			if matchPatterns.OwnerOnly {
+				policyErr = fmt.Errorf("ownerOnly works with the Allow action %v", req.NamespacedName)
+				return policyErr
+			}
+		}
+	}
+	return policyErr
+}
+
+func validateFileSchema(policy *securityv1.KubeArmorHostPolicy, req ctrl.Request) error {
+	var policyErr error
+	for _, matchPaths := range policy.Spec.File.MatchPaths {
+		if policy.Spec.Action != "Allow" {
+			if matchPaths.OwnerOnly {
+				policyErr = fmt.Errorf("ownerOnly works with the Allow action %v", req.NamespacedName)
+				return policyErr
+			}
+		}
+		for _, fromSource := range matchPaths.FromSource {
+			if fromSource.Path != "" {
+				if fromSource.Recursive {
+					policyErr = fmt.Errorf("recursive is only effective with directories, not paths %v", req.NamespacedName)
+					return policyErr
+				}
+			}
+		}
+	}
+	for _, matchDirectories := range policy.Spec.File.MatchDirectories {
+		if policy.Spec.Action != "Allow" {
+			if matchDirectories.OwnerOnly {
+				policyErr = fmt.Errorf("ownerOnly works with the Allow action %v", req.NamespacedName)
+				return policyErr
+			}
+		}
+	}
+	for _, matchPatterns := range policy.Spec.File.MatchPatterns {
+		if policy.Spec.Action != "Allow" {
+			if matchPatterns.OwnerOnly {
+				policyErr = fmt.Errorf("ownerOnly works with the Allow action %v", req.NamespacedName)
+				return policyErr
+			}
+		}
+	}
+	return policyErr
+}
+
+func validateNetworkSchema(policy *securityv1.KubeArmorHostPolicy, req ctrl.Request) error {
+	var policyErr error
+	for _, matchProtocols := range policy.Spec.Network.MatchProtocols {
+		for _, fromSource := range matchProtocols.FromSource {
+			if fromSource.Path != "" {
+				if fromSource.Recursive || !fromSource.Recursive {
+					policyErr = fmt.Errorf("recursive is only effective with directories, not paths %v", req.NamespacedName)
+					return policyErr
+				}
+			}
+		}
+	}
+	return policyErr
+}
+
+func validateCapabilitiesSchema(policy *securityv1.KubeArmorHostPolicy, req ctrl.Request) error {
+	var policyErr error
+	for _, matchCapabilities := range policy.Spec.Capabilities.MatchCapabilities {
+		for _, fromSource := range matchCapabilities.FromSource {
+			if fromSource.Path != "" {
+				if fromSource.Recursive || !fromSource.Recursive {
+					policyErr = fmt.Errorf("recursive is only effective with directories, not paths %v", req.NamespacedName)
+					return policyErr
+				}
+			}
+		}
+	}
+	return policyErr
 }

--- a/pkg/KubeArmorPolicy/api/v1/kubearmorpolicy_types.go
+++ b/pkg/KubeArmorPolicy/api/v1/kubearmorpolicy_types.go
@@ -287,14 +287,14 @@ type KubeArmorPolicySpec struct {
 
 // KubeArmorPolicyStatus defines the observed state of KubeArmorPolicy
 type KubeArmorPolicyStatus struct {
-	// INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
-	// Important: Run "make" to regenerate code after modifying this file
+	PolicyStatus string `json:"status,omitempty"`
 }
 
 // +kubebuilder:object:root=true
 
 // KubeArmorPolicy is the Schema for the kubearmorpolicies API
 // +kubebuilder:resource:shortName=ksp
+// +kubebuilder:subresource:status
 type KubeArmorPolicy struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/KubeArmorPolicy/config/crd/bases/security.kubearmor.com_kubearmorpolicies.yaml
+++ b/pkg/KubeArmorPolicy/config/crd/bases/security.kubearmor.com_kubearmorpolicies.yaml
@@ -484,10 +484,15 @@ spec:
             type: object
           status:
             description: KubeArmorPolicyStatus defines the observed state of KubeArmorPolicy
+            properties:
+              status:
+                type: string
             type: object
         type: object
     served: true
     storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""

--- a/pkg/KubeArmorPolicy/config/manager/kustomization.yaml
+++ b/pkg/KubeArmorPolicy/config/manager/kustomization.yaml
@@ -1,2 +1,8 @@
 resources:
 - manager.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+images:
+- name: controller
+  newName: kubearmor/kubearmor-controller
+  newTag: latest

--- a/pkg/KubeArmorPolicy/config/manager/manager.yaml
+++ b/pkg/KubeArmorPolicy/config/manager/manager.yaml
@@ -27,8 +27,9 @@ spec:
         - /manager
         args:
         - --enable-leader-election
-        image: controller:latest
+        image: kubearmor/kubearmor-controller:latest
         name: manager
+        imagePullPolicy: Never
         resources:
           limits:
             cpu: 100m

--- a/pkg/KubeArmorPolicy/controllers/kubearmorpolicy_controller.go
+++ b/pkg/KubeArmorPolicy/controllers/kubearmorpolicy_controller.go
@@ -18,12 +18,14 @@ package controllers
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/go-logr/logr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	securityv1 "github.com/kubearmor/KubeArmor/pkg/KubeArmorPolicy/api/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -41,19 +43,163 @@ func (r *KubeArmorPolicyReconciler) Reconcile(req ctrl.Request) (ctrl.Result, er
 	ctx := context.Background()
 	log := r.Log.WithValues("kubearmorpolicy", req.NamespacedName)
 
-	policy := securityv1.KubeArmorPolicy{}
+	policy := &securityv1.KubeArmorPolicy{}
 
-	if err := r.Get(ctx, req.NamespacedName, &policy); err != nil {
-		return ctrl.Result{}, client.IgnoreNotFound(err)
+	if err := r.Get(ctx, req.NamespacedName, policy); err != nil {
+		if errors.IsNotFound(err) {
+			return ctrl.Result{}, client.IgnoreNotFound(err)
+		}
+		return ctrl.Result{}, err
 	}
 
-	log.Info("Fetched KubeArmorPolicy")
+	var policyErr error
 
-	return ctrl.Result{}, nil
+	// Validate KubeArmorPolicy
+	// if there are some issues in the policy the delete the policy and return failure code
+	policyErr = validateProcessSchema(policy, req)
+	if policyErr != nil {
+		goto POLICYERROR
+	}
+
+	policyErr = validateFileSchema(policy, req)
+	if policyErr != nil {
+		goto POLICYERROR
+	}
+
+	policyErr = validateNetworkSchema(policy, req)
+	if policyErr != nil {
+		goto POLICYERROR
+	}
+
+	policyErr = validateCapabilitiesSchema(policy, req)
+	if policyErr != nil {
+		goto POLICYERROR
+	}
+
+POLICYERROR:
+	if policyErr != nil {
+		//Update PolicyStatus
+		policy.Status.PolicyStatus = "Not OK"
+		err := r.Status().Update(ctx, policy)
+		log.Info("Invalid KubeArmorPolicy")
+		// delete the invalid KubeArmorPolicy
+		// err := r.Delete(ctx, policy)
+		return ctrl.Result{}, err
+	}
+
+	//Update PolicyStatus
+	policy.Status.PolicyStatus = "OK"
+	err := r.Status().Update(ctx, policy)
+	log.Info("Fetched KubeArmorPolicy")
+	return ctrl.Result{}, err
 }
 
 func (r *KubeArmorPolicyReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&securityv1.KubeArmorPolicy{}).
 		Complete(r)
+}
+
+func validateProcessSchema(policy *securityv1.KubeArmorPolicy, req ctrl.Request) error {
+	var policyErr error
+	for _, matchPaths := range policy.Spec.Process.MatchPaths {
+		if policy.Spec.Action != "Allow" {
+			if matchPaths.OwnerOnly {
+				policyErr = fmt.Errorf("ownerOnly works with the Allow action %v", req.NamespacedName)
+				return policyErr
+			}
+		}
+		for _, fromSource := range matchPaths.FromSource {
+			if fromSource.Path != "" {
+				if fromSource.Recursive || !fromSource.Recursive {
+					policyErr = fmt.Errorf("recursive is only effective with directories, not paths %v", req.NamespacedName)
+					return policyErr
+				}
+			}
+		}
+	}
+	for _, matchDirectories := range policy.Spec.Process.MatchDirectories {
+		if policy.Spec.Action != "Allow" {
+			if matchDirectories.OwnerOnly {
+				policyErr = fmt.Errorf("ownerOnly works with the Allow action %v", req.NamespacedName)
+				return policyErr
+			}
+		}
+	}
+	for _, matchPatterns := range policy.Spec.Process.MatchPatterns {
+		if policy.Spec.Action != "Allow" {
+			if matchPatterns.OwnerOnly {
+				policyErr = fmt.Errorf("ownerOnly works with the Allow action %v", req.NamespacedName)
+				return policyErr
+			}
+		}
+	}
+	return policyErr
+}
+
+func validateFileSchema(policy *securityv1.KubeArmorPolicy, req ctrl.Request) error {
+	var policyErr error
+	for _, matchPaths := range policy.Spec.File.MatchPaths {
+		if policy.Spec.Action != "Allow" {
+			if matchPaths.OwnerOnly {
+				policyErr = fmt.Errorf("ownerOnly works with the Allow action %v", req.NamespacedName)
+				return policyErr
+			}
+		}
+		for _, fromSource := range matchPaths.FromSource {
+			if fromSource.Path != "" {
+				if fromSource.Recursive || !fromSource.Recursive {
+					policyErr = fmt.Errorf("Found invalid schema Recursive for Path %v", req.NamespacedName)
+					return policyErr
+				}
+			}
+		}
+	}
+	for _, matchDirectories := range policy.Spec.File.MatchDirectories {
+		if policy.Spec.Action != "Allow" {
+			if matchDirectories.OwnerOnly {
+				policyErr = fmt.Errorf("ownerOnly works with the Allow action %v", req.NamespacedName)
+				return policyErr
+			}
+		}
+	}
+	for _, matchPatterns := range policy.Spec.File.MatchPatterns {
+		if policy.Spec.Action != "Allow" {
+			if matchPatterns.OwnerOnly {
+				policyErr = fmt.Errorf("ownerOnly works with the Allow action %v", req.NamespacedName)
+				return policyErr
+			}
+		}
+	}
+	return policyErr
+}
+
+func validateNetworkSchema(policy *securityv1.KubeArmorPolicy, req ctrl.Request) error {
+	var policyErr error
+	for _, matchProtocols := range policy.Spec.Network.MatchProtocols {
+		for _, fromSource := range matchProtocols.FromSource {
+			if fromSource.Path != "" {
+				if fromSource.Recursive || !fromSource.Recursive {
+					policyErr = fmt.Errorf("recursive is only effective with directories, not paths %v", req.NamespacedName)
+					return policyErr
+				}
+			}
+		}
+	}
+	return policyErr
+}
+
+func validateCapabilitiesSchema(policy *securityv1.KubeArmorPolicy, req ctrl.Request) error {
+	var policyErr error
+	for _, matchCapabilities := range policy.Spec.Capabilities.MatchCapabilities {
+		for _, fromSource := range matchCapabilities.FromSource {
+			if fromSource.Path != "" {
+				if fromSource.Recursive || !fromSource.Recursive {
+					policyErr = fmt.Errorf("recursive is only effective with directories, not paths %v", req.NamespacedName)
+					return policyErr
+				}
+			}
+		}
+	}
+	return policyErr
 }


### PR DESCRIPTION
Inside the controllers/kubearmorpolicy_controller.go and controllers/kubearmorhostpolicy_controller.go file we have the function ”Reconcile”, Here the function “Reconcile” act as a security policy validator at the Kubernetes side in order to check syntax and semantics errors. So business logic (below 1 & 2 points) for validating the syntax and semantics errors will be part of “Reconcile” function.
1.check policies already applied in kubernetes at the controller.
2. Update the policy status for valid(OK)/invalid(Not OK), 
 delete the invalid policy and return the fail code when a new policy is applied and there are some issues in the policy.

Fixes: #104 