### PR TITLE
update release CI and the self-managed-k8s setup to use latest bcc release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,8 @@ jobs:
           sudo apt-get update
           sudo apt-get -y install build-essential cmake bison flex git python3 python3-pip clang-9 libllvm9 llvm-9-dev libclang-9-dev zlib1g-dev libelf-dev libedit-dev libfl-dev
           pushd /tmp
-          git clone https://github.com/iovisor/bcc.git
+          tag=$(git ls-remote --tags --exit-code --refs https://github.com/iovisor/bcc.git | sed -E 's/^[[:xdigit:]]+[[:space:]]+refs\/tags\/(.+)/\1/g'| sort -V | tail -n1)
+          git clone --branch "$tag" --depth 1 https://github.com/iovisor/bcc.git
           mkdir -p bcc/build; cd bcc/build
           sudo ln -s /usr/lib/llvm-9 /usr/local/llvm
           cmake .. -DPYTHON_CMD=python3 -DCMAKE_INSTALL_PREFIX=/usr

--- a/contribution/self-managed-k8s-selinux/setup.sh
+++ b/contribution/self-managed-k8s-selinux/setup.sh
@@ -7,7 +7,8 @@ mkdir -p /tmp/build; cd /tmp/build
 
 # download bcc
 sudo dnf -y install git
-git -C /tmp/build/ clone https://github.com/iovisor/bcc.git
+tag=$(git ls-remote --tags --exit-code --refs https://github.com/iovisor/bcc.git | sed -E 's/^[[:xdigit:]]+[[:space:]]+refs\/tags\/(.+)/\1/g'| sort -V | tail -n1)
+git -C /tmp/build/ clone --branch "$tag" --depth 1 https://github.com/iovisor/bcc.git
 
 # install dependencies for bcc
 sudo dnf -y install gcc gcc-c++ make cmake bison flex ethtool iperf3 \

--- a/contribution/self-managed-k8s/setup.sh
+++ b/contribution/self-managed-k8s/setup.sh
@@ -16,7 +16,8 @@ sudo apt-get update
 sudo rm -rf /tmp/build; mkdir -p /tmp/build; cd /tmp/build
 
 # download bcc
-git -C /tmp/build/ clone https://github.com/iovisor/bcc.git
+tag=$(git ls-remote --tags --exit-code --refs https://github.com/iovisor/bcc.git | sed -E 's/^[[:xdigit:]]+[[:space:]]+refs\/tags\/(.+)/\1/g'| sort -V | tail -n1)
+git -C /tmp/build/ clone --branch "$tag" --depth 1 https://github.com/iovisor/bcc.git
 
 # install dependencies for bcc
 sudo apt-get -y install build-essential cmake bison flex git python3 python3-pip \


### PR DESCRIPTION
- update self-managed-k8s-selinux/setup.sh and contribution/self-managed-k8s/setup.sh to use latest bcc release
- update release workflow to use latest bcc release