### PR TITLE
Parameter parsing + improvements

### DIFF
--- a/KubeArmor/BPF/codegen.bpf.h
+++ b/KubeArmor/BPF/codegen.bpf.h
@@ -4,9 +4,13 @@
 #ifndef __CODEGEN_BPF_H
 #define __CODEGEN_BPF_H
 
+#include "hash.h"
 #include "runtime.h"
 #include "maps.bpf.h"
 #include "common.bpf.h"
+
+#define ntohs(n) \
+	(((((u16)(n) & 0xFF)) << 8) | (((u16)(n) & 0xFF00) >> 8))
 
 union v4addr {
 	__u32 d1;
@@ -58,154 +62,24 @@ struct syscalls_enter_openat_args {
 	long mode;
 };
 
-struct syscalls_enter_socket_args {
-	unsigned long long unused;
-	long syscall_nr;
-	long family;
-	long type;
-	long protocol;
-};
-
 struct syscalls_enter_connect_args {
 	unsigned long long unused;
 	long syscall_nr;
 	long fd;
-	long uservaddr;
+	long usockaddr;
 	long addrlen;
-};
-
-struct syscalls_enter_accept_args {
-	unsigned long long unused;
-	long syscall_nr;
-	long fd;
-	long upeer_sockaddr;
-	long upeer_addrlen_ptr;
 };
 
 struct syscalls_enter_bind_args {
 	unsigned long long unused;
 	long syscall_nr;
 	long fd;
-	long umyaddr;
+	long usockaddr;
 	long addrlen;
 };
 
-static inline const char *
-tp_sys_execve_path(struct syscalls_enter_execve_args *ctx)
-{
-	return 0;
-}
-
-static inline const char *
-tp_sys_execveat_path(struct syscalls_enter_execveat_args *ctx)
-{
-	return 0;
-}
-
-static inline int
-tp_sys_execveat_flags(struct syscalls_enter_execveat_args *ctx)
-{
-	return 0;
-}
-
-static inline const char *
-tp_sys_open_path(struct syscalls_enter_open_args *ctx)
-{
-	return 0;
-}
-
-static inline int
-tp_sys_open_flags(struct syscalls_enter_open_args *ctx)
-{
-	return 0;
-}
-
-static inline umode_t
-tp_sys_open_mode(struct syscalls_enter_open_args *ctx)
-{
-	return 0;
-}
-
-static inline const char *
-tp_sys_openat_path(struct syscalls_enter_openat_args *ctx)
-{
-	return 0;
-}
-
-static inline int
-tp_sys_openat_flags(struct syscalls_enter_openat_args *ctx)
-{
-	return 0;
-}
-
-static inline umode_t
-tp_sys_openat_mode(struct syscalls_enter_openat_args *ctx)
-{
-	return 0;
-}
-
-static inline int
-tp_sys_socket_protocol(struct syscalls_enter_socket_args *ctx)
-{
-	return 0;
-}
-
-static inline union v4addr *
-tp_sys_connect_ipv4(struct syscalls_enter_connect_args *ctx)
-{
-	return 0;
-}
-
-static inline union v6addr *
-tp_sys_connect_ipv6(struct syscalls_enter_connect_args *ctx)
-{
-	return 0;
-}
-
-static inline unsigned short
-tp_sys_connect_port(struct syscalls_enter_connect_args *ctx)
-{
-	return 0;
-}
-
-static inline union v4addr *
-tp_sys_accept_ipv4(struct syscalls_enter_accept_args *ctx)
-{
-	return 0;
-}
-
-static inline union v6addr *
-tp_sys_accept_ipv6(struct syscalls_enter_accept_args *ctx)
-{
-	return 0;
-}
-
-static inline unsigned short
-tp_sys_accept_port(struct syscalls_enter_accept_args *ctx)
-{
-	return 0;
-}
-
-static inline union v4addr *
-tp_sys_bind_ipv4(struct syscalls_enter_bind_args *ctx)
-{
-	return 0;
-}
-
-static inline union v6addr *
-tp_sys_bind_ipv6(struct syscalls_enter_bind_args *ctx)
-{
-	return 0;
-}
-
-static inline unsigned short
-tp_sys_bind_port(struct syscalls_enter_bind_args *ctx)
-{
-	return 0;
-}
-
 static inline bool
-ka_ea_check_inspect(void)
+ka_ea_audit_task(void)
 {
 	struct process_filter_key key;
 	struct process_filter_value *value;
@@ -214,66 +88,191 @@ ka_ea_check_inspect(void)
 	key.mnt_ns = task_get_mnt_ns(NULL);
 	key.host_pid = task_get_host_pid();
 
-	value = bpf_map_lookup_elem(__ka_ea_map(ka_ea_process_filter_map), &key);
+	value = bpf_map_lookup_elem((void *)__ka_ea_map(ka_ea_process_filter_map), &key);
 	return (value && value->inspect);
 }
 
+static inline u32
+tp_sys_execve_read_path(struct syscalls_enter_execve_args *ctx)
+{
+	char buffer[MAX_FILENAME_LEN] = {};
+	void *uptr = (void *)ctx->filename;
+
+	if (bpf_probe_read_user(&buffer, sizeof(buffer) - 1, uptr) == 0) {
+		return jenkins_hash(buffer, strnlen(buffer, MAX_FILENAME_LEN), 0);
+	}
+
+	return 0;
+}
+
+static inline u32
+tp_sys_execveat_read_path(struct syscalls_enter_execveat_args *ctx)
+{
+	char buffer[MAX_FILENAME_LEN] = {};
+	void *uptr = (void *)ctx->filename;
+
+	if (bpf_probe_read_user(&buffer, sizeof(buffer) - 1, uptr) == 0) {
+		return jenkins_hash(buffer, strnlen(buffer, MAX_FILENAME_LEN), 0);
+	}
+
+	return 0;
+}
+
+static inline u32
+tp_sys_open_read_path(struct syscalls_enter_open_args *ctx)
+{
+	char buffer[MAX_FILENAME_LEN] = {};
+	void *uptr = (void *)ctx->filename;
+
+	if (bpf_probe_read_user(&buffer, sizeof(buffer) - 1, uptr) == 0) {
+		return jenkins_hash(buffer, strnlen(buffer, MAX_FILENAME_LEN), 0);
+	}
+
+	return 0;
+}
+
+static inline u32
+tp_sys_openat_read_path(struct syscalls_enter_openat_args *ctx)
+{
+	char buffer[MAX_FILENAME_LEN] = {};
+	void *uptr = (void *)ctx->filename;
+
+	if (bpf_probe_read_user(&buffer, sizeof(buffer) - 1, uptr) == 0) {
+		return jenkins_hash(buffer, strnlen(buffer, MAX_FILENAME_LEN), 0);
+	}
+
+	return 0;
+}
+
+static inline void
+tp_sys_connect_read_ipv4(struct syscalls_enter_connect_args *ctx, union v4addr *v4ip)
+{
+	struct sockaddr_in sockaddr;
+	void *uptr = (void *)ctx->usockaddr;
+
+	/* sanity check */
+	if (!v4ip)
+		return;
+	if (ctx->addrlen != sizeof(struct sockaddr_in))
+		return;
+
+	if (bpf_probe_read_user(&sockaddr, ctx->addrlen, uptr) == 0) {
+		v4ip->d1 = sockaddr.sin_addr.s_addr;
+	}
+}
+
+static inline unsigned short
+tp_sys_connect_read_port(struct syscalls_enter_connect_args *ctx)
+{
+	struct sockaddr_in sockaddr;
+	void *uptr = (void *)ctx->usockaddr;
+
+	/* sanity check */
+	if (ctx->addrlen != sizeof(struct sockaddr_in))
+		return 0;
+
+	if (bpf_probe_read_user(&sockaddr, ctx->addrlen, uptr) == 0) {
+		return ntohs(sockaddr.sin_port);
+	}
+
+	return 0;
+}
+
+static inline void
+tp_sys_bind_read_ipv4(struct syscalls_enter_connect_args *ctx, union v4addr *v4ip)
+{
+	struct sockaddr_in sockaddr;
+	void *uptr = (void *)ctx->usockaddr;
+
+	/* sanity check */
+	if (!v4ip)
+		return;
+	if (ctx->addrlen != sizeof(struct sockaddr_in))
+		return;
+
+	if (bpf_probe_read_user(&sockaddr, ctx->addrlen, uptr) == 0) {
+		v4ip->d1 = sockaddr.sin_addr.s_addr;
+	}
+}
+
+static inline unsigned short
+tp_sys_bind_read_port(struct syscalls_enter_connect_args *ctx)
+{
+	struct sockaddr_in sockaddr;
+	void *uptr = (void *)ctx->usockaddr;
+
+	/* sanity check */
+	if (ctx->addrlen != sizeof(struct sockaddr_in))
+		return 0;
+
+	if (bpf_probe_read_user(&sockaddr, ctx->addrlen, uptr) == 0) {
+		return ntohs(sockaddr.sin_port);
+	}
+
+	return 0;
+}
+
 // sys_execve
-#define __ka_ea_evt59_path(ctx) \
-	tp_sys_execve_path(ctx)
+#define __ka_ea_evt59_read_path(ctx) \
+	tp_sys_execve_read_path(ctx)
 
 // sys_execveat
-#define __ka_ea_evt322_path(ctx)  \
-	tp_sys_execveat_path(ctx)
-#define __ka_ea_evt322_flags(ctx) \
-	tp_sys_execveat_flags(ctx)
+#define __ka_ea_evt322_read_path(ctx)  \
+	tp_sys_execveat_read_path(ctx)
+#define __ka_ea_evt322_read_flags(ctx) \
+	(int)(((struct syscalls_enter_execveat_args *)ctx)->flags)
 
 // sys_open
-#define __ka_ea_evt2_path(ctx)  \
-	tp_sys_open_path(ctx)
-#define __ka_ea_evt2_flags(ctx) \
-	tp_sys_open_flags(ctx)
-#define __ka_ea_evt2_mode(ctx)  \
-	tp_sys_open_mode(ctx)
+#define __ka_ea_evt2_read_path(ctx)  \
+	tp_sys_open_read_path(ctx)
+#define __ka_ea_evt2_read_flags(ctx) \
+	(int)(((struct syscalls_enter_open_args *)ctx)->flags)
+#define __ka_ea_evt2_read_mode(ctx)  \
+	(mode_t)(((struct syscalls_enter_open_args *)ctx)->mode)
 
 // sys_openat
-#define __ka_ea_evt257_path(ctx)  \
-	tp_sys_openat_path(ctx)
-#define __ka_ea_evt257_flags(ctx) \
-	tp_sys_openat_flags(ctx)
-#define __ka_ea_evt257_mode(ctx)  \
-	tp_sys_openat_mode(ctx)
-
-// sys_socket
-#define __ka_ea_evt41_protocol(ctx) \
-	tp_sys_socket_protocol(ctx)
+#define __ka_ea_evt257_read_path(ctx)  \
+	tp_sys_openat_read_path(ctx)
+#define __ka_ea_evt257_read_flags(ctx) \
+	(int)(((struct syscalls_enter_openat_args *)ctx)->flags)
+#define __ka_ea_evt257_read_mode(ctx)  \
+	(mode_t)(((struct syscalls_enter_openat_args *)ctx)->mode)
 
 // sys_connect
-#define __ka_ea_evt42_ipv4(ctx) \
-	tp_sys_connect_ipv4(ctx)
-#define __ka_ea_evt42_ipv6(ctx) \
-	tp_sys_connect_ipv6(ctx)
-#define __ka_ea_evt42_port(ctx) \
-	tp_sys_connect_port(ctx)
-
-// sys_accept
-#define __ka_ea_evt43_ipv4(ctx) \
-	tp_sys_accept_ipv4(ctx)
-#define __ka_ea_evt43_ipv6(ctx) \
-	tp_sys_accept_ipv6(ctx)
-#define __ka_ea_evt43_port(ctx) \
-	tp_sys_accept_port(ctx)
+#define __ka_ea_evt42_read_ipv4(ctx, v) \
+	tp_sys_connect_read_ipv4(ctx, v)
+#define __ka_ea_evt42_read_port(ctx) \
+	tp_sys_connect_read_port(ctx)
 
 // sys_bind
-#define __ka_ea_evt49_ipv4(ctx) \
-	tp_sys_bind_ipv4(ctx)
-#define __ka_ea_evt49_ipv6(ctx) \
-	tp_sys_bind_ipv6(ctx)
-#define __ka_ea_evt49_port(ctx) \
-	tp_sys_bind_port(ctx)
+#define __ka_ea_evt49_read_ipv4(ctx, v) \
+	tp_sys_bind_read_ipv4(ctx, v)
+#define __ka_ea_evt49_read_port(ctx) \
+	tp_sys_bind_read_port(ctx)
 
 #define __ka_ea_evt_log(m) \
 	bpf_printk(m)
+
+#define __INIT_LOCAL_PATH(e) \
+	u32 path;                \
+	path = __ka_ea_evt## e## _read_path(ctx);
+
+#define __INIT_LOCAL_MODE(e) \
+	umode_t mode;            \
+	mode = __ka_ea_evt## e## _read_mode(ctx);
+
+#define __INIT_LOCAL_FLAGS(e) \
+	int flags;                \
+	flags = __ka_ea_evt## e## _read_flags(ctx);
+
+#define __INIT_LOCAL_PORT(e) \
+	unsigned short port;     \
+	port = __ka_ea_evt## e## _read_port(ctx);
+
+#define __INIT_LOCAL_IPV4(e) \
+	union v4addr v4ip = {};  \
+	__ka_ea_evt## e## _read_ipv4(ctx, &v4ip);
+
 
 char LICENSE[] SEC("license") = "GPL";
 

--- a/KubeArmor/BPF/ka_ea_entrypoint.bpf.c
+++ b/KubeArmor/BPF/ka_ea_entrypoint.bpf.c
@@ -58,9 +58,6 @@ call_event_handler(void *ctx, uint32_t event_id)
         bpf_tail_call(ctx, &ka_ea_event_jmp_table, value->jmp_idx);
     }
 
