### PR TITLE
Remove redundant log

### DIFF
--- a/KubeArmor/feeder/feeder.go
+++ b/KubeArmor/feeder/feeder.go
@@ -628,7 +628,6 @@ func (fd *Feeder) PushLog(log tp.Log) {
 		defer LogLock.Unlock()
 
 		for uid := range LogStructs {
-			kg.Warn("trying to send event")
 			LogStructs[uid].Broadcast <- &pbLog
 		}
 	}


### PR DESCRIPTION
remove redundant warning print introduced in https://github.com/kubearmor/KubeArmor/commit/0bc0086b055f8b3c2a82b8566ff6b4491660b295

Signed-off-by: daemon1024 <barun.acharya@accuknox.com>