### PR TITLE
Handle bitwise OR for mode and flags

### DIFF
--- a/deployments/CRD/KubeArmorAuditPolicy.yaml
+++ b/deployments/CRD/KubeArmorAuditPolicy.yaml
@@ -46,7 +46,6 @@ spec:
                       items:
                         properties:
                           dir:
-                            pattern: ^\/$|^\/([A-z0-9-_.*]+\/)*([A-z0-9-_.*]+)+\/$
                             type: string
                           flags:
                             type: string
@@ -57,7 +56,6 @@ spec:
                           mode:
                             type: string
                           path:
-                            pattern: ^\/([A-z0-9-_.*]+\/)*([A-z0-9-_.*]+)$
                             type: string
                           port:
                             type: string

--- a/examples/multiubuntu/audit-policies/kap_auditpolicy_1.yaml
+++ b/examples/multiubuntu/audit-policies/kap_auditpolicy_1.yaml
@@ -27,7 +27,7 @@ spec:
     events:
     - probe: sys_open
       path: /etc/shadow
-      mode: O_RDWR_APPEND
+      flags: O_RDWR | O_APPEND
   - message: "outbound probes detected (for any process)"
     severity: "5"
     events:

--- a/helm/templates/security.kubearmor.com_kubearmorauditpolicies.yaml
+++ b/helm/templates/security.kubearmor.com_kubearmorauditpolicies.yaml
@@ -46,7 +46,6 @@ spec:
                       items:
                         properties:
                           dir:
-                            pattern: ^\/$|^\/([A-z0-9-_.*]+\/)*([A-z0-9-_.*]+)+\/$
                             type: string
                           flags:
                             type: string
@@ -57,7 +56,6 @@ spec:
                           mode:
                             type: string
                           path:
-                            pattern: ^\/([A-z0-9-_.*]+\/)*([A-z0-9-_.*]+)$
                             type: string
                           port:
                             type: string

--- a/pkg/KubeArmorAuditPolicy/api/v1/kubearmorauditpolicy_types.go
+++ b/pkg/KubeArmorAuditPolicy/api/v1/kubearmorauditpolicy_types.go
@@ -15,9 +15,9 @@ type EventType struct {
 
 	// file related arguments
 
-	// +kubebuilder:validation:Pattern=^\/([A-z0-9-_.*]+\/)*([A-z0-9-_.*]+)$
+	// +kubebuilder:validation:Optional
 	Path string `json:"path,omitempty"`
-	// +kubebuilder:validation:Pattern=^\/$|^\/([A-z0-9-_.*]+\/)*([A-z0-9-_.*]+)+\/$
+	// +kubebuilder:validation:Optional
 	Directory string `json:"dir,omitempty"`
 	// +kubebuilder:validation:Optional
 	Mode string `json:"mode,omitempty"`

--- a/pkg/KubeArmorAuditPolicy/config/crd/bases/security.kubearmor.com_kubearmorauditpolicies.yaml
+++ b/pkg/KubeArmorAuditPolicy/config/crd/bases/security.kubearmor.com_kubearmorauditpolicies.yaml
@@ -46,7 +46,6 @@ spec:
                       items:
                         properties:
                           dir:
-                            pattern: ^\/$|^\/([A-z0-9-_.*]+\/)*([A-z0-9-_.*]+)+\/$
                             type: string
                           flags:
                             type: string
@@ -57,7 +56,6 @@ spec:
                           mode:
                             type: string
                           path:
-                            pattern: ^\/([A-z0-9-_.*]+\/)*([A-z0-9-_.*]+)$
                             type: string
                           port:
                             type: string


### PR DESCRIPTION
This PR contains the following changes:

- [x] Completes the parsing for `flags`.
- [x] Improves the code so we can handle bitwise ORed parameters, like: `O_RDWR | O_APPEND` or `0x400 | 2`.
- [x] Verify the parameters' format before trying to convert the audit policy (from k8s to kubearmor). Any event with invalid/non-expanded parameters are ignored.