### PR TITLE
pkg: update path and dir validation regex

### DIFF
--- a/deployments/CRD/KubeArmorHostPolicy.yaml
+++ b/deployments/CRD/KubeArmorHostPolicy.yaml
@@ -71,7 +71,7 @@ spec:
                           items:
                             properties:
                               path:
-                                pattern: ^\/([A-z0-9-_.]+\/)*([A-z0-9-_.]+)$
+                                pattern: ^\/+.*[^\/]$
                                 type: string
                             type: object
                           type: array
@@ -121,13 +121,13 @@ spec:
                           - Block
                           type: string
                         dir:
-                          pattern: ^\/([A-z0-9-_.]+\/)*([A-z0-9-_.]+)+\/$
+                          pattern: ^\/$|^\/.*\/$
                           type: string
                         fromSource:
                           items:
                             properties:
                               path:
-                                pattern: ^\/([A-z0-9-_.]+\/)*([A-z0-9-_.]+)$
+                                pattern: ^\/+.*[^\/]$
                                 type: string
                             type: object
                           type: array
@@ -164,7 +164,7 @@ spec:
                           items:
                             properties:
                               path:
-                                pattern: ^\/([A-z0-9-_.]+\/)*([A-z0-9-_.]+)$
+                                pattern: ^\/+.*[^\/]$
                                 type: string
                             type: object
                           type: array
@@ -173,7 +173,7 @@ spec:
                         ownerOnly:
                           type: boolean
                         path:
-                          pattern: ^\/([A-z0-9-_.]+\/)*([A-z0-9-_.]+)$
+                          pattern: ^\/+.*[^\/]$
                           type: string
                         readOnly:
                           type: boolean
@@ -252,7 +252,7 @@ spec:
                           items:
                             properties:
                               path:
-                                pattern: ^\/([A-z0-9-_.]+\/)*([A-z0-9-_.]+)$
+                                pattern: ^\/+.*[^\/]$
                                 type: string
                             type: object
                           type: array
@@ -312,13 +312,13 @@ spec:
                           - Block
                           type: string
                         dir:
-                          pattern: ^\/([A-z0-9-_.]+\/)*([A-z0-9-_.]+)+\/$
+                          pattern: ^\/$|^\/.*\/$
                           type: string
                         fromSource:
                           items:
                             properties:
                               path:
-                                pattern: ^\/([A-z0-9-_.]+\/)*([A-z0-9-_.]+)$
+                                pattern: ^\/+.*[^\/]$
                                 type: string
                             type: object
                           type: array
@@ -353,7 +353,7 @@ spec:
                           items:
                             properties:
                               path:
-                                pattern: ^\/([A-z0-9-_.]+\/)*([A-z0-9-_.]+)$
+                                pattern: ^\/+.*[^\/]$
                                 type: string
                             type: object
                           type: array
@@ -362,7 +362,7 @@ spec:
                         ownerOnly:
                           type: boolean
                         path:
-                          pattern: ^\/([A-z0-9-_.]+\/)*([A-z0-9-_.]+)$
+                          pattern: ^\/+.*[^\/]$
                           type: string
                         severity:
                           maximum: 10

--- a/deployments/CRD/KubeArmorPolicy.yaml
+++ b/deployments/CRD/KubeArmorPolicy.yaml
@@ -70,7 +70,7 @@ spec:
                           items:
                             properties:
                               path:
-                                pattern: ^\/([A-z0-9-_.]+\/)*([A-z0-9-_.]+)$
+                                pattern: ^\/+.*[^\/]$
                                 type: string
                             type: object
                           type: array
@@ -119,13 +119,13 @@ spec:
                           - Block
                           type: string
                         dir:
-                          pattern: ^\/([A-z0-9-_.]+\/)*([A-z0-9-_.]+)+\/$
+                          pattern: ^\/$|^\/.*\/$
                           type: string
                         fromSource:
                           items:
                             properties:
                               path:
-                                pattern: ^\/([A-z0-9-_.]+\/)*([A-z0-9-_.]+)$
+                                pattern: ^\/+.*[^\/]$
                                 type: string
                             type: object
                           type: array
@@ -162,7 +162,7 @@ spec:
                           items:
                             properties:
                               path:
-                                pattern: ^\/([A-z0-9-_.]+\/)*([A-z0-9-_.]+)$
+                                pattern: ^\/+.*[^\/]$
                                 type: string
                             type: object
                           type: array
@@ -171,7 +171,7 @@ spec:
                         ownerOnly:
                           type: boolean
                         path:
