### PR TITLE
fix release issue due to k3s tests

### DIFF
--- a/.github/workflows/latest-release.yml
+++ b/.github/workflows/latest-release.yml
@@ -19,19 +19,8 @@ jobs:
 
       - name: Setup Enviroment
         run: |        
-          # create a single-node K3s cluster
-          curl -sfL https://get.k3s.io | K3S_KUBECONFIG_MODE="644" INSTALL_K3S_EXEC="--flannel-backend=none --cluster-cidr=192.168.0.0/16 --disable-network-policy --disable=traefik" sh -
+          ./contribution/k3s/install_k3s.sh
 
-          #setting a variable environment
-          mkdir ~/.kube/
-          cp /etc/rancher/k3s/k3s.yaml ~/.kube/config 
-
-          # install Calico-Operator
-          kubectl create -f https://docs.projectcalico.org/manifests/tigera-operator.yaml
-
-          # install Calico-Manifest
-          kubectl apply -f https://docs.projectcalico.org/manifests/calico.yaml
-            
       - name: Run KubeArmor 
         run: |
           kubectl apply -f KubeArmor/build/kubearmor-test-k3s.yaml

--- a/.github/workflows/latest-release.yml
+++ b/.github/workflows/latest-release.yml
@@ -24,11 +24,8 @@ jobs:
       - name: Run KubeArmor 
         run: |
           kubectl apply -f KubeArmor/build/kubearmor-test-k3s.yaml
-          kubectl get pods --all-namespaces 
-
           while [[ $(kubectl get pods -l kubearmor-app=kubearmor -n kube-system -o 'jsonpath={..status.conditions[?(@.type=="Ready")].status}') != "True" ]]; do echo "waiting for pod" && sleep 1; done
-
-          sleep 60
+          kubectl get pods -A
 
       - name: Run KubeArmor tests
         run: |

--- a/.github/workflows/latest-release.yml
+++ b/.github/workflows/latest-release.yml
@@ -10,6 +10,7 @@ jobs:
   build:
     name: Create KubeArmor Release - 18.04
     runs-on: ubuntu-18.04
+    timeout-minutes: 20
     steps:
       - name: Checkout KubeArmor code
         uses: actions/checkout@v2
@@ -31,16 +32,6 @@ jobs:
         run: |
           ./tests/test-scenarios-github.sh
 
-      - name: Archive log artifacts
-        if: ${{ failure() }}
-        uses: actions/upload-artifact@v2
-        with:
-          name: kubearmor.logs
-          path: |
-            /tmp/kubearmor.test
-            /tmp/kubearmor.log
-            /tmp/kubearmor.msg
-      
       - name: Login to Docker Hub
         uses: docker/login-action@v1
         with:

--- a/KubeArmor/build/kubearmor-test-k3s.yaml
+++ b/KubeArmor/build/kubearmor-test-k3s.yaml
@@ -55,11 +55,12 @@ spec:
         ports:
         - containerPort: 32767
         volumeMounts:
-        - name: containerd-sock-path # containerd (read-only)
-          mountPath: /var/run/containerd/containerd.sock
-          readOnly: true
-        - name: containerd-storage-path # containerd storage (read-only)
-          mountPath: /run/containerd
+        - name: docker-sock-path # docker (read-only)
+          mountPath: /var/run/docker.sock
+          readOnly: true 
+        - name: docker-storage-path # docker storage (read-only)
+          mountPath: /var/lib/docker
+          readOnly: true 
         - name: usr-src-path # BPF (read-only)
           mountPath: /usr/src
           readOnly: true
@@ -90,14 +91,14 @@ spec:
         terminationMessagePath: /dev/termination-log
       terminationGracePeriodSeconds: 30
       volumes:
-      - name: containerd-sock-path # containerd
+      - name: docker-sock-path # docker
         hostPath:
-          path: /run/k3s/containerd/containerd.sock
+          path: /var/run/docker.sock
           type: Socket
-      - name: containerd-storage-path # containerd
+      - name: docker-storage-path # docker
         hostPath:
-          path: /run/k3s/containerd
-          type: DirectoryOrCreate
+          path: /var/lib/docker
+          type: Directory
       - name: usr-src-path # BPF
         hostPath:
           path: /usr/src

--- a/contribution/k3s/install_k3s.sh
+++ b/contribution/k3s/install_k3s.sh
@@ -3,7 +3,7 @@
 # Copyright 2021 Authors of KubeArmor
 
 # create a single-node K3s cluster
-curl -sfL https://get.k3s.io | K3S_KUBECONFIG_MODE="644" INSTALL_K3S_EXEC="--disable=traefik" sh -
+curl -sfL https://get.k3s.io | K3S_KUBECONFIG_MODE="644" INSTALL_K3S_EXEC="--disable=traefik --docker" sh -
 
 KUBEDIR=~/.kube
 KUBECONFIG=$KUBEDIR/config

--- a/contribution/k3s/install_k3s.sh
+++ b/contribution/k3s/install_k3s.sh
@@ -3,10 +3,17 @@
 # Copyright 2021 Authors of KubeArmor
 
 # create a single-node K3s cluster
-curl -sfL https://get.k3s.io | K3S_KUBECONFIG_MODE="644" INSTALL_K3S_EXEC="--flannel-backend=none --cluster-cidr=192.168.0.0/16 --disable-network-policy --disable=traefik" sh -
+curl -sfL https://get.k3s.io | K3S_KUBECONFIG_MODE="644" INSTALL_K3S_EXEC="--disable=traefik" sh -
 
-# install Calico-Operator
-kubectl create -f https://docs.projectcalico.org/manifests/tigera-operator.yaml
+KUBEDIR=~/.kube
+KUBECONFIG=$KUBEDIR/config
 
-# install Calico-Manifest
-kubectl apply -f https://docs.projectcalico.org/manifests/calico.yaml
+[[ ! -d $KUBEDIR ]] && mkdir ~/.kube/
+if [ -f $KUBECONFIG ]; then
+	KUBECONFIGBKP=$KUBEDIR/config.backup
+	echo "Found $KUBECONFIG already in place ... backing it up to $KUBECONFIGBKP"
+	cp $KUBECONFIG $KUBECONFIGBKP
+fi
+
+cp /etc/rancher/k3s/k3s.yaml $KUBEDIR/config 
+


### PR DESCRIPTION
A new workflow was introduced (#524) such that kubearmor images could be tested in a local k3s env before pushing the images to the docker hub. There were following problems with that workflow:
1. k3s by default uses containerd and we were building images in local docker. Thus the image was never used. Changed k3s install script to by default use docker and changed the `kubearmor-test-k3s.yaml` to volume mount docker paths.
2. `test-scenarios-github.sh` always required that kubearmor be instantiated as a local process. This involved scanning local logs to check the output conditions of the test result. Changed `test-scenarios-github.sh` to check if there exists a kubearmor running in k8s env before local instantiation.
3. Updated `.github/workflows/latest-release.yml` to use the `./contribution/k3s/install_k3s.sh` ... so that there is a single k3s script for all purpose.
4. Removed k3s dependency on calico CNI, using flannel as default in k3s.
5. Removed unnecessary sleeps in the test scripts, optimizing test time.