### PR TITLE
support the environments where no LSM is enabled

### DIFF
--- a/Dockerfile.kubearmor
+++ b/Dockerfile.kubearmor
@@ -3,7 +3,7 @@
 FROM golang:1.15.2-alpine3.12 as builder
 
 RUN apk update
-RUN apk add --no-cache bash git wget python3 linux-headers build-base clang clang-dev libc-dev bcc-dev librdkafka
+RUN apk add --no-cache bash git wget python3 linux-headers build-base clang clang-dev libc-dev bcc-dev
 
 WORKDIR /usr/src/KubeArmor
 
@@ -12,6 +12,9 @@ COPY ./protobuf ./protobuf
 COPY ./GKE ./GKE
 
 WORKDIR /usr/src/KubeArmor/KubeArmor
+
+COPY ./pkg/KubeArmorPolicy/config/crd/bases/security.kubearmor.com_kubearmorpolicies.yaml ./CRD/KubeArmorPolicy.yaml
+COPY ./pkg/KubeArmorHostPolicy/config/crd/bases/security.kubearmor.com_kubearmorhostpolicies.yaml ./CRD/KubeArmorHostPolicy.yaml
 
 RUN ./build/patch.sh
 RUN GOOS=linux GOARCH=amd64 go build -a -ldflags '-s -w' -o kubearmor main.go
@@ -25,11 +28,14 @@ RUN echo "@edge http://dl-cdn.alpinelinux.org/alpine/edge/testing" | tee -a /etc
 
 RUN apk update
 RUN apk add bash curl procps bcc bcc-dev