-                          pattern: ^\/([A-z0-9-_.]+\/)*([A-z0-9-_.]+)$
+                          pattern: ^\/+.*[^\/]$
                           type: string
                         readOnly:
                           type: boolean
@@ -250,7 +250,7 @@ spec:
                           items:
                             properties:
                               path:
-                                pattern: ^\/([A-z0-9-_.]+\/)*([A-z0-9-_.]+)$
+                                pattern: ^\/+.*[^\/]$
                                 type: string
                             type: object
                           type: array
@@ -302,13 +302,13 @@ spec:
                           - Block
                           type: string
                         dir:
-                          pattern: ^\/([A-z0-9-_.]+\/)*([A-z0-9-_.]+)+\/$
+                          pattern: ^\/$|^\/.*\/$
                           type: string
                         fromSource:
                           items:
                             properties:
                               path:
-                                pattern: ^\/([A-z0-9-_.]+\/)*([A-z0-9-_.]+)$
+                                pattern: ^\/+.*[^\/]$
                                 type: string
                             type: object
                           type: array
@@ -343,7 +343,7 @@ spec:
                           items:
                             properties:
                               path:
-                                pattern: ^\/([A-z0-9-_.]+\/)*([A-z0-9-_.]+)$
+                                pattern: ^\/+.*[^\/]$
                                 type: string
                             type: object
                           type: array
@@ -352,7 +352,7 @@ spec:
                         ownerOnly:
                           type: boolean
                         path:
-                          pattern: ^\/([A-z0-9-_.]+\/)*([A-z0-9-_.]+)$
+                          pattern: ^\/+.*[^\/]$
                           type: string
                         severity:
                           maximum: 10
@@ -429,12 +429,12 @@ spec:
                           - Block
                           type: string
                         dir:
-                          pattern: ^\/([A-z0-9-_.]+\/)*([A-z0-9-_.]+)+\/$
+                          pattern: ^\/$|^\/.*\/$
                           type: string
                         message:
                           type: string
                         path:
-                          pattern: ^\/([A-z0-9-_.]+\/)*([A-z0-9-_.]+)$
+                          pattern: ^\/+.*[^\/]$
                           type: string
                         readOnly:
                           type: boolean

--- a/pkg/KubeArmorHostPolicy/api/security.kubearmor.com/v1/kubearmorhostpolicy_types.go
+++ b/pkg/KubeArmorHostPolicy/api/security.kubearmor.com/v1/kubearmorhostpolicy_types.go
@@ -15,10 +15,10 @@ type NodeSelectorType struct {
 	MatchLabels map[string]string `json:"matchLabels,omitempty"`
 }
 
-// +kubebuilder:validation:Pattern=^\/([A-z0-9-_.]+\/)*([A-z0-9-_.]+)$
+// +kubebuilder:validation:Pattern=^\/+.*[^\/]$
 type MatchPathType string
 
