### PR TITLE
feeder: solved deadlock issue with telemetry

### DIFF
--- a/KubeArmor/feeder/feeder.go
+++ b/KubeArmor/feeder/feeder.go
@@ -242,7 +242,7 @@ func (ls *LogService) WatchLogs(req *pb.RequestMessage, svr pb.LogService_WatchL
 				case codes.OK:
 					// noop
 				case codes.Unavailable, codes.Canceled, codes.DeadlineExceeded:
-					kg.Warnf("Failed to send a log=[%+v] err=[%s]", resp, status.Err().Error())
+					kg.Warnf("Failed to send a log=[%+v] err=[%s] CODE=%d", resp, status.Err().Error(), status.Code())
 					return status.Err()
 				default:
 					return nil
@@ -497,8 +497,8 @@ func (fd *Feeder) PushMessage(level, message string) {
 	pbMsg.Level = level
 	pbMsg.Message = message
 
-	MsgLock.Lock()
-	defer MsgLock.Unlock()
+	// MsgLock.Lock()
+	// defer MsgLock.Unlock()
 
 	for uid := range MsgStructs {
 		MsgStructs[uid].Broadcast <- &pbMsg
@@ -587,8 +587,8 @@ func (fd *Feeder) PushLog(log tp.Log) {
 
 		pbAlert.Result = log.Result
 
-		AlertLock.Lock()
-		defer AlertLock.Unlock()
+		// AlertLock.Lock()
+		// defer AlertLock.Unlock()
 
 		for uid := range AlertStructs {
 			AlertStructs[uid].Broadcast <- &pbAlert
@@ -624,8 +624,8 @@ func (fd *Feeder) PushLog(log tp.Log) {
 
 		pbLog.Result = log.Result
 
-		LogLock.Lock()
-		defer LogLock.Unlock()
+		//		LogLock.Lock()
+		//		defer LogLock.Unlock()
 
 		for uid := range LogStructs {
 			LogStructs[uid].Broadcast <- &pbLog


### PR DESCRIPTION
If log sending fails, then subsequently the messages on the broadcast channel were blocked. Before sending a message on the broadcast channel, a LogLock is taken. Now if WatchLogs() has returned err due to failure in sending log ... then it tries to delete the client entry and the LogLock is again acquired there, causing deadlock.

The same condition is applicable for WatchAlerts() and WatchMessages(). The solution is to simply remove the lock operation before broadcasting on a channel.

Fixes: #622

Signed-off-by: Rahul Jadhav <r@accuknox.com>