### PR TITLE
Update: Audit Policy CRD,  k8sAuditPolicyConvert

### DIFF
--- a/KubeArmor/core/kubeUpdate.go
+++ b/KubeArmor/core/kubeUpdate.go
@@ -1577,7 +1577,7 @@ func k8sAuditPolicyConvert(k8sAuditPolicySpec tp.K8sAuditPolicySpec) ([]tp.Audit
 
 	defaultSeverity := int64(1)
 	if k8sAuditPolicySpec.Severity != "" {
-		if severity, err := strconv.ParseInt(k8sAuditPolicySpec.Severity, 0, 32); err == nil {
+		if severity, err := strconv.ParseInt(strings.TrimSpace(k8sAuditPolicySpec.Severity), 0, 32); err == nil {
 			defaultSeverity = severity
 		} else {
 			message := fmt.Sprintf("Cannot convert '%v' (K8sAuditPolicySpec.Severity) to int", k8sAuditPolicySpec.Severity)
@@ -1625,7 +1625,7 @@ func k8sAuditPolicyConvert(k8sAuditPolicySpec tp.K8sAuditPolicySpec) ([]tp.Audit
 
 		// set severity
 		if rule.Severity != "" {
-			if severity, err := strconv.ParseInt(rule.Severity, 0, 32); err == nil {
+			if severity, err := strconv.ParseInt(strings.TrimSpace(rule.Severity), 0, 32); err == nil {
 				auditPolicies[i].Severity = int(severity)
 			} else {
 				message := fmt.Sprintf("Cannot convert '%v' (K8sAuditPolicySpec.AuditRules[%v].Severity) to int", rule.Severity, i)
@@ -1645,7 +1645,7 @@ func k8sAuditPolicyConvert(k8sAuditPolicySpec tp.K8sAuditPolicySpec) ([]tp.Audit
 			auditPolicies[i].Events[j].Directory = ruleEvent.Directory
 
 			if ruleEvent.Mode != "" {
-				if number, err := strconv.ParseInt(ruleEvent.Mode, 0, 32); err == nil {
+				if number, err := strconv.ParseInt(strings.TrimSpace(ruleEvent.Mode), 0, 32); err == nil {
 					auditPolicies[i].Events[j].Mode = int(number)
 				} else {
 					message := fmt.Sprintf("Cannot convert '%v' (K8sAuditPolicySpec.AuditRules[%v].Events[%v].Mode) to int", ruleEvent.Mode, i, j)
@@ -1658,7 +1658,7 @@ func k8sAuditPolicyConvert(k8sAuditPolicySpec tp.K8sAuditPolicySpec) ([]tp.Audit
 			auditPolicies[i].Events[j].Ipv6Addr = ruleEvent.Ipv6Addr
 
 			if ruleEvent.Port != "" {
-				if number, err := strconv.ParseInt(ruleEvent.Port, 0, 32); err == nil {
+				if number, err := strconv.ParseInt(strings.TrimSpace(ruleEvent.Port), 0, 32); err == nil {
 					auditPolicies[i].Events[j].Port = int(number)
 				} else {
 					message := fmt.Sprintf("Cannot convert '%v' (K8sAuditPolicySpec.AuditRules[%v].Events[%v].Port) to int", ruleEvent.Port, i, j)

--- a/deployments/CRD/KubeArmorAuditPolicy.yaml
+++ b/deployments/CRD/KubeArmorAuditPolicy.yaml
@@ -46,7 +46,7 @@ spec:
                       items:
                         properties:
                           dir:
-                            pattern: ^/([A-z0-9-.]+/)*([A-z0-9-.]+)+/$
+                            pattern: ^\/$|^\/([A-z0-9-_.*]+\/)*([A-z0-9-_.*]+)+\/$
                             type: string
                           ipv4addr:
                             type: string
@@ -55,7 +55,7 @@ spec:
                           mode:
                             type: string
                           path:
-                            pattern: ^\/([A-z0-9-_.]+\/)*([A-z0-9-_.]+)$
+                            pattern: ^\/([A-z0-9-_.*]+\/)*([A-z0-9-_.*]+)$
                             type: string
                           port:
                             type: string

--- a/helm/templates/security.kubearmor.com_kubearmorauditpolicies.yaml
+++ b/helm/templates/security.kubearmor.com_kubearmorauditpolicies.yaml
@@ -46,7 +46,7 @@ spec:
                       items:
                         properties:
                           dir:
-                            pattern: ^/([A-z0-9-.]+/)*([A-z0-9-.]+)+/$
+                            pattern: ^\/$|^\/([A-z0-9-_.*]+\/)*([A-z0-9-_.*]+)+\/$
                             type: string
                           ipv4addr:
                             type: string
@@ -55,7 +55,7 @@ spec:
                           mode:
                             type: string
                           path:
-                            pattern: ^\/([A-z0-9-_.]+\/)*([A-z0-9-_.]+)$
+                            pattern: ^\/([A-z0-9-_.*]+\/)*([A-z0-9-_.*]+)$
                             type: string
                           port:
                             type: string

--- a/pkg/KubeArmorAuditPolicy/api/v1/kubearmorauditpolicy_types.go
+++ b/pkg/KubeArmorAuditPolicy/api/v1/kubearmorauditpolicy_types.go
@@ -15,9 +15,9 @@ type EventType struct {
 
 	// file related arguments
 
-	// +kubebuilder:validation:Pattern=^\/([A-z0-9-_.]+\/)*([A-z0-9-_.]+)$
+	// +kubebuilder:validation:Pattern=^\/([A-z0-9-_.*]+\/)*([A-z0-9-_.*]+)$
 	Path string `json:"path,omitempty"`
-	// 	+kubebuilder:validation:Pattern=^/([A-z0-9-.]+/)*([A-z0-9-.]+)+/$
+	// +kubebuilder:validation:Pattern=^\/$|^\/([A-z0-9-_.*]+\/)*([A-z0-9-_.*]+)+\/$
 	Directory string `json:"dir,omitempty"`
 	// +kubebuilder:validation:Optional
 	Mode string `json:"mode,omitempty"`

--- a/pkg/KubeArmorAuditPolicy/config/crd/bases/security.kubearmor.com_kubearmorauditpolicies.yaml
+++ b/pkg/KubeArmorAuditPolicy/config/crd/bases/security.kubearmor.com_kubearmorauditpolicies.yaml
@@ -46,7 +46,7 @@ spec:
                       items:
                         properties:
                           dir:
-                            pattern: ^/([A-z0-9-.]+/)*([A-z0-9-.]+)+/$
+                            pattern: ^\/$|^\/([A-z0-9-_.*]+\/)*([A-z0-9-_.*]+)+\/$
                             type: string
                           ipv4addr:
                             type: string
@@ -55,7 +55,7 @@ spec:
                           mode:
                             type: string
                           path:
-                            pattern: ^\/([A-z0-9-_.]+\/)*([A-z0-9-_.]+)$
+                            pattern: ^\/([A-z0-9-_.*]+\/)*([A-z0-9-_.*]+)$
                             type: string
                           port:
                             type: string


### PR DESCRIPTION
- `Audit Policy CRD`: update kubebuilder validation pattern to allow the '*' char on pathnames.
-  `k8sAuditPolicyConvert`: remove whitespaces from integer fields (before conversion).