-// +kubebuilder:validation:Pattern=^\/([A-z0-9-_.]+\/)*([A-z0-9-_.]+)+\/$
+// +kubebuilder:validation:Pattern=^\/$|^\/.*\/$
 type MatchDirectoryType string
 
 type MatchSourceType struct {

--- a/pkg/KubeArmorHostPolicy/config/crd/bases/security.kubearmor.com_kubearmorhostpolicies.yaml
+++ b/pkg/KubeArmorHostPolicy/config/crd/bases/security.kubearmor.com_kubearmorhostpolicies.yaml
@@ -71,7 +71,7 @@ spec:
                           items:
                             properties:
                               path:
-                                pattern: ^\/([A-z0-9-_.]+\/)*([A-z0-9-_.]+)$
+                                pattern: ^\/+.*[^\/]$
                                 type: string
                             type: object
                           type: array
@@ -121,13 +121,13 @@ spec:
                           - Block
                           type: string
                         dir:
-                          pattern: ^\/([A-z0-9-_.]+\/)*([A-z0-9-_.]+)+\/$
+                          pattern: ^\/$|^\/.*\/$
                           type: string
                         fromSource:
                           items:
                             properties:
                               path:
-                                pattern: ^\/([A-z0-9-_.]+\/)*([A-z0-9-_.]+)$
+                                pattern: ^\/+.*[^\/]$
                                 type: string
                             type: object
                           type: array
@@ -164,7 +164,7 @@ spec:
                           items:
                             properties:
                               path:
-                                pattern: ^\/([A-z0-9-_.]+\/)*([A-z0-9-_.]+)$
+                                pattern: ^\/+.*[^\/]$
                                 type: string
                             type: object
                           type: array
@@ -173,7 +173,7 @@ spec:
                         ownerOnly:
                           type: boolean
                         path:
-                          pattern: ^\/([A-z0-9-_.]+\/)*([A-z0-9-_.]+)$
+                          pattern: ^\/+.*[^\/]$
                           type: string
                         readOnly:
                           type: boolean
@@ -252,7 +252,7 @@ spec:
                           items:
                             properties:
                               path:
-                                pattern: ^\/([A-z0-9-_.]+\/)*([A-z0-9-_.]+)$
+                                pattern: ^\/+.*[^\/]$
                                 type: string
                             type: object
                           type: array
@@ -312,13 +312,13 @@ spec:
                           - Block
                           type: string
                         dir:
-                          pattern: ^\/([A-z0-9-_.]+\/)*([A-z0-9-_.]+)+\/$
+                          pattern: ^\/$|^\/.*\/$
                           type: string
                         fromSource:
                           items:
                             properties:
                               path:
-                                pattern: ^\/([A-z0-9-_.]+\/)*([A-z0-9-_.]+)$
+                                pattern: ^\/+.*[^\/]$
                                 type: string
                             type: object
                           type: array
@@ -353,7 +353,7 @@ spec:
                           items:
                             properties:
                               path:
-                                pattern: ^\/([A-z0-9-_.]+\/)*([A-z0-9-_.]+)$
+                                pattern: ^\/+.*[^\/]$
                                 type: string
                             type: object
                           type: array
@@ -362,7 +362,7 @@ spec:
                         ownerOnly:
                           type: boolean
                         path:
-                          pattern: ^\/([A-z0-9-_.]+\/)*([A-z0-9-_.]+)$
+                          pattern: ^\/+.*[^\/]$
                           type: string
                         severity:
                           maximum: 10

--- a/pkg/KubeArmorHostPolicy/crd/KubeArmorHostPolicy.yaml
+++ b/pkg/KubeArmorHostPolicy/crd/KubeArmorHostPolicy.yaml
@@ -71,7 +71,7 @@ spec:
                           items:
                             properties:
                               path:
-                                pattern: ^\/([A-z0-9-_.]+\/)*([A-z0-9-_.]+)$
+                                pattern: ^\/+.*[^\/]$
                                 type: string
                             type: object
                           type: array
@@ -121,13 +121,13 @@ spec:
                           - Block
                           type: string
                         dir:
-                          pattern: ^\/([A-z0-9-_.]+\/)*([A-z0-9-_.]+)+\/$
+                          pattern: ^\/$|^\/.*\/$
                           type: string
                         fromSource:
                           items:
                             properties:
                               path:
-                                pattern: ^\/([A-z0-9-_.]+\/)*([A-z0-9-_.]+)$
+                                pattern: ^\/+.*[^\/]$
                                 type: string
                             type: object
                           type: array
@@ -164,7 +164,7 @@ spec:
                           items:
                             properties:
                               path:
-                                pattern: ^\/([A-z0-9-_.]+\/)*([A-z0-9-_.]+)$
+                                pattern: ^\/+.*[^\/]$
                                 type: string
                             type: object
                           type: array
@@ -173,7 +173,7 @@ spec:
                         ownerOnly:
                           type: boolean
                         path:
-                          pattern: ^\/([A-z0-9-_.]+\/)*([A-z0-9-_.]+)$
+                          pattern: ^\/+.*[^\/]$
                           type: string
                         readOnly:
                           type: boolean
@@ -252,7 +252,7 @@ spec:
                           items:
                             properties:
                               path:
-                                pattern: ^\/([A-z0-9-_.]+\/)*([A-z0-9-_.]+)$
+                                pattern: ^\/+.*[^\/]$
                                 type: string
                             type: object
                           type: array
@@ -312,13 +312,13 @@ spec:
                           - Block
                           type: string
                         dir:
-                          pattern: ^\/([A-z0-9-_.]+\/)*([A-z0-9-_.]+)+\/$
+                          pattern: ^\/$|^\/.*\/$
                           type: string
                         fromSource:
                           items:
                             properties:
                               path:
-                                pattern: ^\/([A-z0-9-_.]+\/)*([A-z0-9-_.]+)$
+                                pattern: ^\/+.*[^\/]$
                                 type: string
                             type: object
                           type: array
@@ -353,7 +353,7 @@ spec:
                           items:
                             properties:
                               path:
-                                pattern: ^\/([A-z0-9-_.]+\/)*([A-z0-9-_.]+)$
+                                pattern: ^\/+.*[^\/]$
                                 type: string
                             type: object
                           type: array
@@ -362,7 +362,7 @@ spec:
                         ownerOnly:
                           type: boolean
                         path:
-                          pattern: ^\/([A-z0-9-_.]+\/)*([A-z0-9-_.]+)$
+                          pattern: ^\/+.*[^\/]$
                           type: string
                         severity:
                           maximum: 10

--- a/pkg/KubeArmorPolicy/api/security.kubearmor.com/v1/kubearmorpolicy_types.go
+++ b/pkg/KubeArmorPolicy/api/security.kubearmor.com/v1/kubearmorpolicy_types.go
@@ -15,10 +15,10 @@ type SelectorType struct {
 	MatchLabels map[string]string `json:"matchLabels,omitempty"`
 }
 
-// +kubebuilder:validation:Pattern=^\/([A-z0-9-_.]+\/)*([A-z0-9-_.]+)$
+// +kubebuilder:validation:Pattern=^\/+.*[^\/]$
 type MatchPathType string
 
-// +kubebuilder:validation:Pattern=^\/([A-z0-9-_.]+\/)*([A-z0-9-_.]+)+\/$
+// +kubebuilder:validation:Pattern=^\/$|^\/.*\/$
 type MatchDirectoryType string
 
 type MatchSourceType struct {

--- a/pkg/KubeArmorPolicy/config/crd/bases/security.kubearmor.com_kubearmorpolicies.yaml
+++ b/pkg/KubeArmorPolicy/config/crd/bases/security.kubearmor.com_kubearmorpolicies.yaml
@@ -70,7 +70,7 @@ spec:
                           items:
                             properties:
                               path:
-                                pattern: ^\/([A-z0-9-_.]+\/)*([A-z0-9-_.]+)$
+                                pattern: ^\/+.*[^\/]$
                                 type: string
                             type: object
                           type: array
@@ -119,13 +119,13 @@ spec:
                           - Block
                           type: string
                         dir:
-                          pattern: ^\/([A-z0-9-_.]+\/)*([A-z0-9-_.]+)+\/$
+                          pattern: ^\/$|^\/.*\/$
                           type: string
                         fromSource:
                           items:
                             properties:
                               path:
-                                pattern: ^\/([A-z0-9-_.]+\/)*([A-z0-9-_.]+)$
+                                pattern: ^\/+.*[^\/]$
                                 type: string
                             type: object
                           type: array
@@ -162,7 +162,7 @@ spec:
                           items:
                             properties:
                               path:
-                                pattern: ^\/([A-z0-9-_.]+\/)*([A-z0-9-_.]+)$
+                                pattern: ^\/+.*[^\/]$
                                 type: string
                             type: object
                           type: array
@@ -171,7 +171,7 @@ spec:
                         ownerOnly:
                           type: boolean
                         path:
-                          pattern: ^\/([A-z0-9-_.]+\/)*([A-z0-9-_.]+)$
+                          pattern: ^\/+.*[^\/]$
                           type: string
                         readOnly:
                           type: boolean
@@ -250,7 +250,7 @@ spec:
                           items:
                             properties:
                               path:
-                                pattern: ^\/([A-z0-9-_.]+\/)*([A-z0-9-_.]+)$
+                                pattern: ^\/+.*[^\/]$
                                 type: string
                             type: object
                           type: array
@@ -302,13 +302,13 @@ spec:
                           - Block
                           type: string
                         dir:
-                          pattern: ^\/([A-z0-9-_.]+\/)*([A-z0-9-_.]+)+\/$
+                          pattern: ^\/$|^\/.*\/$
                           type: string
                         fromSource:
                           items:
                             properties:
                               path:
-                                pattern: ^\/([A-z0-9-_.]+\/)*([A-z0-9-_.]+)$
+                                pattern: ^\/+.*[^\/]$
                                 type: string
                             type: object
                           type: array
@@ -343,7 +343,7 @@ spec:
                           items:
                             properties:
                               path:
-                                pattern: ^\/([A-z0-9-_.]+\/)*([A-z0-9-_.]+)$
+                                pattern: ^\/+.*[^\/]$
                                 type: string
                             type: object
                           type: array
@@ -352,7 +352,7 @@ spec:
                         ownerOnly:
                           type: boolean
                         path:
-                          pattern: ^\/([A-z0-9-_.]+\/)*([A-z0-9-_.]+)$
+                          pattern: ^\/+.*[^\/]$
                           type: string
                         severity:
                           maximum: 10
@@ -429,12 +429,12 @@ spec:
                           - Block
                           type: string
                         dir:
-                          pattern: ^\/([A-z0-9-_.]+\/)*([A-z0-9-_.]+)+\/$
+                          pattern: ^\/$|^\/.*\/$
                           type: string
                         message:
                           type: string
                         path:
-                          pattern: ^\/([A-z0-9-_.]+\/)*([A-z0-9-_.]+)$
+                          pattern: ^\/+.*[^\/]$
                           type: string
                         readOnly:
                           type: boolean

--- a/pkg/KubeArmorPolicy/crd/KubeArmorPolicy.yaml
+++ b/pkg/KubeArmorPolicy/crd/KubeArmorPolicy.yaml
@@ -70,7 +70,7 @@ spec:
                           items:
                             properties:
                               path:
-                                pattern: ^\/([A-z0-9-_.]+\/)*([A-z0-9-_.]+)$
+                                pattern: ^\/+.*[^\/]$
                                 type: string
                             type: object
                           type: array
@@ -119,13 +119,13 @@ spec:
                           - Block
                           type: string
                         dir:
-                          pattern: ^\/([A-z0-9-_.]+\/)*([A-z0-9-_.]+)+\/$
+                          pattern: ^\/$|^\/.*\/$
                           type: string
                         fromSource:
                           items:
                             properties:
                               path:
-                                pattern: ^\/([A-z0-9-_.]+\/)*([A-z0-9-_.]+)$
+                                pattern: ^\/+.*[^\/]$
                                 type: string
                             type: object
                           type: array
@@ -162,7 +162,7 @@ spec:
                           items:
                             properties:
                               path:
-                                pattern: ^\/([A-z0-9-_.]+\/)*([A-z0-9-_.]+)$
+                                pattern: ^\/+.*[^\/]$
                                 type: string
                             type: object
                           type: array
@@ -171,7 +171,7 @@ spec:
                         ownerOnly:
                           type: boolean
                         path:
-                          pattern: ^\/([A-z0-9-_.]+\/)*([A-z0-9-_.]+)$
+                          pattern: ^\/+.*[^\/]$
                           type: string
                         readOnly:
                           type: boolean
@@ -250,7 +250,7 @@ spec:
                           items:
                             properties:
                               path:
-                                pattern: ^\/([A-z0-9-_.]+\/)*([A-z0-9-_.]+)$
+                                pattern: ^\/+.*[^\/]$
                                 type: string
                             type: object
                           type: array
@@ -302,13 +302,13 @@ spec:
                           - Block
                           type: string
                         dir:
-                          pattern: ^\/([A-z0-9-_.]+\/)*([A-z0-9-_.]+)+\/$
+                          pattern: ^\/$|^\/.*\/$
                           type: string
                         fromSource:
                           items:
                             properties:
                               path:
-                                pattern: ^\/([A-z0-9-_.]+\/)*([A-z0-9-_.]+)$
+                                pattern: ^\/+.*[^\/]$
                                 type: string
                             type: object
                           type: array
@@ -343,7 +343,7 @@ spec:
                           items:
                             properties:
                               path:
-                                pattern: ^\/([A-z0-9-_.]+\/)*([A-z0-9-_.]+)$
+                                pattern: ^\/+.*[^\/]$
                                 type: string
                             type: object
                           type: array
@@ -352,7 +352,7 @@ spec:
                         ownerOnly:
                           type: boolean
                         path:
-                          pattern: ^\/([A-z0-9-_.]+\/)*([A-z0-9-_.]+)$
+                          pattern: ^\/+.*[^\/]$
                           type: string
                         severity:
                           maximum: 10
@@ -429,12 +429,12 @@ spec:
                           - Block
                           type: string
                         dir:
-                          pattern: ^\/([A-z0-9-_.]+\/)*([A-z0-9-_.]+)+\/$
+                          pattern: ^\/$|^\/.*\/$
                           type: string
                         message:
                           type: string
                         path:
-                          pattern: ^\/([A-z0-9-_.]+\/)*([A-z0-9-_.]+)$
+                          pattern: ^\/+.*[^\/]$
                           type: string
                         readOnly:
                           type: boolean


### PR DESCRIPTION
- unix file paths accepts all characters, not just alphanumeric. Updated validation regex accordingly
- matchDir now accepts "/" as well

FIxes #641 