### PR TITLE
event-auditor: license attribution for kernel code

### DIFF
--- a/KubeArmor/eventAuditor/BPF/ka_ea_pattern_map.bpf.c
+++ b/KubeArmor/eventAuditor/BPF/ka_ea_pattern_map.bpf.c
@@ -1,5 +1,5 @@
+// SPDX-License-Identifier: GPL-2.0
 // Copyright 2021 Authors of KubeArmor
-// SPDX-License-Identifier: Apache-2.0
 
 #include "vmlinux.h"
 #include <bpf/bpf_helpers.h>
@@ -13,4 +13,4 @@ struct {
 	__uint(max_entries, 1 << 10);
 } ka_ea_pattern_map SEC(".maps");
 
-char LICENSE[] SEC("license") = "Dual BSD/GPL";
+char LICENSE[] SEC("license") = "GPL";

--- a/KubeArmor/eventAuditor/BPF/ka_ea_process_filter_map.bpf.c
+++ b/KubeArmor/eventAuditor/BPF/ka_ea_process_filter_map.bpf.c
@@ -1,5 +1,5 @@
+// SPDX-License-Identifier: GPL-2.0
 // Copyright 2021 Authors of KubeArmor
-// SPDX-License-Identifier: Apache-2.0
 
 #include "vmlinux.h"
 #include <bpf/bpf_helpers.h>
@@ -13,4 +13,4 @@ struct {
 	__uint(max_entries, 1 << 10);
 } ka_ea_process_filter_map SEC(".maps");
 
-char LICENSE[] SEC("license") = "Dual BSD/GPL";
+char LICENSE[] SEC("license") = "GPL";

--- a/KubeArmor/eventAuditor/BPF/ka_ea_process_spec_map.bpf.c
+++ b/KubeArmor/eventAuditor/BPF/ka_ea_process_spec_map.bpf.c
@@ -1,5 +1,5 @@
+// SPDX-License-Identifier: GPL-2.0
 // Copyright 2021 Authors of KubeArmor
-// SPDX-License-Identifier: Apache-2.0
 
 #include "vmlinux.h"
 #include <bpf/bpf_helpers.h>
@@ -13,4 +13,4 @@ struct {
 	__uint(max_entries, 1 << 10);
 } ka_ea_process_spec_map SEC(".maps");
 
-char LICENSE[] SEC("license") = "Dual BSD/GPL";
+char LICENSE[] SEC("license") = "GPL";

--- a/KubeArmor/eventAuditor/BPF/maps.bpf.h
+++ b/KubeArmor/eventAuditor/BPF/maps.bpf.h
@@ -1,5 +1,5 @@
-// Copyright 2021 Authors of KubeArmor
-// SPDX-License-Identifier: Apache-2.0
+/* SPDX-License-Identifier: GPL-2.0 */
+/* Copyright 2021 Authors of KubeArmor */
 
 #ifndef __MAPS_BPF_H
 #define __MAPS_BPF_H

--- a/KubeArmor/eventAuditor/BPF/shared.h
+++ b/KubeArmor/eventAuditor/BPF/shared.h
@@ -1,4 +1,9 @@
 /* SPDX-License-Identifier: GPL-2.0 */
 /* Copyright 2021 Authors of KubeArmor */
 
+#ifndef __SHARED_H
+#define __SHARED_H
+
 #define PATTERN_MAX_LEN 127
+
+#endif /* __SHARED_H */

--- a/KubeArmor/eventAuditor/BPF/shared.h
+++ b/KubeArmor/eventAuditor/BPF/shared.h
@@ -1,4 +1,4 @@
-// Copyright 2021 Authors of KubeArmor
-// SPDX-License-Identifier: Apache-2.0
+/* SPDX-License-Identifier: GPL-2.0 */
+/* Copyright 2021 Authors of KubeArmor */
 
 #define PATTERN_MAX_LEN 127


### PR DESCRIPTION
Partially fixes #280

As per https://www.kernel.org/doc/html/v5.0/process/license-rules.html, the SPDX license identifier should be added in the first possible line and follow different comment styles based on the file type. 

```
C source: // SPDX-License-Identifier: <SPDX License Expression>
C header: /* SPDX-License-Identifier: <SPDX License Expression> */
ASM:      /* SPDX-License-Identifier: <SPDX License Expression> */
```

P.S. The [`checkpatch.pl`](https://www.kernel.org/doc/html/latest/dev-tools/checkpatch.html) kernel script can be incorporated into CI to check these coding style rules. E.g.: `./checkpatch.pl --no-tree -f file.c`

There's also vscode extension for that matter.

```
Name: checkpatch
Id: idanp.checkpatch
Description: Using linux kernel checkpatch tool to lint code.
VS Marketplace Link: https://marketplace.visualstudio.com/items?itemName=idanp.checkpatch
```

---

This also add #include guards to `shared.h`.