-RUN apk add apparmor@edge apparmor-utils@edge
+RUN apk add apparmor@edge apparmor-utils@edge policycoreutils@edge
 
 COPY --from=builder /usr/src/KubeArmor/KubeArmor/kubearmor /KubeArmor/kubearmor
 COPY --from=builder /usr/src/KubeArmor/KubeArmor/templates/* /KubeArmor/templates/
 COPY --from=builder /usr/src/KubeArmor/KubeArmor/BPF/* /KubeArmor/BPF/
 COPY --from=builder /usr/src/KubeArmor/GKE/*.sh /KubeArmor/GKE/
+
+COPY --from=builder /usr/src/KubeArmor/KubeArmor/CRD/KubeArmorPolicy.yaml /KubeArmor/CRD/KubeArmorPolicy.yaml
+COPY --from=builder /usr/src/KubeArmor/KubeArmor/CRD/KubeArmorHostPolicy.yaml /KubeArmor/CRD/KubeArmorHostPolicy.yaml
 
 ENTRYPOINT ["/KubeArmor/kubearmor"]

--- a/KubeArmor/BPF/system_monitor.c
+++ b/KubeArmor/BPF/system_monitor.c
@@ -621,6 +621,11 @@ int trace_ret_execve(struct pt_regs *ctx)
     context.argnum = 0;
     context.retval = PT_REGS_RC(ctx);
 
+    // TEMP: skip if No such file or directory
+    if (context.retval == -2) {
+        return 0;
+    }
+
     set_buffer_offset(sizeof(sys_context_t));
 
     bufs_t *bufs_p = get_buffer();
@@ -682,6 +687,11 @@ int trace_ret_execveat(struct pt_regs *ctx)
     context.event_id = _SYS_EXECVEAT;
     context.argnum = 0;
     context.retval = PT_REGS_RC(ctx);
+
+    // TEMP: skip if No such file or directory
+    if (context.retval == -2) {
+        return 0;
+    }
 
     set_buffer_offset(sizeof(sys_context_t));
 
@@ -806,6 +816,11 @@ static __always_inline int trace_ret_generic(u32 id, struct pt_regs *ctx, u64 ty
     context.event_id = id;
     context.argnum = get_arg_num(types);
     context.retval = PT_REGS_RC(ctx);
+
+    // TEMP: skip if No such file or directory
+    if (context.retval == -2) {
+        return 0;
+    }
 
     set_buffer_offset(sizeof(sys_context_t));
 

--- a/KubeArmor/build/Dockerfile.kubearmor
+++ b/KubeArmor/build/Dockerfile.kubearmor
@@ -3,7 +3,7 @@
 FROM golang:1.15.2-alpine3.12 as builder
 
 RUN apk update
-RUN apk add --no-cache bash git wget python3 linux-headers build-base clang clang-dev libc-dev bcc-dev librdkafka
+RUN apk add --no-cache bash git wget python3 linux-headers build-base clang clang-dev libc-dev bcc-dev
 
 WORKDIR /usr/src/KubeArmor
 
@@ -28,7 +28,7 @@ RUN echo "@edge http://dl-cdn.alpinelinux.org/alpine/edge/testing" | tee -a /etc
 
 RUN apk update
 RUN apk add bash curl procps bcc bcc-dev
-RUN apk add kubectl@edge apparmor@edge apparmor-utils@edge
+RUN apk add kubectl@edge apparmor@edge apparmor-utils@edge policycoreutils@edge
 
 COPY --from=builder /usr/src/KubeArmor/KubeArmor/kubearmor /KubeArmor/kubearmor
 COPY --from=builder /usr/src/KubeArmor/KubeArmor/templates/* /KubeArmor/templates/

--- a/KubeArmor/core/containerdHandler.go
+++ b/KubeArmor/core/containerdHandler.go
@@ -246,8 +246,20 @@ func (dm *KubeArmorDaemon) UpdateContainerdContainer(ctx context.Context, contai
 		dm.ContainersLock.Lock()
 		if _, ok := dm.Containers[containerID]; !ok {
 			dm.Containers[containerID] = container
-		} else if dm.Containers[containerID].AppArmorProfile == "" && container.AppArmorProfile != "" {
-			dm.Containers[containerID] = container
+		} else if dm.Containers[container.ContainerID].PidNS == 0 && dm.Containers[container.ContainerID].MntNS == 0 {
+			// this entry was updated by kubernetes before docker detects it
+			// thus, we here use NamespaceName, ContainerGroupName, and ContainerName given by kubernetes instead of the ones given by docker
+			container.NamespaceName = dm.Containers[container.ContainerID].NamespaceName
+			container.ContainerGroupName = dm.Containers[container.ContainerID].ContainerGroupName
+			container.ContainerName = dm.Containers[container.ContainerID].ContainerName
+			dm.Containers[container.ContainerID] = container
+		} else if dm.Containers[container.ContainerID].AppArmorProfile == "" && container.AppArmorProfile != "" {
+			// this entry was updated by kubernetes before docker detects it
+			// thus, we here use NamespaceName, ContainerGroupName, and ContainerName given by kubernetes instead of the ones given by docker
+			container.NamespaceName = dm.Containers[container.ContainerID].NamespaceName
+			container.ContainerGroupName = dm.Containers[container.ContainerID].ContainerGroupName
+			container.ContainerName = dm.Containers[container.ContainerID].ContainerName
+			dm.Containers[container.ContainerID] = container
 		} else {
 			dm.ContainersLock.Unlock()
 			return false

--- a/KubeArmor/core/dockerHandler.go
+++ b/KubeArmor/core/dockerHandler.go
@@ -176,7 +176,19 @@ func (dm *KubeArmorDaemon) GetAlreadyDeployedDockerContainers() {
 				dm.ContainersLock.Lock()
 				if _, ok := dm.Containers[container.ContainerID]; !ok {
 					dm.Containers[container.ContainerID] = container
+				} else if dm.Containers[container.ContainerID].PidNS == 0 && dm.Containers[container.ContainerID].MntNS == 0 {
+					// this entry was updated by kubernetes before docker detects it
+					// thus, we here use NamespaceName, ContainerGroupName, and ContainerName given by kubernetes instead of the ones given by docker
+					container.NamespaceName = dm.Containers[container.ContainerID].NamespaceName
+					container.ContainerGroupName = dm.Containers[container.ContainerID].ContainerGroupName
+					container.ContainerName = dm.Containers[container.ContainerID].ContainerName
+					dm.Containers[container.ContainerID] = container
 				} else if dm.Containers[container.ContainerID].AppArmorProfile == "" && container.AppArmorProfile != "" {
+					// this entry was updated by kubernetes before docker detects it
+					// thus, we here use NamespaceName, ContainerGroupName, and ContainerName given by kubernetes instead of the ones given by docker
+					container.NamespaceName = dm.Containers[container.ContainerID].NamespaceName
+					container.ContainerGroupName = dm.Containers[container.ContainerID].ContainerGroupName
+					container.ContainerName = dm.Containers[container.ContainerID].ContainerName
 					dm.Containers[container.ContainerID] = container
 				} else {
 					dm.ContainersLock.Unlock()

--- a/KubeArmor/core/kubeArmor.go
+++ b/KubeArmor/core/kubeArmor.go
@@ -228,7 +228,7 @@ func (dm *KubeArmorDaemon) CloseLogFeeder() {
 // InitRuntimeEnforcer Function
 func (dm *KubeArmorDaemon) InitRuntimeEnforcer() bool {
 	dm.RuntimeEnforcer = efc.NewRuntimeEnforcer(dm.LogFeeder, dm.EnableAuditd, dm.EnableHostPolicy)
-	return dm.RuntimeEnforcer != nil
+	return dm.RuntimeEnforcer.IsEnabled()
 }
 
 // CloseRuntimeEnforcer Function
@@ -379,17 +379,13 @@ func KubeArmor(clusterName, gRPCPort, logPath, logFilter string, enableAuditd, e
 
 	// initialize runtime enforcer
 	if !dm.InitRuntimeEnforcer() {
-		dm.LogFeeder.Err("Failed to intialize the runtime enforcer")
-
-		// destroy the daemon
-		dm.DestroyKubeArmorDaemon()
-
-		return
-	}
-	if dm.EnableHostPolicy {
-		dm.LogFeeder.Print("Started to protect a host and containers")
+		dm.LogFeeder.Print("Disabled the runtime enforcer since No LSM is enabled")
 	} else {
-		dm.LogFeeder.Print("Started to protect containers")
+		if dm.EnableHostPolicy {
+			dm.LogFeeder.Print("Started to protect a host and containers")
+		} else {
+			dm.LogFeeder.Print("Started to protect containers")
+		}
 	}
 
 	// wait for a while

--- a/KubeArmor/core/kubeUpdate.go
+++ b/KubeArmor/core/kubeUpdate.go
@@ -360,11 +360,17 @@ func (dm *KubeArmorDaemon) WatchK8sPods() {
 				}
 
 				// exception: no AppArmor
-				if lsm, err := ioutil.ReadFile("/sys/kernel/security/lsm"); err == nil {
-					if !strings.Contains(string(lsm), "apparmor") {
-						if pod.Annotations["kubearmor-policy"] == "enabled" {
-							pod.Annotations["kubearmor-policy"] = "audited"
+				if dm.RuntimeEnforcer.IsEnabled() {
+					if lsm, err := ioutil.ReadFile("/sys/kernel/security/lsm"); err == nil {
+						if !strings.Contains(string(lsm), "apparmor") {
+							if pod.Annotations["kubearmor-policy"] == "enabled" {
+								pod.Annotations["kubearmor-policy"] = "audited"
+							}
 						}
+					}
+				} else { // No LSM
+					if pod.Annotations["kubearmor-policy"] == "enabled" {
+						pod.Annotations["kubearmor-policy"] = "audited"
 					}
 				}
 

--- a/KubeArmor/monitor/systemMonitor.go
+++ b/KubeArmor/monitor/systemMonitor.go
@@ -468,11 +468,6 @@ func (mon *SystemMonitor) TraceSyscall() {
 				continue
 			}
 
-			// TEMP: skip if No such file or directory (ContainerLog)
-			if ctx.Retval == -2 {
-				continue
-			}
-
 			if ctx.EventID == SYS_OPEN {
 				if len(args) != 2 {
 					continue
@@ -675,11 +670,6 @@ func (mon *SystemMonitor) TraceHostSyscall() {
 
 			args, err := GetArgs(dataBuff, ctx.Argnum)
 			if err != nil {
-				continue
-			}
-
-			// TEMP: skip if No such file or directory (HostLog)
-			if ctx.Retval == -2 {
 				continue
 			}
 

--- a/contribution/minikube/ebpf-test.sh
+++ b/contribution/minikube/ebpf-test.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+# run BCC tools
+minikube ssh -- docker run --rm --privileged -v /lib/modules:/lib/modules:ro -v /usr/src:/usr/src:ro -v /etc/localtime:/etc/localtime:ro --workdir /usr/share/bcc/tools zlim/bcc ./execsnoop

--- a/contribution/minikube/minikube-start.sh
+++ b/contribution/minikube/minikube-start.sh
@@ -1,14 +1,14 @@
 #!/bin/bash
 
 # start minikube with a specific image
-minikube start --iso-url https://accuknox.kr/minikube/minikube.iso
+minikube start --iso-url https://accuknox.kr/minikube/minikube.iso --cpus 4 --memory 4096 --cni flannel
 
-# download kernel-headers.tar.lz4
-minikube ssh -- "curl -Lo /tmp/kernel-headers-linux-4.19.94.tar.lz4 https://accuknox.kr/minikube/kernel-headers-linux-4.19.94.tar.lz4"
+# download kernel-headers.tar.gz
+minikube ssh -- curl -Lo /tmp/kernel-headers-linux-4.19.94.tar.gz https://accuknox.kr/minikube/kernel-headers-linux-4.19.94.tar.gz
 
 # install kernel header
-minikube ssh -- "sudo mkdir -p /lib/modules/4.19.94/build"
-minikube ssh -- "lz4 -dc --no-sparse /tmp/kernel-headers-linux-4.19.94.tar.lz4 | sudo tar -C /lib/modules/4.19.94/build -xvf -"
+minikube ssh -- sudo mkdir -p /lib/modules/4.19.94/build
+minikube ssh -- sudo tar xvfz /tmp/kernel-headers-linux-4.19.94.tar.gz -C /lib/modules/4.19.94/build
 
-# remove kernel-headers.tar.lz4
-minikube ssh -- "rm /tmp/kernel-headers-linux-4.19.94.tar.lz4"
+# remove kernel-headers.tar.gz
+minikube ssh -- rm /tmp/kernel-headers-linux-4.19.94.tar.gz

--- a/contribution/minikube/virtualbox-install.sh
+++ b/contribution/minikube/virtualbox-install.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# install virtualbox
+wget -q https://www.virtualbox.org/download/oracle_vbox_2016.asc -O- | sudo apt-key add -
+wget -q https://www.virtualbox.org/download/oracle_vbox.asc -O- | sudo apt-key add -
+sudo add-apt-repository "deb [arch=amd64] http://download.virtualbox.org/virtualbox/debian $(lsb_release -cs) contrib"
+sudo apt-get update
+sudo apt-get -y install virtualbox-6.1

--- a/pkg/KubeArmorHostPolicy/Makefile
+++ b/pkg/KubeArmorHostPolicy/Makefile
@@ -41,7 +41,7 @@ deploy: manifests
 manifests: controller-gen
 	$(CONTROLLER_GEN) $(CRD_OPTIONS) rbac:roleName=manager-role webhook paths="./..." output:crd:artifacts:config=config/crd/bases
 	sed -i 's/scope: Namespaced/scope: Cluster/g' config/crd/bases/security.kubearmor.com_kubearmorhostpolicies.yaml
-	cp config/crd/bases/security.kubearmor.com_kubearmorhostpolicies.yaml ../../helm/templates/security.kubearmor.com_kubearmorhostpolicies.yaml
+	cp config/crd/bases/security.kubearmor.com_kubearmorhostpolicies.yaml ../../deployments/CRD/KubeArmorHostPolicy.yaml
 
 # Run go fmt against code
 fmt:

--- a/pkg/KubeArmorPolicy/Makefile
+++ b/pkg/KubeArmorPolicy/Makefile
@@ -41,6 +41,7 @@ deploy: manifests
 manifests: controller-gen
 	$(CONTROLLER_GEN) $(CRD_OPTIONS) rbac:roleName=manager-role webhook paths="./..." output:crd:artifacts:config=config/crd/bases
 	cp config/crd/bases/security.kubearmor.com_kubearmorpolicies.yaml ../../helm/templates/security.kubearmor.com_kubearmorpolicies.yaml
+	cp config/crd/bases/security.kubearmor.com_kubearmorpolicies.yaml ../../deployments/CRD/KubeArmorPolicy.yaml
 
 # Run go fmt against code
 fmt:

--- a/tests/test-scenarios-in-runtime.sh
+++ b/tests/test-scenarios-in-runtime.sh
@@ -11,6 +11,12 @@ if [ $? == 0 ]; then
     APPARMOR=1
 fi
 
+MINIKUBE=$(kubectl get nodes -l kubernetes.io/hostname=minikube 2> /dev/null | wc -l)
+
+if [ $MINIKUBE == 2 ]; then
+    APPARMOR=0
+fi
+
 RED='\033[0;31m'
 GREEN='\033[0;32m'
 ORANGE='\033[0;33m'


### PR DESCRIPTION
- support no-LSM-environments (e.g., minikube)
- add policycoreutils (including semanage) in the image
- fix the condition for already deployed containers
