### PR TITLE
Update contribution docs for minikube

### DIFF
--- a/contribution/minikube/README.md
+++ b/contribution/minikube/README.md
@@ -21,18 +21,12 @@ Ensure to use virtualbox driver when running minikube. This step is necessary in
 $ minikube config set driver virtualbox
 ```
 
-In order to use KubeArmor, Minikube needs to support eBPF capabilities. Unfortunately, Minikube doesn't suuport them by default. Thus, please run the following command rather than simply running "minikube start".
+In order to use KubeArmor, Minikube needs to support eBPF capabilities. Unfortunately, Minikube doesn't suport them by default. We have compiled Minikube's Kernel with eBPF capablities and AppArmor which is required to enforce security policies. Thus, please run the following command rather than simply running "minikube start".
 
 ```text
 ~/KubeArmor/contribution/minikube$ ./start_minikube.sh
 ```
 
-It will use the minikube image with Linux kernel 4.19.94 and download the Linux kernel 4.19.94 headers.
-
-To check if eBPF programs run in Minikube, please run the following command.
-
-```text
-~/KubeArmor/contribution/minikube$ ./test_ebpf.sh
-```
+It will use the minikube image with Linux kernel 5.4.40 with AppArmor service enabled by default.
 
 If you see no error, you're ready to test KubeArmor.


### PR DESCRIPTION
We now use kernel image 5.4.40 instead of 4.19.94. As this kernel is built with `CONFIG_IKHEADERS`, So we don't need to install additional kernel headers

Signed-off-by: Gaurav Genani <h3llix.pvt@gmail.com>