### PR TITLE
Refactor exported objects into separate subpackage

### DIFF
--- a/deployments/get/defaults.go
+++ b/deployments/get/defaults.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2021 Authors of KubeArmor
 
-package main
+package deployments
 
 import corev1 "k8s.io/api/core/v1"
 

--- a/deployments/get/objects.go
+++ b/deployments/get/objects.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2021 Authors of KubeArmor
 
-package main
+package deployments
 
 import (
 	"strconv"

--- a/deployments/go.mod
+++ b/deployments/go.mod
@@ -10,8 +10,8 @@ replace (
 
 require (
 	github.com/clarketm/json v1.17.1
-	github.com/kubearmor/KubeArmor/pkg/KubeArmorHostPolicy v0.0.0-00010101000000-000000000000
-	github.com/kubearmor/KubeArmor/pkg/KubeArmorPolicy v0.0.0-00010101000000-000000000000
+	github.com/kubearmor/KubeArmor/pkg/KubeArmorHostPolicy v0.0.0-20220128051912-b9f5851b939b
+	github.com/kubearmor/KubeArmor/pkg/KubeArmorPolicy v0.0.0-20220128051912-b9f5851b939b
 	k8s.io/api v0.22.3
 	k8s.io/apimachinery v0.22.3
 	sigs.k8s.io/yaml v1.2.0

--- a/deployments/main.go
+++ b/deployments/main.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/clarketm/json"
 
+	deployments "github.com/kubearmor/KubeArmor/deployments/get"
 	"sigs.k8s.io/yaml"
 
 	hsp "github.com/kubearmor/KubeArmor/pkg/KubeArmorHostPolicy/crd"
@@ -28,15 +29,15 @@ func main() {
 
 	for _, env := range envs {
 		v := []interface{}{
-			GetServiceAccount(namespace),
-			GetClusterRoleBinding(namespace),
-			GetRelayService(namespace),
-			GetRelayDeployment(namespace),
-			GenerateDaemonSet(strings.ToLower(env), namespace),
-			GetPolicyManagerService(namespace),
-			GetPolicyManagerDeployment(namespace),
-			GetHostPolicyManagerService(namespace),
-			GetHostPolicyManagerDeployment(namespace),
+			deployments.GetServiceAccount(namespace),
+			deployments.GetClusterRoleBinding(namespace),
+			deployments.GetRelayService(namespace),
+			deployments.GetRelayDeployment(namespace),
+			deployments.GenerateDaemonSet(strings.ToLower(env), namespace),
+			deployments.GetPolicyManagerService(namespace),
+			deployments.GetPolicyManagerDeployment(namespace),
+			deployments.GetHostPolicyManagerService(namespace),
+			deployments.GetHostPolicyManagerDeployment(namespace),
 			ksp.GetCRD(),
 			hsp.GetCRD()}
 


### PR DESCRIPTION
Current objects weren't importable due to deployment generate tooling being a program and not an importable package, so this commit refactors exported objects into a separate subpackage to serve the intended usecase

Signed-off-by: daemon1024 <barun.acharya@accuknox.com>

This PR aims to fix build errors in https://github.com/kubearmor/kubearmor-client/pull/34
and revert https://github.com/kubearmor/kubearmor-client/commit/0e8b70cc95bd16cef7705bbfb025ababc8dbf6ed