### PR TITLE
event-auditor: populate ka_ea_event_jmp_table and ka_ea_event_filter_map

### DIFF
--- a/KubeArmor/eventAuditor/sharedMaps.go
+++ b/KubeArmor/eventAuditor/sharedMaps.go
@@ -362,6 +362,11 @@ func (efe *EventFilterElement) SetValue(jumpIdx uint32) {
 	efe.Value.JumpIdx = jumpIdx
 }
 
+// SetFoundValue Function (EventFilterElement)
+func (efe *EventFilterElement) SetFoundValue(value []byte) {
+	efe.Value.JumpIdx = binary.LittleEndian.Uint32(value)
+}
+
 // KeyPointer Function (EventFilterElement)
 func (efe *EventFilterElement) KeyPointer() unsafe.Pointer {
 	return unsafe.Pointer(&efe.Key)
@@ -395,6 +400,11 @@ func (ejte *EventJumpTableElement) SetKey(jumpIdx uint32) {
 // SetValue Function (EventJumpTableElement)
 func (ejte *EventJumpTableElement) SetValue(progFd uint32) {
 	ejte.ProgFD = progFd
+}
+
+// SetFoundValue Function (EventFilterElement)
+func (ejte *EventJumpTableElement) SetFoundValue(value []byte) {
+	ejte.ProgFD = binary.LittleEndian.Uint32(value)
 }
 
 // KeyPointer Function (EventJumpTableElement)


### PR DESCRIPTION
This PR complements the #381 with the following tasks:

- [x] Populates ka_ea_event_jmp_table (progfd for tailcall)
- [x] Populates ka_ea_event_filter_map (index of the target program on ka_ea_event_jmp_table)