### PR TITLE
minor updates

### DIFF
--- a/KubeArmor/Makefile
+++ b/KubeArmor/Makefile
@@ -54,7 +54,7 @@ testall:
 
 .PHONY: gofmt
 gofmt:
-	cd $(CURDIR); gofmt -s -d $(shell find . -type f -name '*.go' -print)
+	cd $(CURDIR); gofmt -s -w -d $(shell find . -type f -name '*.go' -print)
 
 .PHONY: golint
 golint:

--- a/KubeArmor/enforcer/SELinuxEnforcer_test.go
+++ b/KubeArmor/enforcer/SELinuxEnforcer_test.go
@@ -47,6 +47,12 @@ func TestSELinuxEnforcer(t *testing.T) {
 	enforcer := NewSELinuxEnforcer(logger)
 	if enforcer == nil {
 		t.Log("[FAIL] Failed to create SELinux Enforcer")
+
+		if err := logger.DestroyFeeder(); err != nil {
+			t.Log("[FAIL] Failed to destroy logger")
+			return
+		}
+
 		return
 	}
 	t.Log("[PASS] Created SELinux Enforcer")
@@ -54,6 +60,12 @@ func TestSELinuxEnforcer(t *testing.T) {
 	// destroy SELinux Enforcer
 	if err := enforcer.DestroySELinuxEnforcer(); err != nil {
 		t.Log("[FAIL] Failed to destroy SELinux Enforcer")
+
+		if err := logger.DestroyFeeder(); err != nil {
+			t.Log("[FAIL] Failed to destroy logger")
+			return
+		}
+
 		return
 	}
 	t.Log("[PASS] Destroyed SELinux Enforcer")

--- a/KubeArmor/enforcer/appArmorEnforcer_test.go
+++ b/KubeArmor/enforcer/appArmorEnforcer_test.go
@@ -47,6 +47,12 @@ func TestAppArmorEnforcer(t *testing.T) {
 	enforcer := NewAppArmorEnforcer(node, logger)
 	if enforcer == nil {
 		t.Log("[FAIL] Failed to create AppArmor Enforcer")
+
+		if err := logger.DestroyFeeder(); err != nil {
+			t.Log("[FAIL] Failed to destroy logger")
+			return
+		}
+
 		return
 	}
 	t.Log("[PASS] Created AppArmor Enforcer")
@@ -54,6 +60,12 @@ func TestAppArmorEnforcer(t *testing.T) {
 	// destroy AppArmor Enforcer
 	if err := enforcer.DestroyAppArmorEnforcer(); err != nil {
 		t.Log("[FAIL] Failed to destroy AppArmor Enforcer")
+
+		if err := logger.DestroyFeeder(); err != nil {
+			t.Log("[FAIL] Failed to destroy logger")
+			return
+		}
+
 		return
 	}
 	t.Log("[PASS] Destroyed AppArmor Enforcer")
@@ -100,6 +112,12 @@ func TestAppArmorProfile(t *testing.T) {
 	enforcer := NewAppArmorEnforcer(node, logger)
 	if enforcer == nil {
 		t.Log("[FAIL] Failed to create AppArmor Enforcer")
+
+		if err := logger.DestroyFeeder(); err != nil {
+			t.Log("[FAIL] Failed to destroy logger")
+			return
+		}
+
 		return
 	}
 	t.Log("[PASS] Created AppArmor Enforcer")
@@ -107,6 +125,23 @@ func TestAppArmorProfile(t *testing.T) {
 	// register AppArmorProfile
 	if ok := enforcer.RegisterAppArmorProfile("test-profile"); !ok {
 		t.Error("[FAIL] Failed to register AppArmorProfile")
+
+		if err := enforcer.DestroyAppArmorEnforcer(); err != nil {
+			t.Log("[FAIL] Failed to destroy AppArmor Enforcer")
+
+			if err := logger.DestroyFeeder(); err != nil {
+				t.Log("[FAIL] Failed to destroy logger")
+				return
+			}
+
+			return
+		}
+
+		if err := logger.DestroyFeeder(); err != nil {
+			t.Log("[FAIL] Failed to destroy logger")
+			return
+		}
+
 		return
 	}
 	t.Log("[PASS] Registered AppArmorProfile")
@@ -114,6 +149,23 @@ func TestAppArmorProfile(t *testing.T) {
 	// unregister AppArmorProfile
 	if ok := enforcer.UnregisterAppArmorProfile("test-profile"); !ok {
 		t.Error("[FAIL] Failed to unregister AppArmorProfile")
+
+		if err := enforcer.DestroyAppArmorEnforcer(); err != nil {
+			t.Log("[FAIL] Failed to destroy AppArmor Enforcer")
+
+			if err := logger.DestroyFeeder(); err != nil {
+				t.Log("[FAIL] Failed to destroy logger")
+				return
+			}
+
+			return
+		}
+
+		if err := logger.DestroyFeeder(); err != nil {
+			t.Log("[FAIL] Failed to destroy logger")
+			return
+		}
+
 		return
 	}
 	t.Log("[PASS] Unregister AppArmorProfile")
@@ -121,6 +173,12 @@ func TestAppArmorProfile(t *testing.T) {
 	// destroy AppArmor Enforcer
 	if err := enforcer.DestroyAppArmorEnforcer(); err != nil {
 		t.Log("[FAIL] Failed to destroy AppArmor Enforcer")
+
+		if err := logger.DestroyFeeder(); err != nil {
+			t.Log("[FAIL] Failed to destroy logger")
+			return
+		}
+
 		return
 	}
 	t.Log("[PASS] Destroyed AppArmor Enforcer")
@@ -167,6 +225,12 @@ func TestHostAppArmorProfile(t *testing.T) {
 	enforcer := NewAppArmorEnforcer(node, logger)
 	if enforcer == nil {
 		t.Log("[FAIL] Failed to create AppArmor Enforcer")
+
+		if err := logger.DestroyFeeder(); err != nil {
+			t.Log("[FAIL] Failed to destroy logger")
+			return
+		}
+
 		return
 	}
 	t.Log("[PASS] Created AppArmor Enforcer")
@@ -174,6 +238,12 @@ func TestHostAppArmorProfile(t *testing.T) {
 	// destroy AppArmor Enforcer
 	if err := enforcer.DestroyAppArmorEnforcer(); err != nil {
 		t.Log("[FAIL] Failed to destroy AppArmor Enforcer")
+
+		if err := logger.DestroyFeeder(); err != nil {
+			t.Log("[FAIL] Failed to destroy logger")
+			return
+		}
+
 		return
 	}
 	t.Log("[PASS] Destroyed AppArmor Enforcer")

--- a/KubeArmor/monitor/systemMonitor_test.go
+++ b/KubeArmor/monitor/systemMonitor_test.go
@@ -51,6 +51,12 @@ func TestSystemMonitor(t *testing.T) {
 		&ActivePidMap, &ActiveHostPidMap, &ActivePidMapLock, &ActiveHostMap, &ActiveHostMapLock)
 	if systemMonitor == nil {
 		t.Log("[FAIL] Failed to create SystemMonitor")
+
+		if err := logger.DestroyFeeder(); err != nil {
+			t.Log("[FAIL] Failed to destroy logger")
+			return
+		}
+
 		return
 	}
 	t.Log("[PASS] Created SystemMonitor")
@@ -58,6 +64,13 @@ func TestSystemMonitor(t *testing.T) {
 	// Destroy System Monitor
 	if err := systemMonitor.DestroySystemMonitor(); err != nil {
 		t.Log("[FAIL] Failed to destroy SystemMonitor")
+
+		if err := logger.DestroyFeeder(); err != nil {
+			t.Log("[FAIL] Failed to destroy logger")
+			return
+		}
+
+		return
 	}
 	t.Log("[PASS] Destroyed SystemMonitor")
 
@@ -106,6 +119,12 @@ func TestTraceSyscallWithPod(t *testing.T) {
 		&ActivePidMap, &ActiveHostPidMap, &ActivePidMapLock, &ActiveHostMap, &ActiveHostMapLock)
 	if systemMonitor == nil {
 		t.Log("[FAIL] Failed to create SystemMonitor")
+
+		if err := logger.DestroyFeeder(); err != nil {
+			t.Log("[FAIL] Failed to destroy logger")
+			return
+		}
+
 		return
 	}
 	t.Log("[PASS] Created SystemMonitor")
@@ -113,6 +132,23 @@ func TestTraceSyscallWithPod(t *testing.T) {
 	// Initialize BPF
 	if err := systemMonitor.InitBPF(); err != nil {
 		t.Errorf("[FAIL] Failed to initialize BPF (%s)", err.Error())
+
+		if err := systemMonitor.DestroySystemMonitor(); err != nil {
+			t.Log("[FAIL] Failed to destroy SystemMonitor")
+
+			if err := logger.DestroyFeeder(); err != nil {
+				t.Log("[FAIL] Failed to destroy logger")
+				return
+			}
+
+			return
+		}
+
+		if err := logger.DestroyFeeder(); err != nil {
+			t.Log("[FAIL] Failed to destroy logger")
+			return
+		}
+
 		return
 	}
 	t.Logf("[PASS] Initialized BPF (for containers)")
@@ -130,6 +166,13 @@ func TestTraceSyscallWithPod(t *testing.T) {
 	// Destroy System Monitor
 	if err := systemMonitor.DestroySystemMonitor(); err != nil {
 		t.Log("[FAIL] Failed to destroy SystemMonitor")
+
+		if err := logger.DestroyFeeder(); err != nil {
+			t.Log("[FAIL] Failed to destroy logger")
+			return
+		}
+
+		return
 	}
 	t.Log("[PASS] Destroyed SystemMonitor")
 
@@ -178,6 +221,12 @@ func TestTraceSyscallWithHost(t *testing.T) {
 		&ActivePidMap, &ActiveHostPidMap, &ActivePidMapLock, &ActiveHostMap, &ActiveHostMapLock)
 	if systemMonitor == nil {
 		t.Log("[FAIL] Failed to create SystemMonitor")
+
+		if err := logger.DestroyFeeder(); err != nil {
+			t.Log("[FAIL] Failed to destroy logger")
+			return
+		}
+
 		return
 	}
 	t.Log("[PASS] Created SystemMonitor")
@@ -185,6 +234,23 @@ func TestTraceSyscallWithHost(t *testing.T) {
 	// Initialize BPF
 	if err := systemMonitor.InitBPF(); err != nil {
 		t.Errorf("[FAIL] Failed to initialize BPF (%s)", err.Error())
+
+		if err := systemMonitor.DestroySystemMonitor(); err != nil {
+			t.Log("[FAIL] Failed to destroy SystemMonitor")
+
+			if err := logger.DestroyFeeder(); err != nil {
+				t.Log("[FAIL] Failed to destroy logger")
+				return
+			}
+
+			return
+		}
+
+		if err := logger.DestroyFeeder(); err != nil {
+			t.Log("[FAIL] Failed to destroy logger")
+			return
+		}
+
 		return
 	}
 	t.Logf("[PASS] Initialized BPF (for a host)")
@@ -202,6 +268,13 @@ func TestTraceSyscallWithHost(t *testing.T) {
 	// Destroy System Monitor
 	if err := systemMonitor.DestroySystemMonitor(); err != nil {
 		t.Log("[FAIL] Failed to destroy SystemMonitor")
+
+		if err := logger.DestroyFeeder(); err != nil {
+			t.Log("[FAIL] Failed to destroy logger")
+			return
+		}
+
+		return
 	}
 	t.Log("[PASS] Destroyed SystemMonitor")
 

--- a/contribution/vagrant/Vagrantfile
+++ b/contribution/vagrant/Vagrantfile
@@ -34,7 +34,7 @@ Vagrant.configure("2") do |config|
     cfg.vm.provider "virtualbox" do |vb|
       vb.name = VM_NAME
       vb.memory = 4096
-      vb.cpus = 4
+      vb.cpus = 2
       vb.customize ['modifyvm', :id, '--nested-hw-virt', 'on']
     end
   end


### PR DESCRIPTION
- enforce go-fmt rather than warning some formats
- reduce the number of CPUs for the vagrant environment
   to restrict the resource usage of KubeArmor from the development stage
- add exception handling logic into unit tests