### PR TITLE
Fix config behaviour

### DIFF
--- a/KubeArmor/config/config.go
+++ b/KubeArmor/config/config.go
@@ -92,22 +92,22 @@ func readCmdLineParams() {
 
 	flag.Parse()
 
-	viper.Set(ConfigCluster, *clusterStr)
-	viper.Set(ConfigHost, *hostStr)
+	viper.SetDefault(ConfigCluster, *clusterStr)
+	viper.SetDefault(ConfigHost, *hostStr)
 
-	viper.Set(ConfigGRPC, *grpcStr)
-	viper.Set(ConfigLogPath, *logStr)
-	viper.Set(ConfigSELinuxProfileDir, *seLinuxProfileDirStr)
+	viper.SetDefault(ConfigGRPC, *grpcStr)
+	viper.SetDefault(ConfigLogPath, *logStr)
+	viper.SetDefault(ConfigSELinuxProfileDir, *seLinuxProfileDirStr)
 
-	viper.Set(ConfigVisibility, *visStr)
-	viper.Set(ConfigHostVisibility, *hostVisStr)
+	viper.SetDefault(ConfigVisibility, *visStr)
+	viper.SetDefault(ConfigHostVisibility, *hostVisStr)
 
-	viper.Set(ConfigKubearmorPolicy, *policyB)
-	viper.Set(ConfigKubearmorHostPolicy, *hostPolicyB)
-	viper.Set(ConfigKubearmorVM, *kvmAgentB)
-	viper.Set(ConfigK8sEnv, *k8sEnvB)
+	viper.SetDefault(ConfigKubearmorPolicy, *policyB)
+	viper.SetDefault(ConfigKubearmorHostPolicy, *hostPolicyB)
+	viper.SetDefault(ConfigKubearmorVM, *kvmAgentB)
+	viper.SetDefault(ConfigK8sEnv, *k8sEnvB)
 
-	viper.Set(ConfigCoverageTest, *coverageTestB)
+	viper.SetDefault(ConfigCoverageTest, *coverageTestB)
 }
 
 // LoadConfig Load configuration


### PR DESCRIPTION
Explicitly calling set, overrides config/env values with default values. This change fixes that behaviour. Note unlike the standard precedence order, value of flags will be overwritten by config/env

Signed-off-by: daemon1024 <barun.acharya@accuknox.com>