### PR TITLE
Update Audit Policy

### DIFF
--- a/KubeArmor/core/kubeArmor.go
+++ b/KubeArmor/core/kubeArmor.go
@@ -67,6 +67,10 @@ type KubeArmorDaemon struct {
 	HostSecurityPolicies     []tp.HostSecurityPolicy
 	HostSecurityPoliciesLock *sync.RWMutex
 
+	// K8s Audit policies
+	K8sAuditPolicies     []tp.K8sKubeArmorAuditPolicy
+	K8sAuditPoliciesLock *sync.RWMutex
+
 	// Audit policies
 	AuditPolicies     []tp.KubeArmorAuditPolicy
 	AuditPoliciesLock *sync.RWMutex
@@ -150,6 +154,9 @@ func NewKubeArmorDaemon(clusterName, gRPCPort, logPath, logFilter string, enable
 
 	dm.HostSecurityPolicies = []tp.HostSecurityPolicy{}
 	dm.HostSecurityPoliciesLock = new(sync.RWMutex)
+
+	dm.K8sAuditPolicies = []tp.K8sKubeArmorAuditPolicy{}
+	dm.K8sAuditPoliciesLock = new(sync.RWMutex)
 
 	dm.AuditPolicies = []tp.KubeArmorAuditPolicy{}
 	dm.AuditPoliciesLock = new(sync.RWMutex)

--- a/KubeArmor/types/types.go
+++ b/KubeArmor/types/types.go
@@ -158,8 +158,7 @@ type K8sKubeArmorAuditPolicyEvent struct {
 
 // K8sEventType Structure
 type K8sEventType struct {
-	Syscall string `json:"syscall,omitempty"`
-	Kprobe  string `json:"kprobe,omitempty"`
+	Probe   string `json:"probe"`
 	Rate    string `json:"rate,omitempty"`
 
 	// socket related arguments
@@ -579,15 +578,10 @@ type KubeArmorMacros map[string]KubeArmorMacrosNamespace
 // == Audit Policy == //
 // ================== //
 
-type SeverityType int
-type RateLimitType string
-type AuditProcessType string
-
 // AuditEventType Structure
 type AuditEventType struct {
-	Syscall string        `json:"syscall,omitempty"`
-	Kprobe  string        `json:"kprobe,omitempty"`
-	Rate    RateLimitType `json:"rate,omitempty"`
+	Probe string `json:"probe"`
+	Rate  string `json:"rate,omitempty"`
 
 	// socket related arguments
 	Protocol string `json:"protocol,omitempty"`
@@ -603,8 +597,8 @@ type AuditEventType struct {
 
 // KubeArmorAuditRuleType Structure
 type KubeArmorAuditRuleType struct {
-	Process  AuditProcessType `json:"process,omitempty"`
-	Severity SeverityType     `json:"severity,omitempty"`
+	Process  string           `json:"process,omitempty"`
+	Severity int              `json:"severity,omitempty"`
 	Tags     []string         `json:"tags,omitempty"`
 	Message  string           `json:"message,omitempty"`
 	Events   []AuditEventType `json:"events"`
@@ -612,7 +606,7 @@ type KubeArmorAuditRuleType struct {
 
 // KubeArmorAuditPolicySpec Structure
 type KubeArmorAuditPolicySpec struct {
-	Severity   SeverityType             `json:"severity,omitempty"`
+	Severity   int                      `json:"severity,omitempty"`
 	Tags       []string                 `json:"tags,omitempty"`
 	Message    string                   `json:"message,omitempty"`
 	AuditRules []KubeArmorAuditRuleType `json:"rules"`
@@ -627,5 +621,4 @@ type AuditPolicyStatus struct {
 type KubeArmorAuditPolicy struct {
 	Metadata map[string]string        `json:"metadata"`
 	Spec     KubeArmorAuditPolicySpec `json:"spec"`
-	RawSpec  K8sAuditPolicySpec       `json:"rawspec"`
 }

--- a/pkg/KubeArmorAuditPolicy/api/v1/kubearmorauditpolicy_types.go
+++ b/pkg/KubeArmorAuditPolicy/api/v1/kubearmorauditpolicy_types.go
@@ -24,8 +24,7 @@ import (
 type SeverityType string
 
 type EventType struct {
-	Syscall string `json:"syscall,omitempty"`
-	Kprobe  string `json:"kprobe,omitempty"`
+	Probe string `json:"probe"`
 
 	// +kubebuilder:validation:Pattern=^([0-9]+p[0-9]+s|[0-9]+p[0-9]+m)$
 	Rate string `json:"rate,omitempty"`

--- a/pkg/KubeArmorAuditPolicy/config/crd/bases/security.kubearmor.com_kubearmorauditpolicies.yaml
+++ b/pkg/KubeArmorAuditPolicy/config/crd/bases/security.kubearmor.com_kubearmorauditpolicies.yaml
@@ -52,8 +52,6 @@ spec:
                             type: string
                           ipv6addr:
                             type: string
-                          kprobe:
-                            type: string
                           mode:
                             type: string
                           path:
@@ -61,6 +59,8 @@ spec:
                             pattern: ^\/([A-z0-9-_.]+\/)*([A-z0-9-_.]+)$
                             type: string
                           port:
+                            type: string
+                          probe:
                             type: string
                           protocol:
                             description: socket related arguments
@@ -77,8 +77,8 @@ spec:
                           rate:
                             pattern: ^([0-9]+p[0-9]+s|[0-9]+p[0-9]+m)$
                             type: string
-                          syscall:
-                            type: string
+                        required:
+                        - probe
                         type: object
                       type: array
                     message:

--- a/pkg/KubeArmorAuditPolicy/config/samples/security_v1_kubearmorauditpolicy.yaml
+++ b/pkg/KubeArmorAuditPolicy/config/samples/security_v1_kubearmorauditpolicy.yaml
@@ -16,24 +16,24 @@ spec:
       message: "suspicious shell activity"
       severity: "5"
       events:
-        - syscall: BIND-CONNECT-ACCEPT
+        - probe: BIND-CONNECT-ACCEPT
           ipv4addr: NON-EXTERNAL-IPV4
           rate: 10p1s
 
     - process: "*"
       events:
-        - syscall: sys_open
+        - probe: sys_open
           path: /etc/shadow
           mode: O_RDWR_APPEND
 
     - message: "outbound probes detected (for any process)"
       severity: "5"
       events:
-        - kprobe: tcp_rst
+        - probe: tcp_rst
           rate: 10p1s
 
     - message: "inbound probes detected"
       severity: "5"
       events:
-        - kprobe: tcp_rst_send
+        - probe: tcp_rst_send
           rate: 10p1s


### PR DESCRIPTION
- remove raw spec from KubeArmor side
- use a single field to describe probe names
- rebuild KubeArmor policies after any macro/policy event