### PR TITLE
kubeUpdate.go: fix typo

### DIFF
--- a/KubeArmor/core/kubeUpdate.go
+++ b/KubeArmor/core/kubeUpdate.go
@@ -1934,7 +1934,7 @@ func (dm *KubeArmorDaemon) UpdateAuditPolicies() {
 
 			// if the same namespace:process exists, merge events
 			if _, ok := auditPolicies[key]; ok {
-				mapEntry := dm.AuditPolicies[key]
+				mapEntry := auditPolicies[key]
 				mapEntry.Events = append(mapEntry.Events, policy.Events...)
 				auditPolicies[key] = mapEntry
 			} else {


### PR DESCRIPTION
Fix typo on kubeUpdate.go