### PR TITLE
set bcc to tag v0.24.0

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -45,8 +45,7 @@ jobs:
           sudo apt-get -y install build-essential cmake bison flex git python3 python3-pip clang-9 libllvm9 llvm-9-dev libclang-9-dev zlib1g-dev libelf-dev libedit-dev libfl-dev
           pushd /tmp
           # fetch latest bcc release
-          tag=$(git ls-remote --tags --exit-code --refs https://github.com/iovisor/bcc.git | sed -E 's/^[[:xdigit:]]+[[:space:]]+refs\/tags\/(.+)/\1/g'| sort -V | tail -n1)
-          git clone --branch "$tag" --depth 1 https://github.com/iovisor/bcc.git
+          git clone --branch v0.24.0 --depth 1 https://github.com/iovisor/bcc.git
           mkdir -p bcc/build; cd bcc/build
           sudo ln -s /usr/lib/llvm-9 /usr/local/llvm
           cmake .. -DPYTHON_CMD=python3 -DCMAKE_INSTALL_PREFIX=/usr

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,8 +22,7 @@ jobs:
           sudo apt-get update
           sudo apt-get -y install build-essential cmake bison flex git python3 python3-pip clang-9 libllvm9 llvm-9-dev libclang-9-dev zlib1g-dev libelf-dev libedit-dev libfl-dev
           pushd /tmp
-          tag=$(git ls-remote --tags --exit-code --refs https://github.com/iovisor/bcc.git | sed -E 's/^[[:xdigit:]]+[[:space:]]+refs\/tags\/(.+)/\1/g'| sort -V | tail -n1)
-          git clone --branch "$tag" --depth 1 https://github.com/iovisor/bcc.git
+          git clone --branch v0.24.0 --depth 1 https://github.com/iovisor/bcc.git
           mkdir -p bcc/build; cd bcc/build
           sudo ln -s /usr/lib/llvm-9 /usr/local/llvm
           cmake .. -DPYTHON_CMD=python3 -DCMAKE_INSTALL_PREFIX=/usr

--- a/contribution/self-managed-k8s-selinux/setup.sh
+++ b/contribution/self-managed-k8s-selinux/setup.sh
@@ -7,8 +7,7 @@ mkdir -p /tmp/build; cd /tmp/build
 
 # download bcc
 sudo dnf -y install git
-tag=$(git ls-remote --tags --exit-code --refs https://github.com/iovisor/bcc.git | sed -E 's/^[[:xdigit:]]+[[:space:]]+refs\/tags\/(.+)/\1/g'| sort -V | tail -n1)
-git -C /tmp/build/ clone --branch "$tag" --depth 1 https://github.com/iovisor/bcc.git
+git -C /tmp/build/ clone --branch v0.24.0 --depth 1 https://github.com/iovisor/bcc.git
 
 # install dependencies for bcc
 sudo dnf -y install gcc gcc-c++ make cmake bison flex ethtool iperf3 \

--- a/contribution/self-managed-k8s/setup.sh
+++ b/contribution/self-managed-k8s/setup.sh
@@ -16,8 +16,7 @@ sudo apt-get update
 sudo rm -rf /tmp/build; mkdir -p /tmp/build; cd /tmp/build
 
 # download bcc
-tag=$(git ls-remote --tags --exit-code --refs https://github.com/iovisor/bcc.git | sed -E 's/^[[:xdigit:]]+[[:space:]]+refs\/tags\/(.+)/\1/g'| sort -V | tail -n1)
-git -C /tmp/build/ clone --branch "$tag" --depth 1 https://github.com/iovisor/bcc.git
+git -C /tmp/build/ clone --branch v0.24.0 --depth 1 https://github.com/iovisor/bcc.git
 
 # install dependencies for bcc
 sudo apt-get -y install build-essential cmake bison flex git python3 python3-pip \


### PR DESCRIPTION
As per this [issue](https://github.com/iovisor/bcc/issues/3881) in the bcc repo issue, bcc will no longer support LLVM 7.
So the pipelines will break again once a new release of bcc is available.
Release v0.24.0 is the last release that will work for us.

This Pull request will serve as a rollback for this [PR](https://github.com/kubearmor/KubeArmor/pull/635), in addition to modifying the ci test action.

Signed-off-by: Achref Ben Saad <achref9612@gmail.com>