### PR TITLE
Added CI job to compile KubeArmor

### DIFF
--- a/.github/workflows/ci-go.yml
+++ b/.github/workflows/ci-go.yml
@@ -46,6 +46,24 @@ jobs:
         run: make gosec
         working-directory: KubeArmor
 
+  go-build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Source
+        uses: actions/checkout@v2
+
+      - uses: actions/setup-go@v2
+        with:
+          go-version: v1.16
+
+      - name: Install Dependencies
+        run: ./contribution/self-managed-k8s/setup.sh
+
+      - name: Compile KubeArmor
+        run: |
+          cd KubeArmor
+          make
+
   license:
     runs-on: ubuntu-latest
     steps:

--- a/contribution/self-managed-k8s/setup.sh
+++ b/contribution/self-managed-k8s/setup.sh
@@ -17,7 +17,6 @@ sudo rm -rf /tmp/build; mkdir -p /tmp/build; cd /tmp/build
 
 # download bcc
 git -C /tmp/build/ clone https://github.com/iovisor/bcc.git
-sed -i 's/find_package(LibDebuginfod)//g' /tmp/build/bcc/CMakeLists.txt
 
 # install dependencies for bcc
 sudo apt-get -y install build-essential cmake bison flex git python3 python3-pip \
@@ -26,6 +25,7 @@ sudo apt-get -y install build-essential cmake bison flex git python3 python3-pip
 
 # install bcc
 mkdir -p /tmp/build/bcc/build; cd /tmp/build/bcc/build
+export LLVM_ROOT=/usr/lib/llvm-9
 cmake .. -DPYTHON_CMD=python3 -DCMAKE_INSTALL_PREFIX=/usr && make -j$(nproc) && sudo make install
 if [ $? != 0 ]; then
     echo "Failed to install bcc"

--- a/contribution/self-managed-k8s/setup.sh
+++ b/contribution/self-managed-k8s/setup.sh
@@ -17,6 +17,7 @@ sudo rm -rf /tmp/build; mkdir -p /tmp/build; cd /tmp/build
 
 # download bcc
 git -C /tmp/build/ clone https://github.com/iovisor/bcc.git
+sed -i 's/find_package(LibDebuginfod)//g' /tmp/build/bcc/CMakeLists.txt
 
 # install dependencies for bcc
 sudo apt-get -y install build-essential cmake bison flex git python3 python3-pip \


### PR DESCRIPTION
### Related issue
#616 
### Proposed changes
* Added CI job to compile KubeArmor at every push or PR against `main` branch
* Fixed an error while installing KubeArmor dependencies within workflow container by defining `LLVM_ROOT` env var before bcc cmake