### PR TITLE
Fix failing CI due to BCC build failure

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -7,12 +7,14 @@ on:
     - 'KubeArmor/**'
     - 'tests/**'
     - 'protobuf/**'
+    - '.github/workflows/ci-test.yml'
   pull_request:
     branches: [main]
     paths: 
     - 'KubeArmor/**'
     - 'tests/**'
     - 'protobuf/**'
+    - '.github/workflows/ci-test.yml'
 
 jobs:
   build:
@@ -42,7 +44,9 @@ jobs:
           sudo apt-get update
           sudo apt-get -y install build-essential cmake bison flex git python3 python3-pip clang-9 libllvm9 llvm-9-dev libclang-9-dev zlib1g-dev libelf-dev libedit-dev libfl-dev
           pushd /tmp
-          git clone https://github.com/iovisor/bcc.git
+          # fetch latest bcc release
+          tag=$(git ls-remote --tags --exit-code --refs https://github.com/iovisor/bcc.git | sed -E 's/^[[:xdigit:]]+[[:space:]]+refs\/tags\/(.+)/\1/g'| sort -V | tail -n1)
+          git clone --branch "$tag" --depth 1 https://github.com/iovisor/bcc.git
           mkdir -p bcc/build; cd bcc/build
           sudo ln -s /usr/lib/llvm-9 /usr/local/llvm
           cmake .. -DPYTHON_CMD=python3 -DCMAKE_INSTALL_PREFIX=/usr


### PR DESCRIPTION
Restricted BCC to latest release instead of latest commit since unreleased code is unstable can introduce CI failure