### PR TITLE
update GlobalCfg.HostVisibility

### DIFF
--- a/KubeArmor/config/config.go
+++ b/KubeArmor/config/config.go
@@ -77,7 +77,7 @@ func readCmdLineParams() {
 	seLinuxProfileDirStr := flag.String(ConfigSELinuxProfileDir, "/tmp/kubearmor.selinux", "SELinux profile directory")
 
 	visStr := flag.String(ConfigVisibility, "process,file,network,capabilities", "Container Visibility to use [process,file,network,capabilities,none]")
-	hostVisStr := flag.String(ConfigHostVisibility, "process,file,network,capabilities", "Host Visibility to use [process,file,network,capabilities,none]")
+	hostVisStr := flag.String(ConfigHostVisibility, "", "Host Visibility to use [process,file,network,capabilities,none] (default \"none\" for k8s, \"process,file,network,capabilities\" for VM)")
 
 	policyB := flag.Bool(ConfigKubearmorPolicy, true, "enabling KubeArmorPolicy")
 	hostPolicyB := flag.Bool(ConfigKubearmorHostPolicy, false, "enabling KubeArmorHostPolicy")
@@ -143,6 +143,14 @@ func LoadConfig() error {
 	if GlobalCfg.KVMAgent {
 		GlobalCfg.Policy = false
 		GlobalCfg.HostPolicy = true
+	}
+
+	if GlobalCfg.HostVisibility == "" {
+		if GlobalCfg.KVMAgent {
+			GlobalCfg.HostVisibility = "process,file,network,capabilities"
+		} else { // k8s
+			GlobalCfg.HostVisibility = "none"
+		}
 	}
 
 	GlobalCfg.CoverageTest = viper.GetBool(ConfigCoverageTest)


### PR DESCRIPTION
Enable HostVisibility depending on given environments. (#574)

- K8s
If no host visibility is set, configure "none" for host visibility by default

- VM
If kvmAgent is set but no host visibility is set, configure "process,file,network,capabilities" for host visibility by default

Otherwise, configure the host visibility option given by an operator.

Signed-off-by: Jaehyun Nam <jn@accuknox.com>