### PR TITLE
event-auditor: replace Errf by Warnf for not supported probes

### DIFF
--- a/KubeArmor/eventAuditor/entryPointHandler.go
+++ b/KubeArmor/eventAuditor/entryPointHandler.go
@@ -150,7 +150,7 @@ func (ea *EventAuditor) EnableEntryPoint(probe string) {
 	_, supported := ea.SupportedEntryPoints[probe]
 
 	if !supported {
-		ea.Logger.Errf("%s is currently not supported", probe)
+		ea.Logger.Warnf("%s is currently not supported", probe)
 		return
 	}
 
@@ -172,7 +172,7 @@ func (ea *EventAuditor) DisableEntryPoint(probe string) {
 	_, supported := ea.SupportedEntryPoints[probe]
 
 	if !supported {
-		ea.Logger.Errf("%s is currently not supported", probe)
+		ea.Logger.Warnf("%s is currently not supported", probe)
 		return
 	}
 


### PR DESCRIPTION
This change is just to avoid to dump the stack trace to the user.