### PR TITLE
Event auditor: Maintain the KubeArmorAuditPolicies + minor fixes

### DIFF
--- a/KubeArmor/core/kubeArmor.go
+++ b/KubeArmor/core/kubeArmor.go
@@ -74,12 +74,12 @@ type KubeArmorDaemon struct {
 	K8sAuditPoliciesLock *sync.RWMutex
 
 	// Audit policies
-	AuditPolicies     []tp.KubeArmorAuditPolicy
+	AuditPolicies     map[string]tp.KubeArmorAuditPolicy
 	AuditPoliciesLock *sync.RWMutex
 
-	// Macros (namespace -> macro)
-	KubeArmorMacrosMap  tp.KubeArmorMacros
-	KubeArmorMacrosLock *sync.RWMutex
+	// Macros
+	K8sMacros     []tp.K8sKubeArmorMacro
+	K8sMacrosLock *sync.RWMutex
 
 	// container id -> (host) pid
 	ActivePidMap     map[string]tp.PidMap
@@ -159,11 +159,11 @@ func NewKubeArmorDaemon(clusterName, gRPCPort, logPath, logFilter string, enable
 	dm.K8sAuditPolicies = []tp.K8sKubeArmorAuditPolicy{}
 	dm.K8sAuditPoliciesLock = new(sync.RWMutex)
 
-	dm.AuditPolicies = []tp.KubeArmorAuditPolicy{}
+	dm.AuditPolicies = map[string]tp.KubeArmorAuditPolicy{}
 	dm.AuditPoliciesLock = new(sync.RWMutex)
 
-	dm.KubeArmorMacrosMap = tp.KubeArmorMacros{}
-	dm.KubeArmorMacrosLock = new(sync.RWMutex)
+	dm.K8sMacros = []tp.K8sKubeArmorMacro{}
+	dm.K8sMacrosLock = new(sync.RWMutex)
 
 	dm.ActivePidMap = map[string]tp.PidMap{}
 	dm.ActiveHostPidMap = map[string]tp.PidMap{}

--- a/KubeArmor/eventAuditor/entryPointHandler.go
+++ b/KubeArmor/eventAuditor/entryPointHandler.go
@@ -1,11 +1,17 @@
 package eventauditor
 
+import (
+	tp "github.com/kubearmor/KubeArmor/KubeArmor/types"
+	"sync"
+)
+
 // =========================== //
 // == Entrypoint Management == //
 // =========================== //
 
 // UpdateEntrypoints Function
-func (ea *EventAuditor) UpdateEntrypoints() { // (auditPolicies *map[string]tp.AuditPolicy, auditPoliciesLock **sync.Mutex)
+func (ea *EventAuditor) UpdateEntrypoints(auditPolicies *map[string]tp.KubeArmorAuditPolicy,
+	auditPoliciesLock **sync.RWMutex) {
 	// AuditPolicies := *(auditPolicies)
 	// AuditPoliciesLock := *(auditPoliciesLock)
 

--- a/KubeArmor/eventAuditor/processSpecHandler.go
+++ b/KubeArmor/eventAuditor/processSpecHandler.go
@@ -1,5 +1,10 @@
 package eventauditor
 
+import (
+	tp "github.com/kubearmor/KubeArmor/KubeArmor/types"
+	"sync"
+)
+
 // ============================= //
 // == Process Spec Management == //
 // ============================= //
@@ -21,6 +26,7 @@ func (ea *EventAuditor) DestroyProcessMaps() bool {
 }
 
 // UpdateProcessMaps Function
-func (ea *EventAuditor) UpdateProcessMaps() { // (auditPolicies *map[string]tp.AuditPolicy, auditPoliciesLock **sync.Mutex)
+func (ea *EventAuditor) UpdateProcessMaps(auditPolicies *map[string]tp.KubeArmorAuditPolicy,
+	auditPoliciesLock **sync.RWMutex) {
 	// update process-spec and pattern maps
 }

--- a/KubeArmor/types/types.go
+++ b/KubeArmor/types/types.go
@@ -147,11 +147,6 @@ type K8sKubeArmorMacro struct {
 	Status   K8sPolicyStatus    `json:"status,omitempty"`
 }
 
-// K8sKubeArmorMacros Structure
-type K8sKubeArmorMacros struct {
-	Items []K8sKubeArmorMacro `json:"items"`
-}
-
 // K8sKubeArmorAuditPolicyEvent Structure
 type K8sKubeArmorAuditPolicyEvent struct {
 	Type   string                  `json:"type"`
@@ -177,20 +172,18 @@ type K8sEventType struct {
 
 // K8sAuditRuleType Structure
 type K8sAuditRuleType struct {
-	Severity string   `json:"severity,omitempty"`
-	Tags     []string `json:"tags,omitempty"`
-	Message  string   `json:"message,omitempty"`
-
-	Process string         `json:"process,omitempty"`
-	Events  []K8sEventType `json:"events"`
+	Process  string         `json:"process,omitempty"`
+	Severity string         `json:"severity,omitempty"`
+	Tags     []string       `json:"tags,omitempty"`
+	Message  string         `json:"message,omitempty"`
+	Events   []K8sEventType `json:"events"`
 }
 
 // K8sAuditPolicySpec Structure
 type K8sAuditPolicySpec struct {
-	Severity string   `json:"severity,omitempty"`
-	Tags     []string `json:"tags,omitempty"`
-	Message  string   `json:"message,omitempty"`
-
+	Severity   string             `json:"severity,omitempty"`
+	Tags       []string           `json:"tags,omitempty"`
+	Message    string             `json:"message,omitempty"`
 	AuditRules []K8sAuditRuleType `json:"rules"`
 }
 
@@ -590,15 +583,6 @@ type KubeArmorMacroSpec struct {
 	Macros []MacrosType `json:"macros"`
 }
 
-// KubeArmorMacrosKeyValue Map
-type KubeArmorMacrosKeyValue map[string]string
-
-// KubeArmorMacrosNamespace Map
-type KubeArmorMacrosNamespace map[string]KubeArmorMacrosKeyValue
-
-// KubeArmorMacros Map
-type KubeArmorMacros map[string]KubeArmorMacrosNamespace
-
 // ================== //
 // == Audit Policy == //
 // ================== //
@@ -608,39 +592,27 @@ type AuditEventType struct {
 	Probe string `json:"probe"`
 	Rate  string `json:"rate,omitempty"`
 
-	// file related arguments
-	Path      string `json:"path,omitempty"`
-	Directory string `json:"dir,omitempty"`
-	Mode      string `json:"mode,omitempty"`
+	Severity int      `json:"severity,omitempty"`
+	Tags     []string `json:"tags,omitempty"`
+	Message  string   `json:"message,omitempty"`
 
 	// socket related arguments
 	Protocol string `json:"protocol,omitempty"`
+	Port     int    `json:"port,omitempty"`
 	Ipv4Addr string `json:"ipv4addr,omitempty"`
 	Ipv6Addr string `json:"ipv6addr,omitempty"`
-	Port     int    `json:"port,omitempty"`
+
+	// file related arguments
+	Path      string `json:"path,omitempty"`
+	Mode      int    `json:"mode,omitempty"`
+	Directory string `json:"dir,omitempty"`
 }
 
 // KubeArmorAuditRuleType Structure
-type KubeArmorAuditRuleType struct {
-	Severity int      `json:"severity,omitempty"`
-	Tags     []string `json:"tags,omitempty"`
-	Message  string   `json:"message,omitempty"`
-
-	Process string           `json:"process,omitempty"`
-	Events  []AuditEventType `json:"events"`
-}
-
-// KubeArmorAuditPolicySpec Structure
-type KubeArmorAuditPolicySpec struct {
-	Severity int      `json:"severity,omitempty"`
-	Tags     []string `json:"tags,omitempty"`
-	Message  string   `json:"message,omitempty"`
-
-	AuditRules []KubeArmorAuditRuleType `json:"rules"`
-}
-
-// KubeArmorAuditPolicy Structure
 type KubeArmorAuditPolicy struct {
-	Metadata map[string]string        `json:"metadata"`
-	Spec     KubeArmorAuditPolicySpec `json:"spec"`
+	Process  string           `json:"process,omitempty"`
+	Severity int              `json:"severity,omitempty"`
+	Tags     []string         `json:"tags,omitempty"`
+	Message  string           `json:"message,omitempty"`
+	Events   []AuditEventType `json:"events"`
 }

--- a/pkg/KubeArmorMacro/config/samples/security_v1_kubearmormacro.yaml
+++ b/pkg/KubeArmorMacro/config/samples/security_v1_kubearmormacro.yaml
@@ -18,8 +18,7 @@ spec:
       value: "2"
 
     - name: O_APPEND
-      value: >
-        0x400
+      value: "0x400"
 
     - name: O_RDWR_APPEND
-      value: O_RDWR | O_APPEND
+      value: "0x402"


### PR DESCRIPTION
- Update KubeArmorMacro sample removing the operator definition (may be included in the future).
- Update the type definitions for macros and audit policies for an "easy to read/maintain" code.
- Finish the initial version of UpdateAuditPolicies with the necessary code to maintain the macros and policies.