### PR TITLE
Run tests only if changes in relevant files

### DIFF
--- a/.github/workflows/ci-kubeadm.yml
+++ b/.github/workflows/ci-kubeadm.yml
@@ -3,8 +3,16 @@ name: ci-test
 on:
   push:
     branches: [main]
+    paths: 
+    - 'KubeArmor/**'
+    - 'tests/**'
+    - 'protobuf/**'
   pull_request:
     branches: [main]
+    paths: 
+    - 'KubeArmor/**'
+    - 'tests/**'
+    - 'protobuf/**'
 
 jobs:
   build:


### PR DESCRIPTION
Our test framework in https://github.com/kubearmor/KubeArmor/blob/main/.github/workflows/ci-kubeadm.yml is quite expensive, taking >10 min to run. 
It's not needed when we make documentation related changes or some other changes.
This PR restricts the CI tests to only run if there are changes in `KubeArmor/**` or `tests/**`