### PR TITLE
Fix #195

### DIFF
--- a/KubeArmor/common/common.go
+++ b/KubeArmor/common/common.go
@@ -96,6 +96,14 @@ func ObjCommaExpandFirstDupOthers(objptr interface{}) {
 	}
 }
 
+// Min Function
+func Min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
 // ========== //
 // == Time == //
 // ========== //

--- a/KubeArmor/enforcer/appArmorEnforcer.go
+++ b/KubeArmor/enforcer/appArmorEnforcer.go
@@ -295,12 +295,12 @@ func (ae *AppArmorEnforcer) CreateAppArmorHostProfile() error {
 		"  file,\n" +
 		"  mount,\n" +
 		"  umount,\n" +
-		"  signal,\n" +
 		"  ptrace,\n" +
 		"  network,\n" +
 		"  capability,\n" +
 		"\n" +
 		"  /usr/bin/runc Ux,\n" + // docker
+		"  /usr/bin/docker-runc Ux, \n" + // docker
 		"  /usr/sbin/runc Ux,\n" + // containerd
 		"  /snap/microk8s/2262/bin/runc Ux,\n" + // microk8s
 		"  /snap/microk8s/2264/bin/runc Ux,\n" + // microk8s

--- a/KubeArmor/enforcer/appArmorHostProfile.go
+++ b/KubeArmor/enforcer/appArmorHostProfile.go
@@ -1833,12 +1833,12 @@ func GenerateHostProfileHead() string {
 		"  file,\n" +
 		"  mount,\n" +
 		"  umount,\n" +
-		"  signal,\n" +
 		"  ptrace,\n" +
 		"  network,\n" +
 		"  capability,\n" +
 		"\n" +
 		"  /usr/bin/runc Ux,\n" + // docker
+		"  /usr/bin/docker-runc Ux, \n" + // docker
 		"  /usr/sbin/runc Ux,\n" + // containerd
 		"  /snap/microk8s/2262/bin/runc Ux,\n" + // microk8s
 		"  /snap/microk8s/2264/bin/runc Ux,\n" + // microk8s

--- a/KubeArmor/monitor/syscallParser.go
+++ b/KubeArmor/monitor/syscallParser.go
@@ -13,6 +13,8 @@ import (
 	"net"
 	"strconv"
 	"strings"
+
+	kl "github.com/kubearmor/KubeArmor/KubeArmor/common"
 )
 
 // ===================== //
@@ -87,10 +89,8 @@ func readUInt32BigendFromBuff(buff io.Reader) (uint32, error) {
 
 // readByteSliceFromBuff Function
 func readByteSliceFromBuff(buff io.Reader, len int) ([]byte, error) {
-	var err error
-	res := make([]byte, len)
-	err = binary.Read(buff, binary.LittleEndian, &res)
-	if err != nil {
+	res := make([]byte, kl.Min(len, MAX_STRING_LEN))
+	if err := binary.Read(buff, binary.LittleEndian, &res); err != nil {
 		return nil, fmt.Errorf("error reading byte array: %v", err)
 	}
 	return res, nil


### PR DESCRIPTION
Under 4.x kernels, KubeArmor uses a single eBPF monitor to get both host and container system events.
Under 5.x kernels, KubeArmor uses one monitor for containers and the other monitor for the host.