### PR TITLE
event-auditor: cleaning up failures

### DIFF
--- a/KubeArmor/eventAuditor/ebpfCommon.go
+++ b/KubeArmor/eventAuditor/ebpfCommon.go
@@ -9,7 +9,7 @@ import (
 	lbpf "github.com/kubearmor/libbpf"
 )
 
-// KABPFObjName type
+// KABPFObjFileName type
 type KABPFObjFileName string
 
 // KABPFMapName type

--- a/KubeArmor/eventAuditor/processSpecHandler.go
+++ b/KubeArmor/eventAuditor/processSpecHandler.go
@@ -42,7 +42,7 @@ func (ea *EventAuditor) DestroyProcessMaps(bman *KABPFManager) error {
 	return AppendErrors(err1, err2, err3)
 }
 
-// InitializeProcessProgs Function
+// InitializeProcessPrograms Function
 func (ea *EventAuditor) InitializeProcessPrograms(bman *KABPFManager) error {
 	if bman == nil {
 		return errors.New("bpf manager cannot be nil")
@@ -58,7 +58,7 @@ func (ea *EventAuditor) InitializeProcessPrograms(bman *KABPFManager) error {
 	return AppendErrors(err1, err2, err3, err4)
 }
 
-// DestroyProcessMaps Function
+// DestroyProcessPrograms Function
 func (ea *EventAuditor) DestroyProcessPrograms(bman *KABPFManager) error {
 	if bman == nil {
 		return errors.New("bpf manager cannot be nil")


### PR DESCRIPTION
This PR checks errors from `SetObjsMapsPath()` and `SetObjsProgsPath()`, fixes #344 destroying already initialized objects in reverse order and fix comments due function name changes.