### PR TITLE
Add automated test framework support for KubeArmorHostPolicy

### DIFF
--- a/examples/host-security-policies/hsp-kubearmor-dev-file-path-audit.yaml
+++ b/examples/host-security-policies/hsp-kubearmor-dev-file-path-audit.yaml
@@ -1,14 +1,14 @@
 apiVersion: security.kubearmor.com/v1
 kind: KubeArmorHostPolicy
 metadata:
-  name: hsp-ubuntu20-proc-path-block
+  name: hsp-kubearmor-dev-file-path-audit
 spec:
   nodeSelector:
     matchLabels:
-      kubernetes.io/hostname: ubuntu20
+      kubernetes.io/hostname: kubearmor-dev
   severity: 5
-  process:
+  file:
     matchPaths:
-    - path: /usr/bin/screen # try screen -h
+    - path: /etc/passwd # cat /etc/passwd
   action:
-    Block
+    Audit

--- a/examples/host-security-policies/hsp-kubearmor-dev-next-file-path-audit.yaml
+++ b/examples/host-security-policies/hsp-kubearmor-dev-next-file-path-audit.yaml
@@ -1,0 +1,14 @@
+apiVersion: security.kubearmor.com/v1
+kind: KubeArmorHostPolicy
+metadata:
+  name: hsp-kubearmor-dev-next-file-path-audit
+spec:
+  nodeSelector:
+    matchLabels:
+      kubernetes.io/hostname: kubearmor-dev-next
+  severity: 5
+  file:
+    matchPaths:
+    - path: /etc/passwd # cat /etc/passwd
+  action:
+    Audit

--- a/examples/host-security-policies/hsp-kubearmor-dev-next-proc-path-block.yaml
+++ b/examples/host-security-policies/hsp-kubearmor-dev-next-proc-path-block.yaml
@@ -1,11 +1,11 @@
 apiVersion: security.kubearmor.com/v1
 kind: KubeArmorHostPolicy
 metadata:
-  name: hsp-ubuntu20-proc-path-block
+  name: hsp-kubearmor-dev-next-proc-path-block
 spec:
   nodeSelector:
     matchLabels:
-      kubernetes.io/hostname: ubuntu20
+      kubernetes.io/hostname: kubearmor-dev-next
   severity: 5
   process:
     matchPaths:

--- a/examples/host-security-policies/hsp-kubearmor-dev-proc-path-block.yaml
+++ b/examples/host-security-policies/hsp-kubearmor-dev-proc-path-block.yaml
@@ -1,11 +1,11 @@
 apiVersion: security.kubearmor.com/v1
 kind: KubeArmorHostPolicy
 metadata:
-  name: hsp-ubuntu20-proc-path-block
+  name: hsp-kubearmor-dev-proc-path-block
 spec:
   nodeSelector:
     matchLabels:
-      kubernetes.io/hostname: ubuntu20
+      kubernetes.io/hostname: kubearmor-dev
   severity: 5
   process:
     matchPaths:

--- a/tests/host_scenarios/kubearmor-dev-next_test_1/cmd1
+++ b/tests/host_scenarios/kubearmor-dev-next_test_1/cmd1
@@ -1,0 +1,7 @@
+source: kubearmor-dev-next
+cmd: screen -h
+result: failed
+---
+operation: Process
+condition: screen
+action: Block

--- a/tests/host_scenarios/kubearmor-dev-next_test_1/hsp-kubearmor-dev-next-proc-path-block.yaml
+++ b/tests/host_scenarios/kubearmor-dev-next_test_1/hsp-kubearmor-dev-next-proc-path-block.yaml
@@ -1,0 +1,1 @@
+../../../examples/host-security-policies/hsp-kubearmor-dev-next-proc-path-block.yaml

--- a/tests/host_scenarios/kubearmor-dev-next_test_2/cmd1
+++ b/tests/host_scenarios/kubearmor-dev-next_test_2/cmd1
@@ -1,0 +1,7 @@
+source: kubearmor-dev-next
+cmd: cat /etc/passwd
+result: passed 
+---
+operation: File
+condition: passwd
+action: Audit

--- a/tests/host_scenarios/kubearmor-dev-next_test_2/hsp-kubearmor-dev-next-file-path-audit.yaml
+++ b/tests/host_scenarios/kubearmor-dev-next_test_2/hsp-kubearmor-dev-next-file-path-audit.yaml
@@ -1,0 +1,1 @@
+../../../examples/host-security-policies/hsp-kubearmor-dev-next-file-path-audit.yaml

--- a/tests/host_scenarios/kubearmor-dev_test_1/cmd1
+++ b/tests/host_scenarios/kubearmor-dev_test_1/cmd1
@@ -1,0 +1,7 @@
+source: kubearmor-dev
+cmd: screen -h
+result: failed
+---
+operation: Process
+condition: screen
+action: Block

--- a/tests/host_scenarios/kubearmor-dev_test_1/hsp-kubearmor-dev-proc-path-block.yaml
+++ b/tests/host_scenarios/kubearmor-dev_test_1/hsp-kubearmor-dev-proc-path-block.yaml
@@ -1,0 +1,1 @@
+../../../examples/host-security-policies/hsp-kubearmor-dev-proc-path-block.yaml

--- a/tests/host_scenarios/kubearmor-dev_test_2/cmd1
+++ b/tests/host_scenarios/kubearmor-dev_test_2/cmd1
@@ -1,0 +1,7 @@
+source: kubearmor-dev
+cmd: cat /etc/passwd
+result: passed 
+---
+operation: File
+condition: passwd
+action: Audit

--- a/tests/host_scenarios/kubearmor-dev_test_2/hsp-kubearmor-dev-file-path-audit.yaml
+++ b/tests/host_scenarios/kubearmor-dev_test_2/hsp-kubearmor-dev-file-path-audit.yaml
@@ -1,0 +1,1 @@
+../../../examples/host-security-policies/hsp-kubearmor-dev-file-path-audit.yaml

--- a/tests/host_scenarios/ubuntu20_test_1/cmd1
+++ b/tests/host_scenarios/ubuntu20_test_1/cmd1
@@ -1,0 +1,7 @@
+source: ubuntu20
+cmd: screen -h
+result: failed
+---
+operation: Process
+condition: screen
+action: Block

--- a/tests/host_scenarios/ubuntu20_test_1/hsp-ubuntu20-proc-path-block.yaml
+++ b/tests/host_scenarios/ubuntu20_test_1/hsp-ubuntu20-proc-path-block.yaml
@@ -1,0 +1,1 @@
+../../../examples/host-security-policies/hsp-ubuntu20-proc-path-block.yaml

--- a/tests/host_scenarios/ubuntu20_test_2/cmd1
+++ b/tests/host_scenarios/ubuntu20_test_2/cmd1
@@ -1,0 +1,7 @@
+source: ubuntu20
+cmd: cat /etc/passwd
+result: passed
+---
+operation: File
+condition: passwd
+action: Audit

--- a/tests/host_scenarios/ubuntu20_test_2/hsp-ubuntu20-file-path-audit.yaml
+++ b/tests/host_scenarios/ubuntu20_test_2/hsp-ubuntu20-file-path-audit.yaml
@@ -1,0 +1,1 @@
+../../../examples/host-security-policies/hsp-ubuntu20-file-path-audit.yaml

