### PR TITLE
Builtin Macros

### DIFF
--- a/KubeArmor/BPF/codegen.bpf.h
+++ b/KubeArmor/BPF/codegen.bpf.h
@@ -210,8 +210,8 @@ ka_ea_check_inspect(void)
 	struct process_filter_key key;
 	struct process_filter_value *value;
 
-	key.pid_ns = task_get_pid_ns();
-	key.mnt_ns = task_get_mnt_ns();
+	key.pid_ns = task_get_pid_ns(NULL);
+	key.mnt_ns = task_get_mnt_ns(NULL);
 	key.host_pid = task_get_host_pid();
 
 	value = bpf_map_lookup_elem(__ka_ea_map(ka_ea_process_filter_map), &key);

--- a/KubeArmor/core/kubeUpdate.go
+++ b/KubeArmor/core/kubeUpdate.go
@@ -1722,28 +1722,24 @@ func k8sAuditPolicyMergeMacro(k8sAuditPolicySpec *tp.K8sAuditPolicySpec, macroNa
 			expandMacroField(&k8sAuditPolicySpec.AuditRules[i].Events[j].Directory, macroName, macroValue)
 
 			// expand individual values (Mode)
-			if strings.Contains(k8sAuditPolicySpec.AuditRules[i].Events[j].Mode, "|") {
-				modeValues := strings.Split(k8sAuditPolicySpec.AuditRules[i].Events[j].Mode, "|")
-				for idx := 0; idx < len(modeValues); idx++ {
-					if strings.TrimSpace(modeValues[idx]) == macroName {
-						modeValues[idx] = macroValue
-					}
+			modeValues := strings.Split(k8sAuditPolicySpec.AuditRules[i].Events[j].Mode, "|")
+			for idx := 0; idx < len(modeValues); idx++ {
+				if strings.TrimSpace(modeValues[idx]) == macroName {
+					modeValues[idx] = macroValue
 				}
-
-				k8sAuditPolicySpec.AuditRules[i].Events[j].Mode = strings.Join(modeValues, "|")
 			}
+
+			k8sAuditPolicySpec.AuditRules[i].Events[j].Mode = strings.Join(modeValues, "|")
 
 			// expand individual values (Flags)
-			if strings.Contains(k8sAuditPolicySpec.AuditRules[i].Events[j].Flags, "|") {
-				flagsValues := strings.Split(k8sAuditPolicySpec.AuditRules[i].Events[j].Flags, "|")
-				for idx := 0; idx < len(flagsValues); idx++ {
-					if strings.TrimSpace(flagsValues[idx]) == macroName {
-						flagsValues[idx] = macroValue
-					}
+			flagsValues := strings.Split(k8sAuditPolicySpec.AuditRules[i].Events[j].Flags, "|")
+			for idx := 0; idx < len(flagsValues); idx++ {
+				if strings.TrimSpace(flagsValues[idx]) == macroName {
+					flagsValues[idx] = macroValue
 				}
-
-				k8sAuditPolicySpec.AuditRules[i].Events[j].Flags = strings.Join(flagsValues, "|")
 			}
+
+			k8sAuditPolicySpec.AuditRules[i].Events[j].Flags = strings.Join(flagsValues, "|")
 
 			expandMacroField(&k8sAuditPolicySpec.AuditRules[i].Events[j].Protocol, macroName, macroValue)
 			expandMacroField(&k8sAuditPolicySpec.AuditRules[i].Events[j].Ipv4Addr, macroName, macroValue)
@@ -1930,6 +1926,11 @@ func (dm *KubeArmorDaemon) UpdateAuditPolicies() {
 		if err := kl.Clone(k8sPolicy.Spec, &k8sAuditPolicySpec); err != nil {
 			dm.Logger.Errf("Failed to clone spec for k8sPolicy %s", k8sPolicy.Metadata.Name)
 			continue
+		}
+
+		// merge builtin macros
+		for macroName, macroValue := range edt.KAEABuiltinMacros {
+			k8sAuditPolicyMergeMacro(&k8sAuditPolicySpec, macroName, macroValue)
 		}
 
 		// merge macros

--- a/KubeArmor/eventAuditor/eventAuditor.go
+++ b/KubeArmor/eventAuditor/eventAuditor.go
@@ -18,6 +18,53 @@ import (
 // == Event Auditor == //
 // =================== //
 
+// Builtin Macro Definitions
+var KAEABuiltinMacros = map[string]string{
+	// from fcntl.h
+	"O_ACCMODE":      "00000003",
+	"O_RDONLY":       "00000000",
+	"O_WRONLY":       "00000001",
+	"O_RDWR":         "00000002",
+	"O_CREAT":        "00000100",
+	"O_EXCL":         "00000200",
+	"O_NOCTTY":       "00000400",
+	"O_TRUNC":        "00001000",
+	"O_APPEND":       "00002000",
+	"O_NONBLOCK":     "00004000",
+	"O_DSYNC":        "00010000",
+	"FASYNC":         "00040000",
+	"O_DIRECT":       "00000003",
+	"O_LARGEFILE":    "00100000",
+	"O_DIRECTORY":    "00200000",
+	"O_NOFOLLOW":     "00400000",
+	"O_NOATIME":      "01000000",
+	"O_CLOEXEC":      "02000000",
+	"O_PATH":         "010000000",
+	"__O_SYNC":       "04000000",
+	"O_SYNC":         "__O_SYNC | O_DSYNC",
+	"__O_TMPFILE":    "020000000",
+	"O_TMPFILE":      "__O_TMPFILE | O_DIRECTORY",
+	"O_TMPFILE_MASK": "__O_TMPFILE | O_DIRECTORY | O_CREAT",
+	"O_NDELAY":       "O_NONBLOCK",
+
+	// from open(2) — Linux manual page
+	"S_IRWXU": "00700",
+	"S_IRUSR": "00400",
+	"S_IWUSR": "00200",
+	"S_IXUSR": "00100",
+	"S_IRWXG": "00070",
+	"S_IRGRP": "00040",
+	"S_IWGRP": "00020",
+	"S_IXGRP": "00010",
+	"S_IRWXO": "00007",
+	"S_IROTH": "00004",
+	"S_IWOTH": "00002",
+	"S_IXOTH": "00001",
+	"S_ISUID": "0004000",
+	"S_ISGID": "0002000",
+	"S_ISVTX": "0001000",
+}
+
 // EventAuditor Structure
 type EventAuditor struct {
 	// logs

--- a/examples/multiubuntu/audit-policies/kmc_macro_1.yaml
+++ b/examples/multiubuntu/audit-policies/kmc_macro_1.yaml
@@ -16,12 +16,3 @@ spec:
 
   - name: NON-EXTERNAL-IPV6
     value: fe80::37be:*:*:*
-
-  - name: O_RDWR
-    value: "2"
-
-  - name: O_APPEND
-    value: "0x400"
-
-  - name: O_RDWR_APPEND
-    value: 0x400 | 2


### PR DESCRIPTION
- [x] Define initial values for builtin macros. For now we have values from `fcntl.h` and from `open(2) linux manual`.
- [x] Merge builtin before user-defined macros.

Additionally 
- [x] Update `codegen.bpf.h` including the arguments in the `task_get_{pid,mnt}_ns` calls.
- [x] Remove unnecessary definitions on macro sample.
- [x] Fix macro expansion error (when there is no `|` definition).