### PR TITLE
fix kubearmor on vm/bare metal

### DIFF
--- a/KubeArmor/core/kubeArmor.go
+++ b/KubeArmor/core/kubeArmor.go
@@ -374,13 +374,6 @@ func KubeArmor() {
 			}
 		}
 
-	} else {
-		kg.Warn("Neither K8s nor KVMAgent is configured")
-
-		// destroy the daemon
-		dm.DestroyKubeArmorDaemon()
-
-		return
 	}
 
 	// == //


### PR DESCRIPTION
We started terminating KubeArmor if there's no k8s or KVMAgent found in https://github.com/kubearmor/KubeArmor/commit/d2cf1f2c47c0a3a4d1413f94177455789200ba2c But we have a bare metal/vm mode which supports host policy enforcement leveraging kArmor tool used by our systemd service. This commits reverts back the termination

Signed-off-by: daemon1024 <barun.acharya@accuknox.com>