### PR TITLE
Save multiple events in single percpu_array map buffer

### DIFF
--- a/KubeArmor/BPF/system_monitor.c
+++ b/KubeArmor/BPF/system_monitor.c
@@ -34,7 +34,7 @@
 // == Structures == //
 
 #define MAX_BUFFER_SIZE   32768
-#define MAX_BUF_ELEM_SIZE 256
+#define MAX_BUF_ELEM_SIZE 2048
 #define MAX_STRING_SIZE   4096
 #define MAX_STR_ARR_ELEM  20
 

--- a/KubeArmor/BPF/system_monitor.c
+++ b/KubeArmor/BPF/system_monitor.c
@@ -631,6 +631,9 @@ int syscall__execve(struct pt_regs *ctx,
 
     if (base_off >= (MAX_BUFFER_SIZE>>2)) {
         set_buffer_offset(0);
+        if (bpf_get_prandom_u32() % 2) {
+            return 0;
+        }
         base_off = 0;
         off = base_off;
         *off_global += MAX_BUF_ELEM_SIZE;
@@ -680,6 +683,9 @@ int trace_ret_execve(struct pt_regs *ctx)
 
     if (base_off >= (MAX_BUFFER_SIZE>>2)) {
         set_buffer_offset(0);
+        if (bpf_get_prandom_u32() % 2) {
+            return 0;
+        }
         base_off = 0;
         off = base_off;
         *off_global += MAX_BUF_ELEM_SIZE;
@@ -729,6 +735,9 @@ int syscall__execveat(struct pt_regs *ctx,
 
     if (base_off >= (MAX_BUFFER_SIZE>>2)) {
         set_buffer_offset(0);
+        if (bpf_get_prandom_u32() % 2) {
+            return 0;
+        }
         base_off = 0;
         off = base_off;
         *off_global += MAX_BUF_ELEM_SIZE;
@@ -782,6 +791,9 @@ int trace_ret_execveat(struct pt_regs *ctx)
 
     if (base_off >= (MAX_BUFFER_SIZE>>2)) {
         set_buffer_offset(0);
+        if (bpf_get_prandom_u32() % 2) {
+            return 0;
+        }
         base_off = 0;
         off = base_off;
         *off_global += MAX_BUF_ELEM_SIZE;
@@ -827,6 +839,9 @@ int trace_do_exit(struct pt_regs *ctx, long code)
 
     if (base_off >= (MAX_BUFFER_SIZE>>2)) {
         set_buffer_offset(0);
+        if (bpf_get_prandom_u32() % 2) {
+            return 0;
+        }
         base_off = 0;
         off = base_off;
         *off_global += MAX_BUF_ELEM_SIZE;
@@ -944,6 +959,9 @@ static __always_inline int trace_ret_generic(u32 id, struct pt_regs *ctx, u64 ty
 
     if (base_off >= (MAX_BUFFER_SIZE>>2)) {
         set_buffer_offset(0);
+        if (bpf_get_prandom_u32() % 2) {
+            return 0;
+        }
         base_off = 0;
         off = base_off;
         *off_global += MAX_BUF_ELEM_SIZE;

--- a/KubeArmor/BPF/system_monitor.c
+++ b/KubeArmor/BPF/system_monitor.c
@@ -31,10 +31,6 @@
 #error Minimal required kernel version is 4.14
 #endif
 
-#ifndef lock_xadd
-# define lock_xadd(ptr, val)              \
-   ((void)__sync_fetch_and_add(ptr, val))
-#endif
 
 // == Structures == //
 
@@ -632,19 +628,17 @@ int syscall__execve(struct pt_regs *ctx,
         return -1;
     }
 
-    lock_xadd(off_global, MAX_BUF_ELEM_SIZE);
-    //set_buffer_offset(sizeof(sys_context_t));
-
     u32 base_off = (*off_global) & (MAX_BUFFER_SIZE - 1);
-    u32 off = 0;
-    if (base_off >= MAX_BUF_ELEM_SIZE)
-        base_off -= MAX_BUF_ELEM_SIZE;
-    off = base_off;
+    *off_global += MAX_BUF_ELEM_SIZE;
+    set_buffer_offset(*off_global);
+    u32 off = base_off;
+
     if (base_off > (MAX_BUFFER_SIZE>>2)) {
         set_buffer_offset(0);
-        lock_xadd(off_global, MAX_BUF_ELEM_SIZE);
         base_off = 0;
         off = base_off;
+        *off_global += MAX_BUF_ELEM_SIZE;
+        set_buffer_offset(*off_global);
     }
     
     bufs_t *bufs_p = get_buffer();
@@ -686,19 +680,17 @@ int trace_ret_execve(struct pt_regs *ctx)
         return -1;
     }
 
-    lock_xadd(off_global, MAX_BUF_ELEM_SIZE);
-    //set_buffer_offset(sizeof(sys_context_t));
-
     u32 base_off = (*off_global) & (MAX_BUFFER_SIZE - 1);
-    u32 off = 0;
-    if (base_off >= MAX_BUF_ELEM_SIZE)
-        base_off -= MAX_BUF_ELEM_SIZE;
-    off = base_off;
+    *off_global += MAX_BUF_ELEM_SIZE;
+    set_buffer_offset(*off_global);
+    u32 off = base_off;
+
     if (base_off > (MAX_BUFFER_SIZE>>2)) {
         set_buffer_offset(0);
-        lock_xadd(off_global, MAX_BUF_ELEM_SIZE);
         base_off = 0;
         off = base_off;
+        *off_global += MAX_BUF_ELEM_SIZE;
+        set_buffer_offset(*off_global);
     }
 
     bufs_t *bufs_p = get_buffer();
@@ -739,19 +731,17 @@ int syscall__execveat(struct pt_regs *ctx,
         return -1;
     }
 
-    lock_xadd(off_global, MAX_BUF_ELEM_SIZE);
-    //set_buffer_offset(sizeof(sys_context_t));
-
     u32 base_off = (*off_global) & (MAX_BUFFER_SIZE - 1);
-    u32 off = 0;
-    if (base_off >= MAX_BUF_ELEM_SIZE)
-        base_off -= MAX_BUF_ELEM_SIZE;
-    off = base_off;
+    *off_global += MAX_BUF_ELEM_SIZE;
+    set_buffer_offset(*off_global);
+    u32 off = base_off;
+
     if (base_off > (MAX_BUFFER_SIZE>>2)) {
         set_buffer_offset(0);
-        lock_xadd(off_global, MAX_BUF_ELEM_SIZE);
         base_off = 0;
         off = base_off;
+        *off_global += MAX_BUF_ELEM_SIZE;
+        set_buffer_offset(*off_global);
     }
 
     bufs_t *bufs_p = get_buffer();
@@ -796,19 +786,18 @@ int trace_ret_execveat(struct pt_regs *ctx)
         return -1;
     }
 
-    lock_xadd(off_global, MAX_BUF_ELEM_SIZE);
-    //set_buffer_offset(sizeof(sys_context_t));
 
     u32 base_off = (*off_global) & (MAX_BUFFER_SIZE - 1);
-    u32 off = 0;
-    if (base_off >= MAX_BUF_ELEM_SIZE)
-        base_off -= MAX_BUF_ELEM_SIZE;
-    off = base_off;
+    *off_global += MAX_BUF_ELEM_SIZE;
+    set_buffer_offset(*off_global);
+    u32 off = base_off;
+
     if (base_off > (MAX_BUFFER_SIZE>>2)) {
         set_buffer_offset(0);
-        lock_xadd(off_global, MAX_BUF_ELEM_SIZE);
         base_off = 0;
         off = base_off;
+        *off_global += MAX_BUF_ELEM_SIZE;
+        set_buffer_offset(*off_global);
     }
 
     bufs_t *bufs_p = get_buffer();
@@ -845,19 +834,18 @@ int trace_do_exit(struct pt_regs *ctx, long code)
         return -1;
     }
 
-    lock_xadd(off_global, MAX_BUF_ELEM_SIZE);
-    //set_buffer_offset(sizeof(sys_context_t));
 
     u32 base_off = (*off_global) & (MAX_BUFFER_SIZE - 1);
-    u32 off = 0;
-    if (base_off >= MAX_BUF_ELEM_SIZE)
-        base_off -= MAX_BUF_ELEM_SIZE;
-    off = base_off;
+    *off_global += MAX_BUF_ELEM_SIZE;
+    set_buffer_offset(*off_global);
+    u32 off = base_off;
+
     if (base_off > (MAX_BUFFER_SIZE>>2)) {
         set_buffer_offset(0);
-        lock_xadd(off_global, MAX_BUF_ELEM_SIZE);
         base_off = 0;
         off = base_off;
+        *off_global += MAX_BUF_ELEM_SIZE;
+        set_buffer_offset(*off_global);
     }
 
     bufs_t *bufs_p = get_buffer();
@@ -967,19 +955,17 @@ static __always_inline int trace_ret_generic(u32 id, struct pt_regs *ctx, u64 ty
         return -1;
     }
 
-    lock_xadd(off_global, MAX_BUF_ELEM_SIZE);
-    //set_buffer_offset(sizeof(sys_context_t));
-
     u32 base_off = (*off_global) & (MAX_BUFFER_SIZE - 1);
-    u32 off = 0;
-    if (base_off >= MAX_BUF_ELEM_SIZE)
-        base_off -= MAX_BUF_ELEM_SIZE;
-    off = base_off;
+    *off_global += MAX_BUF_ELEM_SIZE;
+    set_buffer_offset(*off_global);
+    u32 off = base_off;
+
     if (base_off > (MAX_BUFFER_SIZE>>2)) {
         set_buffer_offset(0);
-        lock_xadd(off_global, MAX_BUF_ELEM_SIZE);
         base_off = 0;
         off = base_off;
+        *off_global += MAX_BUF_ELEM_SIZE;
+        set_buffer_offset(*off_global);
     }
 
     bufs_t *bufs_p = get_buffer();

--- a/KubeArmor/BPF/system_monitor.c
+++ b/KubeArmor/BPF/system_monitor.c
@@ -31,7 +31,6 @@
 #error Minimal required kernel version is 4.14
 #endif
 
-
 // == Structures == //
 
 #define MAX_BUFFER_SIZE   32768
@@ -418,7 +417,6 @@ static __always_inline int save_context_to_buffer(bufs_t *bufs_p, void *ptr, u32
 
 static __always_inline int save_str_to_buffer(bufs_t *bufs_p, void *ptr, u32 *off)
 {
-    //u32 *off = get_buffer_offset();
     if (off == NULL) {
         return -1;
     }
@@ -598,6 +596,7 @@ static __always_inline int events_perf_submit(struct pt_regs *ctx, u32 *base_off
 
     void *data = &bufs_p->buf[(*base_off & ((MAX_BUFFER_SIZE>>2) - 1))];
     u32 size = (*off & (MAX_BUFFER_SIZE - 1)) - (*base_off & ((MAX_BUFFER_SIZE>>2) - 1));
+
     return sys_events.perf_submit(ctx, data, size & (MAX_BUF_ELEM_SIZE - 1));
 }
 
@@ -643,6 +642,7 @@ int syscall__execve(struct pt_regs *ctx,
     bufs_t *bufs_p = get_buffer();
     if (bufs_p == NULL)
         return 0;
+
     save_context_to_buffer(bufs_p, (void*)&context, &off);
 
     save_str_to_buffer(bufs_p, (void *)filename, &off);
@@ -721,8 +721,6 @@ int syscall__execveat(struct pt_regs *ctx,
     context.argnum = 4;
     context.retval = 0;
 
-    //set_buffer_offset(sizeof(sys_context_t));
-
     u32 *off_global = get_buffer_offset();
     if (off_global == NULL) {
         return -1;
@@ -747,6 +745,7 @@ int syscall__execveat(struct pt_regs *ctx,
     bufs_t *bufs_p = get_buffer();
     if (bufs_p == NULL)
         return 0;
+
     save_context_to_buffer(bufs_p, (void*)&context, &off);
 
     save_to_buffer(bufs_p, (void*)&dirfd, sizeof(int), INT_T, &off);
@@ -777,12 +776,10 @@ int trace_ret_execveat(struct pt_regs *ctx)
         return 0;
     }
 
-
     u32 *off_global = get_buffer_offset();
     if (off_global == NULL) {
         return -1;
     }
-
 
     u32 base_off = (*off_global) & ((MAX_BUFFER_SIZE) - 1);
     *off_global += MAX_BUF_ELEM_SIZE;
@@ -825,12 +822,10 @@ int trace_do_exit(struct pt_regs *ctx, long code)
 
     remove_pid_ns();
 
-
     u32 *off_global = get_buffer_offset();
     if (off_global == NULL) {
         return -1;
     }
-
 
     u32 base_off = (*off_global) & ((MAX_BUFFER_SIZE) - 1);
     *off_global += MAX_BUF_ELEM_SIZE;
@@ -851,6 +846,7 @@ int trace_do_exit(struct pt_regs *ctx, long code)
     bufs_t *bufs_p = get_buffer();
     if (bufs_p == NULL)
         return 0;
+
     save_context_to_buffer(bufs_p, (void*)&context, &off);
 
     events_perf_submit(ctx, &base_off, &off);
@@ -971,6 +967,7 @@ static __always_inline int trace_ret_generic(u32 id, struct pt_regs *ctx, u64 ty
     bufs_t *bufs_p = get_buffer();
     if (bufs_p == NULL)
         return 0;
+
     save_context_to_buffer(bufs_p, (void*)&context, &off);
     save_args_to_buffer(types, &args, &off);
 


### PR DESCRIPTION
This PR makes it possible to save events to buffer in a first come first serve manner. This will reduce lost events count which occurs due to buffer being overwritten.
Assumptions are that each event requires at max ~~256~~ 2048 bytes and so for every event these many bytes are incremented to bufs_offset value. It adds a new constant MAX_BUF_ELEM_SIZE which should always be a power of 2.
Each event maintains it's offset info as two local variables off and base_off for storing offset and base offset respectively.


Fixes: #249