--- a/tests/test-scenarios-in-runtime.sh
+++ b/tests/test-scenarios-in-runtime.sh
@@ -28,16 +28,13 @@ SKIP_NATIVE_HOST_POLICY=1
 
 case $1 in
     "-testHostPolicy")
-        SKIP_HOST_POLICY=0
         SKIP_CONTAINER_POLICY=1
-        ;;
-    "-testContainerPolicy")
-        SKIP_CONTAINER_POLICY=0
-        SKIP_HOST_POLICY=1
-        ;;
-    "-testAllButNative")
-        SKIP_CONTAINER_POLICY=0
         SKIP_HOST_POLICY=0
+        ;;
+    "-testNativePolicy")
+        SKIP_CONTAINER_POLICY=1
+        SKIP_NATIVE_POLICY=0
+        SKIP_NATIVE_HOST_POLICY=0
         ;;
     "-testAll")
         SKIP_CONTAINER_POLICY=0
@@ -45,7 +42,7 @@ case $1 in
         SKIP_NATIVE_POLICY=0
         SKIP_NATIVE_HOST_POLICY=0
         ;;
-    *)
+    *) # -testContainerPolicy by default
         ;;
 esac
 

--- a/tests/test-scenarios-in-runtime.sh
+++ b/tests/test-scenarios-in-runtime.sh
@@ -567,7 +567,7 @@ function run_test_scenario() {
                     should_find_blocked_host_log $OP $COND $ACTION $NATIVE_HOST
                 fi
             fi
-        fi    
+        fi
 
         if [ $res_cmd == 0 ]; then
             echo "Testcase: $3 (command #$cmd_count)" >> $TEST_LOG

--- a/tests/test-scenarios-in-runtime.sh
+++ b/tests/test-scenarios-in-runtime.sh
@@ -21,6 +21,11 @@ realpath() {
 
 TEST_HOME=`dirname $(realpath "$0")`
 
+SKIP_CONTAINER_POLICY=0
+SKIP_NATIVE_POLICY=1
+SKIP_HOST_POLICY=1
+SKIP_NATIVE_HOST_POLICY=1
+
 ARMOR_LOG=/tmp/kubearmor.log
 TEST_LOG=/tmp/kubearmor.test
 
@@ -74,7 +79,7 @@ function apply_and_wait_for_microservice_creation() {
     sleep 1
 }
 
-function delete_and_wait_for_microserivce_deletion() {
+function delete_and_wait_for_microservice_deletion() {
     cd $TEST_HOME/microservices/$1
 
     kubectl delete -f .
@@ -225,6 +230,152 @@ function should_find_blocked_log() {
     fi
 }
 
+function should_not_find_any_host_log() {
+    NODE=$(hostname)
+    KUBEARMOR=$(kubectl get pods -n kube-system -l kubearmor-app=kubearmor -o wide | grep $NODE | grep kubearmor | awk '{print $1}')
+
+    sleep 3
+
+    echo -e "${GREEN}[INFO] Finding the corresponding log${NC}"
+
+    if [[ $KUBEARMOR = "kubearmor"* ]]; then
+        audit_log=$(kubectl -n kube-system exec -it $KUBEARMOR -- grep -E "$HOST_NAME.*Policy.*$1.*$2.*$3" $ARMOR_LOG | grep -v Passed)
+        if [ $? == 0 ]; then
+            sleep 10
+
+            audit_log=$(kubectl -n kube-system exec -it $KUBEARMOR -- grep -E "$HOST_NAME.*Policy.*$1.*$2.*$3" $ARMOR_LOG | grep -v Passed)
+            if [ $? == 0 ]; then
+                echo $audit_log
+                echo -e "${RED}[FAIL] Found the log from logs${NC}"
+                res_cmd=1
+            else
+                audit_log="<No Log>"
+                echo "[INFO] Found no log from logs"
+            fi
+        else
+            audit_log="<No Log>"
+            echo "[INFO] Found no log from logs"
+        fi
+    else # local
+        audit_log=$(grep -E "$HOST_NAME.*Policy.*$1.*$2.*$3" $ARMOR_LOG | grep -v Passed)
+        if [ $? == 0 ]; then
+            sleep 10
+
+            audit_log=$(grep -E "$HOST_NAME.*Policy.*$1.*$2.*$3" $ARMOR_LOG | grep -v Passed)
+            if [ $? == 0 ]; then
+                echo $audit_log
+                echo -e "${RED}[FAIL] Found the log from logs${NC}"
+                res_cmd=1
+            else
+                audit_log="<No Log>"
+                echo "[INFO] Found no log from logs"
+            fi
+        else
+            audit_log="<No Log>"
+            echo "[INFO] Found no log from logs"
+        fi    
+    fi
+}
+
+function should_find_passed_host_log() {
+    NODE=$(hostname)
+    KUBEARMOR=$(kubectl get pods -n kube-system -l kubearmor-app=kubearmor -o wide | grep $NODE | grep kubearmor | awk '{print $1}')
+
+    sleep 3
+
+    echo -e "${GREEN}[INFO] Finding the corresponding log${NC}"
+
+    if [[ $KUBEARMOR = "kubearmor"* ]]; then
+        audit_log=$(kubectl -n kube-system exec -it $KUBEARMOR -- grep -E "$HOST_NAME.*MatchedHostPolicy.*$1.*$2.*$3" $ARMOR_LOG | grep Passed)
+        if [ $? != 0 ]; then
+            sleep 10
+
+            audit_log=$(kubectl -n kube-system exec -it $KUBEARMOR -- grep -E "$HOST_NAME.*MatchedHostPolicy.*$1.*$2.*$3" $ARMOR_LOG | grep Passed)
+            if [ $? != 0 ]; then
+                audit_log="<No Log>"
+                echo -e "${RED}[FAIL] Failed to find the log from logs${NC}"
+                res_cmd=1
+            else
+                echo $audit_log
+                echo "[INFO] Found the log from logs"
+            fi
+        else
+            echo $audit_log
+            echo "[INFO] Found the log from logs"
+        fi    
+    else # local
+        audit_log=$(grep -E "$HOST_NAME.*MatchedHostPolicy.*$1.*$2.*$3" $ARMOR_LOG | grep Passed)
+        if [ $? != 0 ]; then
+            sleep 10
+
+            audit_log=$(grep -E "$HOST_NAME.*MatchedHostPolicy.*$1.*$2.*$3" $ARMOR_LOG | grep Passed)
+            if [ $? != 0 ]; then
+                audit_log="<No Log>"
+                echo -e "${RED}[FAIL] Failed to find the log from logs${NC}"
+                res_cmd=1
+            else
+                echo $audit_log
+                echo "[INFO] Found the log from logs"
+            fi
+        else
+            echo $audit_log
+            echo "[INFO] Found the log from logs"
+        fi    
+    fi
+}
+
+function should_find_blocked_host_log() {
+    NODE=$(hostname)
+    KUBEARMOR=$(kubectl get pods -n kube-system -l kubearmor-app=kubearmor -o wide | grep $NODE | grep kubearmor | awk '{print $1}')
+
+    match_type="MatchedHostPolicy"
+    if [[ $4 -eq 1 ]]; then
+        match_type="MatchedNativePolicy" 
+    fi
+
+    sleep 3
+
+    echo -e "${GREEN}[INFO] Finding the corresponding log${NC}"
+
+    if [[ $KUBEARMOR = "kubearmor"* ]]; then
+        audit_log=$(kubectl -n kube-system exec -it $KUBEARMOR -- grep -E "$HOST_NAME.*$match_type.*$1.*$2.*$3" $ARMOR_LOG | grep -v Passed)
+        if [ $? != 0 ]; then
+            sleep 10
+
+            audit_log=$(kubectl -n kube-system exec -it $KUBEARMOR -- grep -E "$HOST_NAME.*$match_type.*$1.*$2.*$3" $ARMOR_LOG | grep -v Passed)
+            if [ $? != 0 ]; then
+                audit_log="<No Log>"
+                echo -e "${RED}[FAIL] Failed to find the log from logs${NC}"
+                res_cmd=1
+            else
+                echo $audit_log
+                echo "[INFO] Found the log from logs"
+            fi
+        else
+            echo $audit_log
+            echo "[INFO] Found the log from logs"
+        fi    
+    else # local
+        audit_log=$(grep -E "$HOST_NAME.*$match_type.*$1.*$2.*$3" $ARMOR_LOG | grep -v Passed)
+        if [ $? != 0 ]; then
+            sleep 10
+
+            audit_log=$(grep -E "$HOST_NAME.*$match_type.*$1.*$2.*$3" $ARMOR_LOG | grep -v Passed)
+            if [ $? != 0 ]; then
+                audit_log="<No Log>"
+                echo -e "${RED}[FAIL] Failed to find the log from logs${NC}"
+                res_cmd=1
+            else
+                echo $audit_log
+                echo "[INFO] Found the log from logs"
+            fi
+        else
+            echo $audit_log
+            echo "[INFO] Found the log from logs"
+        fi    
+    fi
+}
+
 function run_test_scenario() {
     cd $1
 
@@ -232,16 +383,54 @@ function run_test_scenario() {
     policy_type=$(echo $YAML_FILE | awk '{split($0,a,"-"); print a[1]}')
 
     NATIVE=0
+    HOST_POLICY=0
+    NATIVE_HOST=0
     if [[ $policy_type == "np" ]]; then
         # skip a policy with a native profile unless AppArmor is enabled
         if [ $APPARMOR == 0 ]; then
+            echo -e "${MAGENTA}[SKIP] Skipped $3${NC}"
+            skipped_testcases+=("$3")
+            return
+        fi
+        if [ $SKIP_NATIVE_POLICY == 1 ]; then
+            echo -e "${MAGENTA}[SKIP] Skipped $3${NC}"
+            skipped_testcases+=("$3")
             return
         fi
         NATIVE=1
     fi
 
+    if [[ $policy_type == "hsp" ]]; then
+        if [ $SKIP_HOST_POLICY == 1 ]; then
+            echo -e "${MAGENTA}[SKIP] Skipped $3${NC}"
+            skipped_testcases+=("$3")
+            return
+        fi
+        HOST_POLICY=1
+    fi
+
+    if [[ $policy_type == "nhsp" ]]; then
+        # skip a policy with a native profile unless AppArmor is enabled
+        if [ $APPARMOR == 0 ]; then
+            echo -e "${MAGENTA}[SKIP] Skipped $3${NC}"
+            skipped_testcases+=("$3")
+            return
+        fi
+        if [ $SKIP_NATIVE_HOST_POLICY == 1 ]; then
+            echo -e "${MAGENTA}[SKIP] Skipped $3${NC}"
+            skipped_testcases+=("$3")
+            return
+        fi
+        NATIVE_HOST=1
+    fi
+
     echo -e "${GREEN}[INFO] Applying $YAML_FILE into $2${NC}"
-    kubectl apply -n $2 -f $YAML_FILE
+    if [[ $HOST_POLICY -eq 1 ]] || [[ $NATIVE_HOST -eq 1 ]]; then
+        kubectl apply -f $YAML_FILE
+    else
+        kubectl apply -n $2 -f $YAML_FILE
+    fi
+    
     if [ $? != 0 ]; then
         echo -e "${RED}[FAIL] Failed to apply $YAML_FILE into $2${NC}"
         res_case=1
@@ -257,8 +446,10 @@ function run_test_scenario() {
         cmd_count=$((cmd_count+1))
 
         SOURCE=$(cat $cmd | grep "^source" | awk '{print $2}')
-        POD=$(kubectl get pods -n $2 | grep $SOURCE | awk '{print $1}')
-
+        POD=""
+        if [[ $HOST_POLICY -eq 0 ]] && [[ $NATIVE_HOST -eq 0 ]]; then
+            POD=$(kubectl get pods -n $2 | grep $SOURCE | awk '{print $1}')
+        fi
         CMD=$(cat $cmd | grep "^cmd" | cut -d' ' -f2-)
         RESULT=$(cat $cmd | grep "^result" | awk '{print $2}')
 
@@ -288,36 +479,68 @@ function run_test_scenario() {
         actual_res="passed"
 
         echo -e "${GREEN}[INFO] Running \"$CMD\"${NC}"
-        kubectl exec -n $2 -it $POD -- bash -c "$CMD"
+        if [[ $HOST_POLICY -eq 1 ]] || [[ $NATIVE_HOST -eq 1 ]]; then
+            bash -c "$CMD"
+        else
+            kubectl exec -n $2 -it $POD -- bash -c "$CMD"
+        fi
         if [ $? != 0 ]; then
             actual_res="failed"
         fi
 
-        if [ "$ACTION" == "Allow" ]; then
-            if [ "$RESULT" == "passed" ]; then
-                echo "[INFO] $ACTION action, and the command should be passed"
-                should_not_find_any_log $POD $OP $COND $ACTION
-            else
-                echo "[INFO] $ACTION action, but the command should be failed"
-                should_find_blocked_log $POD $OP $COND $ACTION $NATIVE
+        if [[ $HOST_POLICY -eq 0 ]]; then
+            if [ "$ACTION" == "Allow" ]; then
+                if [ "$RESULT" == "passed" ]; then
+                    echo "[INFO] $ACTION action, and the command should be passed"
+                    should_not_find_any_log $POD $OP $COND $ACTION
+                else
+                    echo "[INFO] $ACTION action, but the command should be failed"
+                    should_find_blocked_log $POD $OP $COND $ACTION $NATIVE
+                fi
+            elif [ "$ACTION" == "Audit" ] || [ "$ACTION" == "AllowWithAudit" ]; then
+                if [ "$RESULT" == "passed" ]; then
+                    echo "[INFO] $ACTION action, and the command should be passed"
+                    should_find_passed_log $POD $OP $COND $ACTION
+                else
+                    echo "[INFO] $ACTION action, but the command should be failed"
+                    should_find_blocked_log $POD $OP $COND $ACTION $NATIVE
+                fi
+            elif [ "$ACTION" == "Block" ] || [ "$ACTION" == "BlockWithAudit" ]; then
+                if [ "$RESULT" == "passed" ]; then
+                    echo "[INFO] $ACTION action, but the command should be passed"
+                    should_not_find_any_log $POD $OP $COND $ACTION
+                else
+                    echo "[INFO] $ACTION action, and the command should be failed"
+                    should_find_blocked_log $POD $OP $COND $ACTION $NATIVE
+                fi
             fi
-        elif [ "$ACTION" == "Audit" ] || [ "$ACTION" == "AllowWithAudit" ]; then
-            if [ "$RESULT" == "passed" ]; then
-                echo "[INFO] $ACTION action, and the command should be passed"
-                should_find_passed_log $POD $OP $COND $ACTION
-            else
-                echo "[INFO] $ACTION action, but the command should be failed"
-                should_find_blocked_log $POD $OP $COND $ACTION $NATIVE
+        else
+            if [ "$ACTION" == "Allow" ]; then
+                if [ "$RESULT" == "passed" ]; then
+                    echo "[INFO] $ACTION action, and the command should be passed"
+                    should_not_find_any_host_log $OP $COND $ACTION
+                else
+                    echo "[INFO] $ACTION action, but the command should be failed"
+                    should_find_blocked_host_log $OP $COND $ACTION $NATIVE_HOST
+                fi
+            elif [ "$ACTION" == "Audit" ] || [ "$ACTION" == "AllowWithAudit" ]; then
+                if [ "$RESULT" == "passed" ]; then
+                    echo "[INFO] $ACTION action, and the command should be passed"
+                    should_find_passed_host_log $OP $COND $ACTION
+                else
+                    echo "[INFO] $ACTION action, but the command should be failed"
+                    should_find_blocked_host_log $OP $COND $ACTION $NATIVE_HOST
+                fi
+            elif [ "$ACTION" == "Block" ] || [ "$ACTION" == "BlockWithAudit" ]; then
+                if [ "$RESULT" == "passed" ]; then
+                    echo "[INFO] $ACTION action, but the command should be passed"
+                    should_not_find_any_host_log $OP $COND $ACTION
+                else
+                    echo "[INFO] $ACTION action, and the command should be failed"
+                    should_find_blocked_host_log $OP $COND $ACTION $NATIVE_HOST
+                fi
             fi
-        elif [ "$ACTION" == "Block" ] || [ "$ACTION" == "BlockWithAudit" ]; then
-            if [ "$RESULT" == "passed" ]; then
-                echo "[INFO] $ACTION action, but the command should be passed"
-                should_not_find_any_log $POD $OP $COND $ACTION
-            else
-                echo "[INFO] $ACTION action, and the command should be failed"
-                should_find_blocked_log $POD $OP $COND $ACTION $NATIVE
-            fi
-        fi
+        fi    
 
         if [ $res_cmd == 0 ]; then
             echo "Testcase: $3 (command #$cmd_count)" >> $TEST_LOG
@@ -337,7 +560,11 @@ function run_test_scenario() {
             echo "Command: $CMD" >> $TEST_LOG
             echo "Result: $RESULT (expected) / $actual_res (actual)" >> $TEST_LOG
             echo "Output:" >> $TEST_LOG
-            echo ""$(kubectl exec -n $2 -it $POD -- bash -c "$CMD") >> $TEST_LOG
+            if [[ $HOST_POLICY -eq 0 ]]; then 
+                echo ""$(kubectl exec -n $2 -it $POD -- bash -c "$CMD") >> $TEST_LOG
+            else
+                echo ""$(bash -c "$CMD") >> $TEST_LOG
+            fi
             echo "Log:" >> $TEST_LOG
             echo $audit_log >> $TEST_LOG
             echo >> $TEST_LOG
@@ -347,7 +574,7 @@ function run_test_scenario() {
         sleep 1
     done
 
-    if [ $res_cmd != 0 ]; then
+    if [ $res_case != 0 ]; then
         echo -e "${RED}[FAIL] Failed $3${NC}"
         failed_testcases+=("$3")
     else
@@ -356,7 +583,11 @@ function run_test_scenario() {
     fi
 
     echo -e "${GREEN}[INFO] Deleting $YAML_FILE from $2${NC}"
-    kubectl delete -n $2 -f $YAML_FILE
+    if [[ $HOST_POLICY -eq 1 ]] || [[ $NATIVE_HOST -eq 1 ]]; then
+        kubectl delete -f $YAML_FILE
+    else
+        kubectl delete -n $2 -f $YAML_FILE
+    fi 
     if [ $? != 0 ]; then
         echo -e "${RED}[FAIL] Failed to delete $YAML_FILE from $2${NC}"
         res_case=1
@@ -369,10 +600,15 @@ function run_test_scenario() {
 
 ## == KubeArmor == ##
 
-total_testcases=$(ls -l $TEST_HOME/scenarios | grep ^d | wc -l)
+if [ "$(ps -f --pid $(pidof kubearmor)|cat|grep enableHostPolicy)" != "" ]; then
+    SKIP_HOST_POLICY=0
+fi
+
+total_testcases=$(expr $(ls -l $TEST_HOME/scenarios | grep ^d | wc -l) + $(ls -ld $TEST_HOME/host_scenarios/$(hostname)_* | grep ^d | wc -l))
 
 passed_testcases=()
 failed_testcases=()
+skipped_testcases=()
 
 echo "< KubeArmor Test Report >" > $TEST_LOG
 echo >> $TEST_LOG
@@ -383,8 +619,9 @@ echo "== Testcases ==" >> $TEST_LOG
 echo >> $TEST_LOG
 
 ## == Test Scenarios == ##
-
 cd $TEST_HOME
+
+echo -e "${ORANGE}[INFO] Running Container Scenarios${NC}"
 
 res_microservice=0
 
@@ -406,7 +643,7 @@ do
 
         cd $TEST_HOME/scenarios
 
-        for testcase in $(ls -d $microservice_*)
+        for testcase in $(ls -d "$microservice"_*)
         do
             res_case=0
 
@@ -433,19 +670,57 @@ do
         res_delete=0
 
         echo -e "${ORANGE}[INFO] Deleting $microservice${NC}"
-        delete_and_wait_for_microserivce_deletion $microservice
+        delete_and_wait_for_microservice_deletion $microservice
 
         if [ $res_delete == 0 ]; then
             echo "[INFO] Deleted $microservice"
         fi
     fi
+done    
+echo "[INFO] Finished Container Scenarios"
+
+
+HOST_NAME="$(hostname)"
+res_host=0
+
+cd $TEST_HOME
+
+echo -e "${ORANGE}[INFO] Running Host Scenarios${NC}"
+echo "[INFO] Started to run host testcases"
+
+cd $TEST_HOME/host_scenarios
+
+for testcase in $(ls -d "$HOST_NAME"_*)
+do
+    res_case=0
+
+    echo -e "${ORANGE}[INFO] Testing $testcase${NC}"
+    run_test_scenario $TEST_HOME/host_scenarios/$testcase $HOST_NAME $testcase
+
+    if [ $res_case != 0 ]; then
+        res_case=0
+
+        echo -e "${ORANGE}[INFO] Testing $testcase${NC} again to check if it failed due to some lost events"
+        total_testcases=$(expr $total_testcases + 1)
+        run_test_scenario $TEST_HOME/host_scenarios/$testcase $HOST_NAME $testcase
+
+        if [ $res_case != 0 ]; then
+            echo -e "${RED}[FAIL] Failed to test $testcase${NC}"
+            res_host=1
+        else
+            echo -e "${BLUE}[PASS] Successfully tested $testcase${NC}"
+        fi
+    else
+        echo -e "${BLUE}[PASS] Successfully tested $testcase${NC}"
+    fi
 done
+echo "[INFO] Finished Host Scenarios"
 
 echo "== Summary ==" >> $TEST_LOG
 echo >> $TEST_LOG
 echo "Passed testcases: ${#passed_testcases[@]}/$total_testcases" >> $TEST_LOG
-echo >> $TEST_LOG
 if [ "${#passed_testcases[@]}" != "0" ]; then
+    echo >> $TEST_LOG
     for (( i=0; i<${#passed_testcases[@]}; i++ ));
     do
         echo "${passed_testcases[$i]}" >> $TEST_LOG;
@@ -453,18 +728,27 @@ if [ "${#passed_testcases[@]}" != "0" ]; then
 fi
 echo >> $TEST_LOG
 echo "Failed testcases: ${#failed_testcases[@]}/$total_testcases" >> $TEST_LOG
-echo >> $TEST_LOG
 if [ "${#failed_testcases[@]}" != "0" ]; then
+    echo >> $TEST_LOG
     for (( i=0; i<${#failed_testcases[@]}; i++ ));
     do
         echo "${failed_testcases[$i]}" >> $TEST_LOG;
     done
 fi
 echo >> $TEST_LOG
+echo "Skipped testcases: ${#skipped_testcases[@]}/$total_testcases" >> $TEST_LOG
+if [ "${#skipped_testcases[@]}" != "0" ]; then
+    echo >> $TEST_LOG
+    for (( i=0; i<${#skipped_testcases[@]}; i++ ));
+    do
+        echo "${skipped_testcases[$i]}" >> $TEST_LOG;
+    done
+fi
+echo >> $TEST_LOG
 
 ## == KubeArmor == ##
 
-if [ $res_microservice != 0 ]; then
+if [[ $res_microservice -eq 1 ]] || [[ $res_host -eq 1 ]]; then
     echo -e "${RED}[FAIL] Failed to test KubeArmor${NC}"
     exit 1
 else

--- a/tests/test-scenarios-local.sh
+++ b/tests/test-scenarios-local.sh
@@ -24,7 +24,10 @@ CRD_HOME=`dirname $(realpath "$0")`/../deployments/CRD
 ARMOR_HOME=`dirname $(realpath "$0")`/../KubeArmor
 
 ARMOR_OPTIONS=$@
+SKIP_CONTAINER_POLICY=0
 SKIP_NATIVE_POLICY=1
+SKIP_HOST_POLICY=1
+SKIP_NATIVE_HOST_POLICY=1
 
 ARMOR_MSG=/tmp/kubearmor.msg
 ARMOR_LOG=/tmp/kubearmor.log
@@ -63,6 +66,7 @@ function start_and_wait_for_kubearmor_initialization() {
     cd $ARMOR_HOME
 
     echo "Options: -logPath=$ARMOR_LOG $ARMOR_OPTIONS"
+
     if [ "$GITHUB_ACTIONS" = true ]
     then
         echo "Github Actions - Environment"
@@ -71,6 +75,10 @@ function start_and_wait_for_kubearmor_initialization() {
     else
         sudo -E ./kubearmor -logPath=$ARMOR_LOG $ARMOR_OPTIONS > $ARMOR_MSG &
     fi
+
+    if [[ " ${ARMOR_OPTIONS[@]} " =~ "-enableHostPolicy" ]]; then
+        SKIP_HOST_POLICY=0
+    fi    
 
     for (( ; ; ))
     do
@@ -124,7 +132,7 @@ function apply_and_wait_for_microservice_creation() {
     done
 }
 
-function delete_and_wait_for_microserivce_deletion() {
+function delete_and_wait_for_microservice_deletion() {
     cd $TEST_HOME/microservices/$1
 
     kubectl delete -f .
@@ -211,6 +219,83 @@ function should_find_blocked_log() {
     fi
 }
 
+function should_not_find_any_host_log() {
+    echo -e "${GREEN}[INFO] Finding the corresponding log${NC}"
+
+    sleep 3
+
+    audit_log=$(grep -E "$HOST_NAME.*Policy.*$1.*$2.*$3" $ARMOR_LOG | grep -v Passed)
+    if [ $? == 0 ]; then
+        sleep 10
+
+        audit_log=$(grep -E "$HOST_NAME.*Policy.*$1.*$2.*$3" $ARMOR_LOG | grep -v Passed)
+        if [ $? == 0 ]; then
+            echo $audit_log
+            echo -e "${RED}[FAIL] Found the log from logs${NC}"
+            res_cmd=1
+        else
+            audit_log="<No Log>"
+            echo "[INFO] Found no log from logs"
+        fi
+    else
+        audit_log="<No Log>"
+        echo "[INFO] Found no log from logs"
+    fi
+}
+
+function should_find_passed_host_log() {
+    echo -e "${GREEN}[INFO] Finding the corresponding log${NC}"
+
+    sleep 3
+
+    audit_log=$(grep -E "$HOST_NAME.*MatchedHostPolicy.*$1.*$2.*$3" $ARMOR_LOG | grep Passed)
+    if [ $? != 0 ]; then
+        sleep 10
+
+        audit_log=$(grep -E "$HOST_NAME.*MatchedHostPolicy.*$1.*$2.*$3" $ARMOR_LOG | grep Passed)
+        if [ $? != 0 ]; then
+            audit_log="<No Log>"
+            echo -e "${RED}[FAIL] Failed to find the log from logs${NC}"
+            res_cmd=1
+        else
+            echo $audit_log
+            echo "[INFO] Found the log from logs"
+        fi
+    else
+        echo $audit_log
+        echo "[INFO] Found the log from logs"
+    fi
+}
+
+function should_find_blocked_host_log() {
+    echo -e "${GREEN}[INFO] Finding the corresponding log${NC}"
+
+    sleep 3
+
+    match_type="MatchedHostPolicy"
+    if [[ $4 -eq 1 ]]; then
+        match_type="MatchedNativePolicy" 
+    fi
+
+    audit_log=$(grep -E "$HOST_NAME.*$match_type.*$1.*$2.*$3" $ARMOR_LOG | grep -v Passed)
+    if [ $? != 0 ]; then
+        sleep 10
+
+        audit_log=$(grep -E "$HOST_NAME.*$match_type.*$1.*$2.*$3" $ARMOR_LOG | grep -v Passed)
+        if [ $? != 0 ]; then
+            audit_log="<No Log>"
+            echo -e "${RED}[FAIL] Failed to find the log from logs${NC}"
+            res_cmd=1
+        else
+            echo $audit_log
+            echo "[INFO] Found the log from logs"
+        fi
+    else
+        echo $audit_log
+        echo "[INFO] Found the log from logs"
+    fi
+}
+
 function run_test_scenario() {
     cd $1
 
@@ -218,19 +303,54 @@ function run_test_scenario() {
     policy_type=$(echo $YAML_FILE | awk '{split($0,a,"-"); print a[1]}')
     
     NATIVE=0
+    HOST_POLICY=0
+    NATIVE_HOST=0
     if [[ $policy_type == "np" ]]; then
         # skip a policy with a native profile unless AppArmor is enabled
         if [ $APPARMOR == 0 ]; then
+            echo -e "${MAGENTA}[SKIP] Skipped $3${NC}"
+            skipped_testcases+=("$3")
             return
         fi
         if [ $SKIP_NATIVE_POLICY == 1 ]; then
+            echo -e "${MAGENTA}[SKIP] Skipped $3${NC}"
+            skipped_testcases+=("$3")
             return
         fi
         NATIVE=1
     fi
 
+    if [[ $policy_type == "hsp" ]]; then
+        if [ $SKIP_HOST_POLICY == 1 ]; then
+            echo -e "${MAGENTA}[SKIP] Skipped $3${NC}"
+            skipped_testcases+=("$3")
+            return
+        fi
+        HOST_POLICY=1
+    fi
+
+    if [[ $policy_type == "nhsp" ]]; then
+        # skip a policy with a native profile unless AppArmor is enabled
+        if [ $APPARMOR == 0 ]; then
+            echo -e "${MAGENTA}[SKIP] Skipped $3${NC}"
+            skipped_testcases+=("$3")
+            return
+        fi
+        if [ $SKIP_NATIVE_HOST_POLICY == 1 ]; then
+            echo -e "${MAGENTA}[SKIP] Skipped $3${NC}"
+            skipped_testcases+=("$3")
+            return
+        fi
+        NATIVE_HOST=1
+    fi
+
     echo -e "${GREEN}[INFO] Applying $YAML_FILE into $2${NC}"
-    kubectl apply -n $2 -f $YAML_FILE
+    if [[ $HOST_POLICY -eq 1 ]] || [[ $NATIVE_HOST -eq 1 ]]; then
+        kubectl apply -f $YAML_FILE
+    else
+        kubectl apply -n $2 -f $YAML_FILE
+    fi
+
     if [ $? != 0 ]; then
         echo -e "${RED}[FAIL] Failed to apply $YAML_FILE into $2${NC}"
         res_case=1
@@ -246,8 +366,10 @@ function run_test_scenario() {
         cmd_count=$((cmd_count+1))
 
         SOURCE=$(cat $cmd | grep "^source" | awk '{print $2}')
-        POD=$(kubectl get pods -n $2 | grep $SOURCE | awk '{print $1}')
-
+        POD=""
+        if [[ $HOST_POLICY -eq 0 ]] && [[ $NATIVE_HOST -eq 0 ]]; then
+            POD=$(kubectl get pods -n $2 | grep $SOURCE | awk '{print $1}')
+        fi
         CMD=$(cat $cmd | grep "^cmd" | cut -d' ' -f2-)
         RESULT=$(cat $cmd | grep "^result" | awk '{print $2}')
 
@@ -277,36 +399,68 @@ function run_test_scenario() {
         actual_res="passed"
 
         echo -e "${GREEN}[INFO] Running \"$CMD\"${NC}"
-        kubectl exec -n $2 -it $POD -- bash -c "$CMD"
+        if [[ $HOST_POLICY -eq 1 ]] || [[ $NATIVE_HOST -eq 1 ]]; then
+            bash -c "$CMD"
+        else
+            kubectl exec -n $2 -it $POD -- bash -c "$CMD"
+        fi
         if [ $? != 0 ]; then
             actual_res="failed"
         fi
 
-        if [ "$ACTION" == "Allow" ]; then
-            if [ "$RESULT" == "passed" ]; then
-                echo "[INFO] $ACTION action, and the command should be passed"
-                should_not_find_any_log $POD $OP $COND $ACTION
-            else
-                echo "[INFO] $ACTION action, but the command should be failed"
-                should_find_blocked_log $POD $OP $COND $ACTION $NATIVE
+        if [[ $HOST_POLICY -eq 0 ]]; then
+            if [ "$ACTION" == "Allow" ]; then
+                if [ "$RESULT" == "passed" ]; then
+                    echo "[INFO] $ACTION action, and the command should be passed"
+                    should_not_find_any_log $POD $OP $COND $ACTION
+                else
+                    echo "[INFO] $ACTION action, but the command should be failed"
+                    should_find_blocked_log $POD $OP $COND $ACTION $NATIVE
+                fi
+            elif [ "$ACTION" == "Audit" ] || [ "$ACTION" == "AllowWithAudit" ]; then
+                if [ "$RESULT" == "passed" ]; then
+                    echo "[INFO] $ACTION action, and the command should be passed"
+                    should_find_passed_log $POD $OP $COND $ACTION
+                else
+                    echo "[INFO] $ACTION action, but the command should be failed"
+                    should_find_blocked_log $POD $OP $COND $ACTION $NATIVE
+                fi
+            elif [ "$ACTION" == "Block" ] || [ "$ACTION" == "BlockWithAudit" ]; then
+                if [ "$RESULT" == "passed" ]; then
+                    echo "[INFO] $ACTION action, but the command should be passed"
+                    should_not_find_any_log $POD $OP $COND $ACTION
+                else
+                    echo "[INFO] $ACTION action, and the command should be failed"
+                    should_find_blocked_log $POD $OP $COND $ACTION $NATIVE
+                fi
             fi
-        elif [ "$ACTION" == "Audit" ] || [ "$ACTION" == "AllowWithAudit" ]; then
-            if [ "$RESULT" == "passed" ]; then
-                echo "[INFO] $ACTION action, and the command should be passed"
-                should_find_passed_log $POD $OP $COND $ACTION
-            else
-                echo "[INFO] $ACTION action, but the command should be failed"
-                should_find_blocked_log $POD $OP $COND $ACTION $NATIVE
+        else
+            if [ "$ACTION" == "Allow" ]; then
+                if [ "$RESULT" == "passed" ]; then
+                    echo "[INFO] $ACTION action, and the command should be passed"
+                    should_not_find_any_host_log $OP $COND $ACTION
+                else
+                    echo "[INFO] $ACTION action, but the command should be failed"
+                    should_find_blocked_host_log $OP $COND $ACTION $NATIVE_HOST
+                fi
+            elif [ "$ACTION" == "Audit" ] || [ "$ACTION" == "AllowWithAudit" ]; then
+                if [ "$RESULT" == "passed" ]; then
+                    echo "[INFO] $ACTION action, and the command should be passed"
+                    should_find_passed_host_log $OP $COND $ACTION
+                else
+                    echo "[INFO] $ACTION action, but the command should be failed"
+                    should_find_blocked_host_log $OP $COND $ACTION $NATIVE_HOST
+                fi
+            elif [ "$ACTION" == "Block" ] || [ "$ACTION" == "BlockWithAudit" ]; then
+                if [ "$RESULT" == "passed" ]; then
+                    echo "[INFO] $ACTION action, but the command should be passed"
+                    should_not_find_any_host_log $OP $COND $ACTION
+                else
+                    echo "[INFO] $ACTION action, and the command should be failed"
+                    should_find_blocked_host_log $OP $COND $ACTION $NATIVE_HOST
+                fi
             fi
-        elif [ "$ACTION" == "Block" ] || [ "$ACTION" == "BlockWithAudit" ]; then
-            if [ "$RESULT" == "passed" ]; then
-                echo "[INFO] $ACTION action, but the command should be passed"
-                should_not_find_any_log $POD $OP $COND $ACTION
-            else
-                echo "[INFO] $ACTION action, and the command should be failed"
-                should_find_blocked_log $POD $OP $COND $ACTION $NATIVE
-            fi
-        fi
+        fi    
 
         if [ $res_cmd == 0 ]; then
             echo "Testcase: $3 (command #$cmd_count)" >> $TEST_LOG
@@ -326,7 +480,11 @@ function run_test_scenario() {
             echo "Command: $CMD" >> $TEST_LOG
             echo "Result: $RESULT (expected) / $actual_res (actual)" >> $TEST_LOG
             echo "Output:" >> $TEST_LOG
-            echo ""$(kubectl exec -n $2 -it $POD -- bash -c "$CMD") >> $TEST_LOG
+            if [[ $HOST_POLICY -eq 0 ]]; then 
+                echo ""$(kubectl exec -n $2 -it $POD -- bash -c "$CMD") >> $TEST_LOG
+            else
+                echo ""$(bash -c "$CMD") >> $TEST_LOG
+            fi
             echo "Log:" >> $TEST_LOG
             echo $audit_log >> $TEST_LOG
             echo >> $TEST_LOG
@@ -345,7 +503,11 @@ function run_test_scenario() {
     fi
 
     echo -e "${GREEN}[INFO] Deleting $YAML_FILE from $2${NC}"
-    kubectl delete -n $2 -f $YAML_FILE
+    if [[ $HOST_POLICY -eq 1 ]] || [[ $NATIVE_HOST -eq 1 ]]; then
+        kubectl delete -f $YAML_FILE
+    else
+        kubectl delete -n $2 -f $YAML_FILE
+    fi 
     if [ $? != 0 ]; then
         echo -e "${RED}[FAIL] Failed to delete $YAML_FILE from $2${NC}"
         res_case=1
@@ -360,10 +522,11 @@ function run_test_scenario() {
 
 sudo rm -f $ARMOR_MSG $ARMOR_LOG
 
-total_testcases=$(ls -l $TEST_HOME/scenarios | grep ^d | wc -l)
+total_testcases=$(expr $(ls -l $TEST_HOME/scenarios | grep ^d | wc -l) + $(ls -ld $TEST_HOME/host_scenarios/$(hostname)_* | grep ^d | wc -l))
 
 passed_testcases=()
 failed_testcases=()
+skipped_testcases=()
 
 echo "< KubeArmor Test Report >" > $TEST_LOG
 echo >> $TEST_LOG
@@ -388,8 +551,9 @@ start_and_wait_for_kubearmor_initialization
 echo "[INFO] Started KubeArmor"
 
 ## == Test Scenarios == ##
-
 cd $TEST_HOME
+
+echo -e "${ORANGE}[INFO] Running Container Scenarios${NC}"
 
 res_microservice=0
 
@@ -411,7 +575,7 @@ do
 
         cd $TEST_HOME/scenarios
 
-        for testcase in $(ls -d $microservice_*)
+        for testcase in $(ls -d "$microservice"_*)
         do
             res_case=0
 
@@ -438,19 +602,56 @@ do
         res_delete=0
 
         echo -e "${ORANGE}[INFO] Deleting $microservice${NC}"
-        delete_and_wait_for_microserivce_deletion $microservice
+        delete_and_wait_for_microservice_deletion $microservice
 
         if [ $res_delete == 0 ]; then
             echo "[INFO] Deleted $microservice"
         fi
     fi
+done    
+echo "[INFO] Finished Container Scenarios"
+
+
+HOST_NAME="$(hostname)"
+res_host=0
+
+cd $TEST_HOME
+
+echo -e "${ORANGE}[INFO] Running Host Scenarios${NC}"
+echo "[INFO] Started to run host testcases"
+
+cd $TEST_HOME/host_scenarios
+
+for testcase in $(ls -d "$HOST_NAME"_*)
+do
+    res_case=0
+
+    echo -e "${ORANGE}[INFO] Testing $testcase${NC}"
+    run_test_scenario $TEST_HOME/host_scenarios/$testcase $HOST_NAME $testcase
+
+    if [ $res_case != 0 ]; then
+        res_case=0
+
+        echo -e "${ORANGE}[INFO] Testing $testcase${NC} again to check if it failed due to some lost events"
+        run_test_scenario $TEST_HOME/host_scenarios/$testcase $HOST_NAME $testcase
+
+        if [ $res_case != 0 ]; then
+            echo -e "${RED}[FAIL] Failed to test $testcase${NC}"
+            res_host=1
+        else
+            echo -e "${BLUE}[PASS] Successfully tested $testcase${NC}"
+        fi
+    else
+        echo -e "${BLUE}[PASS] Successfully tested $testcase${NC}"
+    fi
 done
+echo "[INFO] Finished Host Scenarios"
 
 echo "== Summary ==" >> $TEST_LOG
 echo >> $TEST_LOG
 echo "Passed testcases: ${#passed_testcases[@]}/$total_testcases" >> $TEST_LOG
-echo >> $TEST_LOG
 if [ "${#passed_testcases[@]}" != "0" ]; then
+    echo >> $TEST_LOG
     for (( i=0; i<${#passed_testcases[@]}; i++ ));
     do
         echo "${passed_testcases[$i]}" >> $TEST_LOG;
@@ -458,11 +659,20 @@ if [ "${#passed_testcases[@]}" != "0" ]; then
 fi
 echo >> $TEST_LOG
 echo "Failed testcases: ${#failed_testcases[@]}/$total_testcases" >> $TEST_LOG
-echo >> $TEST_LOG
 if [ "${#failed_testcases[@]}" != "0" ]; then
+    echo >> $TEST_LOG
     for (( i=0; i<${#failed_testcases[@]}; i++ ));
     do
         echo "${failed_testcases[$i]}" >> $TEST_LOG;
+    done
+fi
+echo >> $TEST_LOG
+echo "Skipped testcases: ${#skipped_testcases[@]}/$total_testcases" >> $TEST_LOG
+if [ "${#skipped_testcases[@]}" != "0" ]; then
+    echo >> $TEST_LOG
+    for (( i=0; i<${#skipped_testcases[@]}; i++ ));
+    do
+        echo "${skipped_testcases[$i]}" >> $TEST_LOG;
     done
 fi
 echo >> $TEST_LOG
@@ -478,7 +688,7 @@ if [ $res_kubearmor == 0 ]; then
     echo "[INFO] Stopped KubeArmor"
 fi
 
-if [ $res_microservice != 0 ]; then
+if [[ $res_microservice -eq 1 ]] || [[ $res_host -eq 1 ]]; then
     echo -e "${RED}[FAIL] Failed to test KubeArmor${NC}"
 else
     echo -e "${BLUE}[PASS] Successfully tested KubeArmor${NC}"
@@ -495,7 +705,7 @@ else
     echo "[INFO] Removed the temporary logs"
 fi
 
-if [ $res_microservice != 0 ]; then
+if [[ $res_microservice -ne 0 ]] || [[ $res_host -ne 0 ]]; then
     exit 1
 else
     exit 0

--- a/tests/test-scenarios-local.sh
+++ b/tests/test-scenarios-local.sh
@@ -493,7 +493,7 @@ function run_test_scenario() {
                     should_find_blocked_host_log $OP $COND $ACTION $NATIVE_HOST
                 fi
             fi
-        fi    
+        fi
 
         if [ $res_cmd == 0 ]; then
             echo "Testcase: $3 (command #$cmd_count)" >> $TEST_LOG

--- a/tests/test-scenarios-local.sh
+++ b/tests/test-scenarios-local.sh
@@ -305,7 +305,14 @@ function run_test_scenario() {
     NATIVE=0
     HOST_POLICY=0
     NATIVE_HOST=0
-    if [[ $policy_type == "np" ]]; then
+
+    if [[ $policy_type == "ksp" ]]; then
+        if [ $SKIP_CONTAINER_POLICY == 1 ]; then
+            echo -e "${MAGENTA}[SKIP] Skipped $3${NC}"
+            skipped_testcases+=("$3")
+            return
+        fi
+    elif [[ $policy_type == "np" ]]; then
         # skip a policy with a native profile unless AppArmor is enabled
         if [ $APPARMOR == 0 ]; then
             echo -e "${MAGENTA}[SKIP] Skipped $3${NC}"
@@ -318,18 +325,14 @@ function run_test_scenario() {
             return
         fi
         NATIVE=1
-    fi
-
-    if [[ $policy_type == "hsp" ]]; then
+    elif [[ $policy_type == "hsp" ]]; then
         if [ $SKIP_HOST_POLICY == 1 ]; then
             echo -e "${MAGENTA}[SKIP] Skipped $3${NC}"
             skipped_testcases+=("$3")
             return
         fi
         HOST_POLICY=1
-    fi
-
-    if [[ $policy_type == "nhsp" ]]; then
+    elif [[ $policy_type == "nhsp" ]]; then
         # skip a policy with a native profile unless AppArmor is enabled
         if [ $APPARMOR == 0 ]; then
             echo -e "${MAGENTA}[SKIP] Skipped $3${NC}"
@@ -342,6 +345,10 @@ function run_test_scenario() {
             return
         fi
         NATIVE_HOST=1
+    else
+        echo -e "${MAGENTA}[SKIP] Skipped unknown testcase $3${NC}"
+        skipped_testcases+=("$3")
+        return
     fi
 
     echo -e "${GREEN}[INFO] Applying $YAML_FILE into $2${NC}"
@@ -527,6 +534,7 @@ total_testcases=$(expr $(ls -l $TEST_HOME/scenarios | grep ^d | wc -l) + $(ls -l
 passed_testcases=()
 failed_testcases=()
 skipped_testcases=()
+reran_testcases=()
 
 echo "< KubeArmor Test Report >" > $TEST_LOG
 echo >> $TEST_LOG
@@ -586,6 +594,8 @@ do
                 res_case=0
 
                 echo -e "${ORANGE}[INFO] Testing $testcase${NC} again to check if it failed due to some lost events"
+                total_testcases=$(expr $total_testcases + 1)
+                reran_testcases+=("$testcase")
                 run_test_scenario $TEST_HOME/scenarios/$testcase $microservice $testcase
 
                 if [ $res_case != 0 ]; then
@@ -622,7 +632,9 @@ echo "[INFO] Started to run host testcases"
 
 cd $TEST_HOME/host_scenarios
 
-for testcase in $(ls -d "$HOST_NAME"_*)
+host_testcases=$(ls -d "$HOST_NAME"_*)
+if [ $? -eq 0 ]; then 
+for testcase in $host_testcases
 do
     res_case=0
 
@@ -633,6 +645,8 @@ do
         res_case=0
 
         echo -e "${ORANGE}[INFO] Testing $testcase${NC} again to check if it failed due to some lost events"
+        total_testcases=$(expr $total_testcases + 1)
+        reran_testcases+=("$testcase")
         run_test_scenario $TEST_HOME/host_scenarios/$testcase $HOST_NAME $testcase
 
         if [ $res_case != 0 ]; then
@@ -646,6 +660,9 @@ do
     fi
 done
 echo "[INFO] Finished Host Scenarios"
+else
+echo -e "${RED}[INFO] No testcases found for current host${NC}"
+fi
 
 echo "== Summary ==" >> $TEST_LOG
 echo >> $TEST_LOG
@@ -673,6 +690,15 @@ if [ "${#skipped_testcases[@]}" != "0" ]; then
     for (( i=0; i<${#skipped_testcases[@]}; i++ ));
     do
         echo "${skipped_testcases[$i]}" >> $TEST_LOG;
+    done
+fi
+echo >> $TEST_LOG
+echo "Reran testcases: ${#reran_testcases[@]}/$total_testcases" >> $TEST_LOG
+if [ "${#reran_testcases[@]}" != "0" ]; then
+    echo >> $TEST_LOG
+    for (( i=0; i<${#reran_testcases[@]}; i++ ));
+    do
+        echo "${reran_testcases[$i]}" >> $TEST_LOG;
     done
 fi
 echo >> $TEST_LOG

--- a/tests/test-scenarios-local.sh
+++ b/tests/test-scenarios-local.sh
@@ -32,18 +32,14 @@ SKIP_NATIVE_HOST_POLICY=1
 
 case $1 in
     "-testHostPolicy")
-        SKIP_HOST_POLICY=0
         SKIP_CONTAINER_POLICY=1
-        ARMOR_OPTIONS=${@:2}
-        ;;
-    "-testContainerPolicy")
-        SKIP_CONTAINER_POLICY=0
-        SKIP_HOST_POLICY=1
-        ARMOR_OPTIONS=${@:2}
-        ;;
-    "-testAllButNative")
-        SKIP_CONTAINER_POLICY=0
         SKIP_HOST_POLICY=0
+        ARMOR_OPTIONS=${@:2}
+        ;;
+    "-testNativePolicy")
+        SKIP_CONTAINER_POLICY=1
+        SKIP_NATIVE_POLICY=0
+        SKIP_NATIVE_HOST_POLICY=0
         ARMOR_OPTIONS=${@:2}
         ;;
     "-testAll")
@@ -53,7 +49,7 @@ case $1 in
         SKIP_NATIVE_HOST_POLICY=0
         ARMOR_OPTIONS=${@:2}
         ;;
-    *)
+    *) # -testContainerPolicy by default
         ARMOR_OPTIONS=$@
         ;;
 esac


### PR DESCRIPTION
This adds KubeArmorHostPolicy support to the existing test framework. To run the host test scenarios hostpolicy must be enabled in kubearmor using the `-enableHostPolicy` option.

The commits also add skipped and reran testcase information to be shown in the test results and during the test script run.

Fixes: #168