### PR TITLE
event-auditor: introduce match() for patterns

### DIFF
--- a/KubeArmor/BPF/maps.bpf.h
+++ b/KubeArmor/BPF/maps.bpf.h
@@ -8,7 +8,7 @@
 #include "shared.h"
 
 struct pattern_key {
-	char pattern[PATTERN_MAX_LEN];
+	char pattern[MAX_PATTERN_LEN];
 };
 
 struct pattern_value {

--- a/KubeArmor/BPF/shared.h
+++ b/KubeArmor/BPF/shared.h
@@ -5,19 +5,10 @@
 #define __SHARED_H
 
 #define TASK_COMM_LEN 16
-#define MAX_FILENAME_LEN 256
-#define PATTERN_MAX_LEN TASK_COMM_LEN
+#define MAX_FILENAME_LEN 42 // verifier limit for match() unrolling
+#define MAX_PATTERN_LEN 7   // verifier limit for match() unrolling
 
 #define get_dynamic_array(entry, field) \
 	((void *)entry + (entry->__data_loc_##field & 0xffff))
-
-struct task_context {
-	unsigned int pid;
-	unsigned int tid;
-	unsigned int pid_ns;
-	unsigned int mnt_ns;
-	char comm[TASK_COMM_LEN];
-	char filename[MAX_FILENAME_LEN];
-};
 
 #endif /* __SHARED_H */

--- a/KubeArmor/eventAuditor/ebpfCommon.go
+++ b/KubeArmor/eventAuditor/ebpfCommon.go
@@ -32,7 +32,13 @@ type KABPFProg struct {
 	Name      KABPFProgName
 	EventName KABPFEventName
 	EventType lbpf.KABPFLinkType
+	TailProgs []KABPFTailProg
 	FileName  KABPFObjFileName
+}
+
+type KABPFTailProg struct {
+	Name  KABPFProgName
+	Index uint32
 }
 
 // KABPFPinBasePath constant

--- a/KubeArmor/eventAuditor/eventAuditor.go
+++ b/KubeArmor/eventAuditor/eventAuditor.go
@@ -55,6 +55,11 @@ func NewEventAuditor(feeder *fd.Feeder) *EventAuditor {
 		goto fail1
 	}
 
+	if err := ea.PopulateProcessJMPMap(ea.BPFManager); err != nil {
+		ea.Logger.Errf("Failed to populate process jmp map: %v", err)
+		return nil
+	}
+
 	// initialize entrypoints
 	if !ea.InitializeEntryPoints() {
 		ea.Logger.Err("Failed to initialize entrypoints")

--- a/KubeArmor/eventAuditor/processProgs.go
+++ b/KubeArmor/eventAuditor/processProgs.go
@@ -7,9 +7,11 @@ import lbpf "github.com/kubearmor/libbpf"
 
 // KubeArmor Event Auditor Programs
 const (
-	KAEASysExecveProg     KABPFProgName    = "ka_ea_sched_process_exec"
-	KAEASysExecveEvent    KABPFEventName   = "sched:sched_process_exec"
-	KAEASysExecveProgFile KABPFObjFileName = "ka_ea_process.bpf.o"
+	KAEASysExecveProg      KABPFProgName    = "ka_ea_sched_process_exec"
+	KAEASysExecveEvent     KABPFEventName   = "sched:sched_process_exec"
+	KAEASysExecveTailProg0 KABPFProgName    = "ka_ea_sched_process_exec_0"
+	KAEASysExecveTailProg1 KABPFProgName    = "ka_ea_sched_process_exec_1"
+	KAEASysExecveProgFile  KABPFObjFileName = "ka_ea_process.bpf.o"
 
 	KAEASysExitProg     KABPFProgName    = "ka_ea_sched_process_exit"
 	KAEASysExitEvent    KABPFEventName   = "sched:sched_process_exit"
@@ -24,13 +26,24 @@ func KAEAGetProg(name KABPFProgName) KABPFProg {
 			Name:      KAEASysExecveProg,
 			EventName: KAEASysExecveEvent,
 			EventType: lbpf.KABPFLinkTypeTracepoint,
-			FileName:  KAEASysExecveProgFile,
+			TailProgs: []KABPFTailProg{
+				{
+					Name:  KAEASysExecveTailProg0,
+					Index: 0,
+				},
+				{
+					Name:  KAEASysExecveTailProg1,
+					Index: 1,
+				},
+			},
+			FileName: KAEASysExecveProgFile,
 		}
 	case KAEASysExitProg:
 		return KABPFProg{
 			Name:      KAEASysExitProg,
 			EventName: KAEASysExitEvent,
 			EventType: lbpf.KABPFLinkTypeTracepoint,
+			TailProgs: []KABPFTailProg{},
 			FileName:  KAEASysExitProgFile,
 		}
 	default:
@@ -38,6 +51,7 @@ func KAEAGetProg(name KABPFProgName) KABPFProg {
 			Name:      "",
 			EventName: "",
 			EventType: lbpf.KABPFLinkTypeUnspec,
+			TailProgs: []KABPFTailProg{},
 			FileName:  "",
 		}
 	}

--- a/KubeArmor/eventAuditor/sharedMaps.go
+++ b/KubeArmor/eventAuditor/sharedMaps.go
@@ -18,6 +18,9 @@ import (
 
 // KubeArmor Event Auditor Maps
 const (
+	KAEAProcessJMPMap     KABPFMapName     = "ka_ea_process_jmp_map"
+	KAEAProcessJMPMapFile KABPFObjFileName = "ka_ea_process.bpf.o"
+
 	KAEAPatternMap     KABPFMapName     = "ka_ea_pattern_map"
 	KAEAPatternMapFile KABPFObjFileName = "ka_ea_process.bpf.o"
 
@@ -40,6 +43,11 @@ const (
 // KAEAGetMap Function
 func KAEAGetMap(name KABPFMapName) KABPFMap {
 	switch name {
+	case KAEAProcessJMPMap:
+		return KABPFMap{
+			Name:     KAEAProcessJMPMap,
+			FileName: KAEAProcessJMPMapFile,
+		}
 	case KAEAPatternMap:
 		return KABPFMap{
 			Name:     KAEAPatternMap,
@@ -79,11 +87,51 @@ func KAEAGetMap(name KABPFMapName) KABPFMap {
 }
 
 // =========================== //
+// ===== Process JMP Map ===== //
+// =========================== //
+
+// ProcessJMPMapElement Structure
+type ProcessJMPMapElement struct {
+	Key   uint32
+	Value uint32
+}
+
+// SetKey Function (ProcessJMPMapElement)
+func (pme *ProcessJMPMapElement) SetKey(index uint32) {
+	pme.Key = index
+}
+
+// SetValue Function (ProcessJMPMapElement)
+func (pme *ProcessJMPMapElement) SetValue(progFD uint32) {
+	pme.Value = progFD
+}
+
+// SetFoundValue Function (ProcessJMPMapElement)
+func (pme *ProcessJMPMapElement) SetFoundValue(value []byte) {
+	pme.Value = binary.LittleEndian.Uint32(value)
+}
+
+// KeyPointer Function (ProcessJMPMapElement)
+func (pme *ProcessJMPMapElement) KeyPointer() unsafe.Pointer {
+	return unsafe.Pointer(&pme.Key)
+}
+
+// ValuePointer Function (ProcessJMPMapElement)
+func (pme *ProcessJMPMapElement) ValuePointer() unsafe.Pointer {
+	return unsafe.Pointer(&pme.Value)
+}
+
+// MapName Function (ProcessJMPMapElement)
+func (pme *ProcessJMPMapElement) MapName() string {
+	return string(KAEAProcessJMPMap)
+}
+
+// =========================== //
 // ======= Pattern Map ======= //
 // =========================== //
 
 // PatternMaxLen constant
-const PatternMaxLen = int(C.PATTERN_MAX_LEN)
+const PatternMaxLen = int(C.MAX_PATTERN_LEN)
 
 // PatternMapElement Structure
 type PatternMapElement struct {


### PR DESCRIPTION
This PR (continuation of #313) brings a lot of changes attempting to shrink a basic match()
function into the ka_ea_process.bpf.c program.

match() treats only the '*' and '?' wildcards. Its algorithm is inspired by
two sources [1-2], being modified to satisfy the ebpf verifier when it comes
to bounded loops.

Despite the algorithm design undertaken, the verifier still complained of
1 million instructions being exceeded.

Two decisions were made:

- reduce iterations (reducing MAX_FILENAME_LEN from to 256 to 42 and
  MAX_PATTERN_LEN (former PATTERN_MAX_LEN) from 16 to 7.
- split the ebpf program logic into 3 making use of tail calls,
  leaving one entirely for the match() logic.

After these, the verifier didn't complain.

The first decision was taken as a temporary measure giving rise to
questions about the design:

- Would '#pragma unroll n' be a solution? (this committer was unable
  to find a magic n)
- Should we take another route for pattern matching?

This commit also adds:

- ka_ea_process_jmp_map to ka_ea_process.bpf.c
- global variables accessible from the tail programs through .bss map
- get_task_filename - program logic split
- get_task_ids() - program logic split
- task_auditable_0() and task_auditable_1() - program logic split
- ka_ea_sched_process_exec_0() and ka_ea_sched_process_exec_1() - program
  logic split
- check_hash_elem() - handler for bpf_for_each_map_elem() iterator
- callback_ctx struct - input/output for the check_hash_elem()

- KABPFTailProg struct to ebpfCommon.go - and put it as a KABPFProg slice field
- ProcessJMPMapElement struct and methods to sharedMaps.go
- PopulateProcessJMPMap() to processSpecHandler.go

This gets rid of:

- task_context struct
- get_task_context()

[1] https://github.com/kirkjkrauss/MatchingWildcards/blob/master/Listing1.cpp
[2] http://dodobyte.com/wildcard.html