-    bpf_printk("[ka-ea-entrypoint]: bpf_tail_call failure: pidns=%d, mntns=%d, event=%d",
-        key.pid_ns, key.mnt_ns, key.event_id);
-
     return 0;
 }
 

--- a/KubeArmor/core/kubeUpdate.go
+++ b/KubeArmor/core/kubeUpdate.go
@@ -1855,6 +1855,11 @@ func k8sEventVerifyParams(event tp.K8sEventType) error {
 	// check ipv4 using event auditor parsing
 	if len(event.Ipv4Addr) > 0 {
 		for _, ipv4 := range strings.Split(event.Ipv4Addr, ",") {
+			ipv4 = strings.TrimSpace(ipv4)
+			if ipv4[0] == '-' {
+				ipv4 = ipv4[1:]
+			}
+
 			if err := edt.TryTokenizeIpv4(ipv4); err != nil {
 				return err
 			}

--- a/KubeArmor/eventAuditor/codeGenerator.go
+++ b/KubeArmor/eventAuditor/codeGenerator.go
@@ -15,6 +15,8 @@ import (
 	kl "github.com/kubearmor/KubeArmor/KubeArmor/common"
 	tp "github.com/kubearmor/KubeArmor/KubeArmor/types"
 	lbpf "github.com/kubearmor/libbpf"
+
+	jenkins "leb.io/hashland/jenkins"
 )
 
 // Configuration
@@ -313,19 +315,18 @@ func ipv4Tokenize(ipv4Value string) ([]Token, error) {
 	return nil, fmt.Errorf("invalid parameter: %v (ipv4addr)", ipv4Value)
 }
 
-func generateIpv4Match(ipv4Tokens []Token, eventID uint32) string {
+func generateIpv4Match(ipv4Tokens []Token) string {
 	matchGroup := []string{}
 	for i, token := range ipv4Tokens {
 		if token.isNumber() {
 			matchGroup = append(matchGroup,
-				fmt.Sprintf("((__ka_ea_evt%d_ipv4(ctx)->octet[%d]) == %d)",
-					eventID, i, token.getNumber()))
+				fmt.Sprintf("((v4ip.octet[%d]) == %d)", i, token.getNumber()))
 
 		} else if token.isRange() {
 			matchGroup = append(matchGroup,
-				fmt.Sprintf("(((__ka_ea_evt%d_ipv4(ctx)->octet[%d]) >= %d) && ((__ka_ea_evt%d_ipv4(ctx)->octet[%d]) <= %d))",
-					eventID, i, token.getRange()[0],
-					eventID, i, token.getRange()[1]))
+				fmt.Sprintf("(((v4ip.octet[%d]) >= %d) && ((v4ip.octet[%d]) <= %d))",
+					i, token.getRange()[0],
+					i, token.getRange()[1]))
 		}
 	}
 
@@ -333,7 +334,7 @@ func generateIpv4Match(ipv4Tokens []Token, eventID uint32) string {
 	return match
 }
 
-func generateIpv4MatchExclusion(ipv4Field string, eventID uint32) (string, error) {
+func generateIpv4MatchExclusion(ipv4Field string) (string, error) {
 	var err error
 	var ipv4Tokens []Token
 	var match string
@@ -349,7 +350,7 @@ func generateIpv4MatchExclusion(ipv4Field string, eventID uint32) (string, error
 				return "", err
 			}
 
-			matchGroup = append(matchGroup, generateIpv4Match(ipv4Tokens, eventID))
+			matchGroup = append(matchGroup, generateIpv4Match(ipv4Tokens))
 		}
 	}
 
@@ -360,7 +361,7 @@ func generateIpv4MatchExclusion(ipv4Field string, eventID uint32) (string, error
 	return match, nil
 }
 
-func generateIpv4MatchInclusion(ipv4Field string, eventID uint32) (string, error) {
+func generateIpv4MatchInclusion(ipv4Field string) (string, error) {
 	var err error
 	var ipv4Tokens []Token
 	var match string
@@ -376,7 +377,7 @@ func generateIpv4MatchInclusion(ipv4Field string, eventID uint32) (string, error
 				return "", err
 			}
 
-			matchGroup = append(matchGroup, generateIpv4Match(ipv4Tokens, eventID))
+			matchGroup = append(matchGroup, generateIpv4Match(ipv4Tokens))
 		}
 	}
 
@@ -421,7 +422,7 @@ func portTokenize(portValue string) (Token, error) {
 		fmt.Errorf("invalid parameter: %v (port)", portValue)
 }
 
-func generatePortMatch(portField string, eventID uint32) (string, error) {
+func generatePortMatch(portField string) (string, error) {
 	var err error
 	var portToken Token
 	var match string
@@ -436,13 +437,13 @@ func generatePortMatch(portField string, eventID uint32) (string, error) {
 
 		if portToken.isNumber() {
 			matchGroup = append(matchGroup,
-				fmt.Sprintf("(__ka_ea_evt%d_port(ctx) == %d)", eventID, portToken.getNumber()))
+				fmt.Sprintf("(port == %d)", portToken.getNumber()))
 
 		} else if portToken.isRange() {
 			matchGroup = append(matchGroup,
-				fmt.Sprintf("((__ka_ea_evt%d_port(ctx) >= %d) && (__ka_ea_evt%d_port(ctx) <= %d))",
-					eventID, portToken.getRange()[0],
-					eventID, portToken.getRange()[1]))
+				fmt.Sprintf("((port >= %d) && (port <= %d))",
+					portToken.getRange()[0],
+					portToken.getRange()[1]))
 		}
 	}
 
@@ -465,7 +466,7 @@ func modeTokenize(modeValue string) (Token, error) {
 		fmt.Errorf("invalid parameter: %v (mode)", modeValue)
 }
 
-func generateModeMatch(modeField string, eventID uint32) (string, error) {
+func generateModeMatch(modeField string) (string, error) {
 	var err error
 	var modeToken Token
 
@@ -480,7 +481,7 @@ func generateModeMatch(modeField string, eventID uint32) (string, error) {
 		modeInt64 |= modeToken.getNumber()
 	}
 
-	match := fmt.Sprintf("(__ka_ea_evt%d_mode(ctx) == 0x%x)", eventID, modeInt64)
+	match := fmt.Sprintf("(mode == 0x%x)", modeInt64)
 	return match, nil
 }
 
@@ -496,7 +497,7 @@ func flagsTokenize(flagsValue string) (Token, error) {
 		fmt.Errorf("invalid parameter: %v (flags)", flagsValue)
 }
 
-func generateFlagsMatch(flagsField string, eventID uint32) (string, error) {
+func generateFlagsMatch(flagsField string) (string, error) {
 	var err error
 	var flagsToken Token
 
@@ -511,18 +512,24 @@ func generateFlagsMatch(flagsField string, eventID uint32) (string, error) {
 		flagsInt64 |= flagsToken.getNumber()
 	}
 
-	match := fmt.Sprintf("(__ka_ea_evt%d_flags(ctx) == 0x%x)", eventID, flagsInt64)
+	match := fmt.Sprintf("(flags == 0x%x)", flagsInt64)
 	return match, nil
 }
 
-func buildIpv4AddrParam(ipv4Field string, eventID uint32, inc *[]string, exc *[]string) error {
-	if match, err := generateIpv4MatchInclusion(ipv4Field, eventID); err != nil {
+func generatePathMatch(pathField string) (string, error) {
+	hashKey, _ := jenkins.HashString(pathField, 0, 0)
+	match := fmt.Sprintf("(path == 0x%x)", hashKey)
+	return match, nil
+}
+
+func buildIpv4AddrParam(ipv4Field string, inc *[]string, exc *[]string) error {
+	if match, err := generateIpv4MatchInclusion(ipv4Field); err != nil {
 		return err
 	} else if len(match) > 0 {
 		*inc = append(*inc, match)
 	}
 
-	if match, err := generateIpv4MatchExclusion(ipv4Field, eventID); err != nil {
+	if match, err := generateIpv4MatchExclusion(ipv4Field); err != nil {
 		return err
 	} else if len(match) > 0 {
 		*exc = append(*exc, match)
@@ -531,8 +538,8 @@ func buildIpv4AddrParam(ipv4Field string, eventID uint32, inc *[]string, exc *[]
 	return nil
 }
 
-func buildPortParam(portField string, eventID uint32, inc *[]string) error {
-	if match, err := generatePortMatch(portField, eventID); err != nil {
+func buildPortParam(portField string, inc *[]string) error {
+	if match, err := generatePortMatch(portField); err != nil {
 		return err
 	} else if len(match) > 0 {
 		*inc = append(*inc, match)
@@ -541,8 +548,8 @@ func buildPortParam(portField string, eventID uint32, inc *[]string) error {
 	return nil
 }
 
-func buildModeParam(modeField string, eventID uint32, inc *[]string) error {
-	if match, err := generateModeMatch(modeField, eventID); err != nil {
+func buildModeParam(modeField string, inc *[]string) error {
+	if match, err := generateModeMatch(modeField); err != nil {
 		return err
 	} else if len(match) > 0 {
 		*inc = append(*inc, match)
@@ -551,8 +558,18 @@ func buildModeParam(modeField string, eventID uint32, inc *[]string) error {
 	return nil
 }
 
-func buildFlagsParam(flagsField string, eventID uint32, inc *[]string) error {
-	if match, err := generateFlagsMatch(flagsField, eventID); err != nil {
+func buildFlagsParam(flagsField string, inc *[]string) error {
+	if match, err := generateFlagsMatch(flagsField); err != nil {
+		return err
+	} else if len(match) > 0 {
+		*inc = append(*inc, match)
+	}
+
+	return nil
+}
+
+func buildPathParam(pathField string, inc *[]string) error {
+	if match, err := generatePathMatch(pathField); err != nil {
 		return err
 	} else if len(match) > 0 {
 		*inc = append(*inc, match)
@@ -593,6 +610,7 @@ func (ea *EventAuditor) generateCodeBlock(auditEvent tp.AuditEventType, probe st
 	var codeBlock string
 	var matchInclusion []string
 	var matchExclusion []string
+	var localVariables []string
 
 	eventSupportsArgument := func(param string, value string) bool {
 		if !kl.ContainsElement(ea.EntryPointParameters[probe], param) {
@@ -606,34 +624,61 @@ func (ea *EventAuditor) generateCodeBlock(auditEvent tp.AuditEventType, probe st
 	eventID := ea.SupportedEntryPoints[probe]
 	if len(auditEvent.Ipv4Addr) > 0 {
 		if eventSupportsArgument("Ipv4Addr", auditEvent.Ipv4Addr) {
-			if err := buildIpv4AddrParam(auditEvent.Ipv4Addr, eventID, &matchInclusion, &matchExclusion); err != nil {
+			if err := buildIpv4AddrParam(auditEvent.Ipv4Addr, &matchInclusion, &matchExclusion); err != nil {
 				return "", err
 			}
+
+			variable := fmt.Sprintf("__INIT_LOCAL_IPV4(%d)", eventID)
+			localVariables = append(localVariables, variable)
 		}
 	}
 
 	if len(auditEvent.Port) > 0 {
 		if eventSupportsArgument("Port", auditEvent.Port) {
-			if err := buildPortParam(auditEvent.Port, eventID, &matchInclusion); err != nil {
+			if err := buildPortParam(auditEvent.Port, &matchInclusion); err != nil {
 				return "", err
 			}
+
+			variable := fmt.Sprintf("__INIT_LOCAL_PORT(%d)", eventID)
+			localVariables = append(localVariables, variable)
 		}
 	}
 
 	if len(auditEvent.Mode) > 0 {
 		if eventSupportsArgument("Mode", auditEvent.Mode) {
-			if err := buildModeParam(auditEvent.Mode, eventID, &matchInclusion); err != nil {
+			if err := buildModeParam(auditEvent.Mode, &matchInclusion); err != nil {
 				return "", err
 			}
+
+			variable := fmt.Sprintf("__INIT_LOCAL_MODE(%d)", eventID)
+			localVariables = append(localVariables, variable)
 		}
 	}
 
 	if len(auditEvent.Flags) > 0 {
 		if eventSupportsArgument("Flags", auditEvent.Flags) {
-			if err := buildFlagsParam(auditEvent.Flags, eventID, &matchInclusion); err != nil {
+			if err := buildFlagsParam(auditEvent.Flags, &matchInclusion); err != nil {
 				return "", err
 			}
+
+			variable := fmt.Sprintf("__INIT_LOCAL_FLAGS(%d)", eventID)
+			localVariables = append(localVariables, variable)
 		}
+	}
+
+	if len(auditEvent.Path) > 0 {
+		if eventSupportsArgument("Path", auditEvent.Path) {
+			if err := buildPathParam(auditEvent.Path, &matchInclusion); err != nil {
+				return "", err
+			}
+
+			variable := fmt.Sprintf("__INIT_LOCAL_PATH(%d)", eventID)
+			localVariables = append(localVariables, variable)
+		}
+	}
+
+	for _, variable := range localVariables {
+		codeBlock += "\n" + variable + "\n"
 	}
 
 	if len(matchExclusion) > 0 {
@@ -700,7 +745,7 @@ func (ea *EventAuditor) GenerateAuditProgram(probe string, codeBlocks []string) 
 	source += "int " + getFnName(probe) + "(void *ctx)\n{\n"
 
 	// common prologue
-	source += "\tif (!ka_ea_check_inspect())\n\t"
+	source += "\tif (!ka_ea_audit_task())\n\t"
 	source += "{\n"
 	source += "\t\treturn 0;\n\t"
 	source += "}\n"

--- a/KubeArmor/eventAuditor/entryPointHandler.go
+++ b/KubeArmor/eventAuditor/entryPointHandler.go
@@ -41,7 +41,7 @@ func (ea *EventAuditor) InitializeEntryPoints() bool {
 
 	ea.SupportedEntryPoints = map[string]uint32{
 		"execve": 59, "execveat": 322, "open": 2, "openat": 257,
-		"socket": 41, "connect": 42, "accept": 43, "bind": 49, "listen": 50}
+		"socket": 41, "connect": 42, "bind": 49, "listen": 50}
 
 	ea.EntryPointParameters = make(map[string][]string)
 	ea.EntryPointParameters["execve"] = []string{"Path"}
@@ -50,7 +50,6 @@ func (ea *EventAuditor) InitializeEntryPoints() bool {
 	ea.EntryPointParameters["openat"] = []string{"Path", "Flags", "Mode"}
 	ea.EntryPointParameters["socket"] = []string{"Protocol"}
 	ea.EntryPointParameters["connect"] = []string{"Ipv4Addr", "Ipv6Addr", "Port"}
-	ea.EntryPointParameters["accept"] = []string{"Ipv4Addr", "Ipv6Addr", "Port"}
 	ea.EntryPointParameters["bind"] = []string{"Ipv4Addr", "Ipv6Addr", "Port"}
 	ea.EntryPointParameters["listen"] = []string{}
 

--- a/KubeArmor/eventAuditor/processSpecHandler.go
+++ b/KubeArmor/eventAuditor/processSpecHandler.go
@@ -142,23 +142,21 @@ func (ea *EventAuditor) getProcessElements() (map[FilenameElement]bool, map[Proc
 			}
 
 			for _, auditPolicy := range ep.AuditPolicies {
-				for _, event := range auditPolicy.Events {
-					for _, path := range strings.Split(event.Path, ",") {
-						fne := FilenameElement{}
-						hashKey, _ := jenkins.HashString(path, 0, 0)
+				for _, path := range strings.Split(auditPolicy.Process, ",") {
+					fne := FilenameElement{}
+					hashKey, _ := jenkins.HashString(path, 0, 0)
 
-						fne.SetKey(hashKey)
-						fne.SetValue(true)
+					fne.SetKey(hashKey)
+					fne.SetValue(true)
 
-						filenameHashes[fne] = true
+					filenameHashes[fne] = true
 
-						ps := ProcessSpecElement{}
+					ps := ProcessSpecElement{}
 
-						ps.SetKey(cn.PidNS, cn.MntNS, fne.Key.Hash)
-						ps.SetValue(true)
+					ps.SetKey(cn.PidNS, cn.MntNS, fne.Key.Hash)
+					ps.SetValue(true)
 
-						procSpecs[ps] = true
-					}
+					procSpecs[ps] = true
 				}
 			}
 		}

--- a/examples/multiubuntu/audit-policies/kap_auditpolicy_1.yaml
+++ b/examples/multiubuntu/audit-policies/kap_auditpolicy_1.yaml
@@ -19,15 +19,15 @@ spec:
     message: "suspicious shell activity"
     severity: "5"
     events:
-    - probe: BIND-CONNECT-ACCEPT
+    - probe: BIND-CONNECT
       ipv4addr: NON-EXTERNAL-IPV4
       port: 8080, 20-25, 6667
       rate: 10p1s
-  - process: "*"
+  - process: "/bin/cat"
     events:
-    - probe: sys_open
+    - probe: sys_openat
       path: /etc/shadow
-      flags: O_RDWR | O_APPEND
+      flags: O_RDONLY
   - message: "outbound probes detected (for any process)"
     severity: "5"
     events:

--- a/examples/multiubuntu/audit-policies/kmc_macro_1.yaml
+++ b/examples/multiubuntu/audit-policies/kmc_macro_1.yaml
@@ -8,8 +8,8 @@ spec:
   - name: SHELLS
     value: /bin/*sh, /usr/bin/*sh
 
-  - name: BIND-CONNECT-ACCEPT
-    value: sys_bind, sys_connect, sys_accept
+  - name: BIND-CONNECT
+    value: sys_bind, sys_connect
 
   - name: NON-EXTERNAL-IPV4
     value: 192.168.*.*, 10.*.*.*


### PR DESCRIPTION
This PR includes:

- [x] Parameter parsing on the ebpf functions (completing the priorities of #381)
Additionally the code generation was simplified. Now we declare and fetch the used parameters once at the beginning of the function with the help of the macros `__INIT_LOCAL_*` declared on `codegen.bpf.h`
- [x] Removes `sys_accept` from the supported probes - we need to think more how to handle this syscall.
- [x] Updates the parameter checker function to ignore values starting with `-` (to allowing exclusions like `-10.*.*.1`)

Minor fixes:
- [x] Updates `processSpecHandler.go` to read the process name from the right field.
- [x] Updates `ka_ea_entrypoint.bpf.c` removing the log message.