### PR TITLE
deploy/core: kubearmor for GKE latest COS images [backport]

### DIFF
--- a/deployments/EKS/kubearmor.yaml
+++ b/deployments/EKS/kubearmor.yaml
@@ -100,9 +100,6 @@ spec:
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:
-        - mountPath: /usr/src
-          name: usr-src-path
-          readOnly: true
         - mountPath: /lib/modules
           name: lib-modules-path
           readOnly: true
@@ -114,6 +111,9 @@ spec:
           name: sys-kernel-debug-path
         - mountPath: /media/root/etc/os-release
           name: os-release-path
+          readOnly: true
+        - mountPath: /usr/src
+          name: usr-src-path
           readOnly: true
         - mountPath: /etc/apparmor.d
           name: etc-apparmor-d-path
@@ -138,10 +138,6 @@ spec:
       - operator: Exists
       volumes:
       - hostPath:
-          path: /usr/src
-          type: Directory
-        name: usr-src-path
-      - hostPath:
           path: /lib/modules
           type: Directory
         name: lib-modules-path
@@ -161,6 +157,10 @@ spec:
           path: /etc/os-release
           type: File
         name: os-release-path
+      - hostPath:
+          path: /usr/src
+          type: Directory
+        name: usr-src-path
       - hostPath:
           path: /etc/apparmor.d
           type: DirectoryOrCreate

--- a/deployments/GKE/kubearmor.yaml
+++ b/deployments/GKE/kubearmor.yaml
@@ -100,9 +100,6 @@ spec:
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:
-        - mountPath: /usr/src
-          name: usr-src-path
-          readOnly: true
         - mountPath: /lib/modules
           name: lib-modules-path
           readOnly: true
@@ -114,6 +111,9 @@ spec:
           name: sys-kernel-debug-path
         - mountPath: /media/root/etc/os-release
           name: os-release-path
+          readOnly: true
+        - mountPath: /media/root/usr
+          name: usr-src-path
           readOnly: true
         - mountPath: /etc/apparmor.d
           name: etc-apparmor-d-path
@@ -138,10 +138,6 @@ spec:
       - operator: Exists
       volumes:
       - hostPath:
-          path: /usr/src
-          type: Directory
-        name: usr-src-path
-      - hostPath:
           path: /lib/modules
           type: Directory
         name: lib-modules-path
@@ -161,6 +157,10 @@ spec:
           path: /etc/os-release
           type: File
         name: os-release-path
+      - hostPath:
+          path: /usr
+          type: Directory
+        name: usr-src-path
       - hostPath:
           path: /etc/apparmor.d
           type: DirectoryOrCreate

--- a/deployments/docker/kubearmor.yaml
+++ b/deployments/docker/kubearmor.yaml
@@ -100,9 +100,6 @@ spec:
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:
-        - mountPath: /usr/src
-          name: usr-src-path
-          readOnly: true
         - mountPath: /lib/modules
           name: lib-modules-path
           readOnly: true
@@ -114,6 +111,9 @@ spec:
           name: sys-kernel-debug-path
         - mountPath: /media/root/etc/os-release
           name: os-release-path
+          readOnly: true
+        - mountPath: /usr/src
+          name: usr-src-path
           readOnly: true
         - mountPath: /etc/apparmor.d
           name: etc-apparmor-d-path
@@ -135,10 +135,6 @@ spec:
       - operator: Exists
       volumes:
       - hostPath:
-          path: /usr/src
-          type: Directory
-        name: usr-src-path
-      - hostPath:
           path: /lib/modules
           type: Directory
         name: lib-modules-path
@@ -158,6 +154,10 @@ spec:
           path: /etc/os-release
           type: File
         name: os-release-path
+      - hostPath:
+          path: /usr/src
+          type: Directory
+        name: usr-src-path
       - hostPath:
           path: /etc/apparmor.d
           type: DirectoryOrCreate

--- a/deployments/generic/kubearmor.yaml
+++ b/deployments/generic/kubearmor.yaml
@@ -100,9 +100,6 @@ spec:
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:
-        - mountPath: /usr/src
-          name: usr-src-path
-          readOnly: true
         - mountPath: /lib/modules
           name: lib-modules-path
           readOnly: true
@@ -114,6 +111,9 @@ spec:
           name: sys-kernel-debug-path
         - mountPath: /media/root/etc/os-release
           name: os-release-path
+          readOnly: true
+        - mountPath: /usr/src
+          name: usr-src-path
           readOnly: true
         - mountPath: /etc/apparmor.d
           name: etc-apparmor-d-path
@@ -138,10 +138,6 @@ spec:
       - operator: Exists
       volumes:
       - hostPath:
-          path: /usr/src
-          type: Directory
-        name: usr-src-path
-      - hostPath:
           path: /lib/modules
           type: Directory
         name: lib-modules-path
@@ -161,6 +157,10 @@ spec:
           path: /etc/os-release
           type: File
         name: os-release-path
+      - hostPath:
+          path: /usr/src
+          type: Directory
+        name: usr-src-path
       - hostPath:
           path: /etc/apparmor.d
           type: DirectoryOrCreate

--- a/deployments/get/defaults.go
+++ b/deployments/get/defaults.go
@@ -29,6 +29,53 @@ var hostPathDirectoryOrCreate = corev1.HostPathDirectoryOrCreate
 var hostPathFile = corev1.HostPathFile
 var hostPathSocket = corev1.HostPathSocket
 
+var gkeHostUsrVolMnt = corev1.VolumeMount{
+	Name:      "usr-src-path", // /usr -> /media/root/usr (read-only) check issue #579 for details
+	MountPath: "/media/root/usr",
+	ReadOnly:  true,
+}
+
+var gkeHostUsrVol = corev1.Volume{ // check #579 why GKE is handled separately
+	Name: "usr-src-path",
+	VolumeSource: corev1.VolumeSource{
+		HostPath: &corev1.HostPathVolumeSource{
+			Path: "/usr",
+			Type: &hostPathDirectory,
+		},
+	},
+}
+
+var hostUsrVolMnt = corev1.VolumeMount{
+	Name:      "usr-src-path", // /usr/src (read-only)
+	MountPath: "/usr/src",
+	ReadOnly:  true,
+}
+
+var hostUsrVol = corev1.Volume{
+	Name: "usr-src-path",
+	VolumeSource: corev1.VolumeSource{
+		HostPath: &corev1.HostPathVolumeSource{
+			Path: "/usr/src",
+			Type: &hostPathDirectory,
+		},
+	},
+}
+
+var apparmorVolMnt = corev1.VolumeMount{
+	Name:      "etc-apparmor-d-path",
+	MountPath: "/etc/apparmor.d",
+}
+
+var apparmorVol = corev1.Volume{
+	Name: "etc-apparmor-d-path",
+	VolumeSource: corev1.VolumeSource{
+		HostPath: &corev1.HostPathVolumeSource{
+			Path: "/etc/apparmor.d",
+			Type: &hostPathDirectoryOrCreate,
+		},
+	},
+}
+
 // Environment Specific Daemonset Configuration
 var defaultConfigs = map[string]DaemonSetConfig{
 	"generic": {
@@ -36,10 +83,8 @@ var defaultConfigs = map[string]DaemonSetConfig{
 			"-enableKubeArmorHostPolicy",
 		},
 		VolumeMounts: []corev1.VolumeMount{
-			{
-				Name:      "etc-apparmor-d-path",
-				MountPath: "/etc/apparmor.d",
-			},
+			hostUsrVolMnt,
+			apparmorVolMnt,
 			{
 				Name:      "containerd-sock-path", // containerd
 				MountPath: "/var/run/containerd/containerd.sock",
@@ -57,15 +102,8 @@ var defaultConfigs = map[string]DaemonSetConfig{
 			},
 		},
 		Volumes: []corev1.Volume{
-			{
-				Name: "etc-apparmor-d-path",
-				VolumeSource: corev1.VolumeSource{
-					HostPath: &corev1.HostPathVolumeSource{
-						Path: "/etc/apparmor.d",
-						Type: &hostPathDirectoryOrCreate,
-					},
-				},
-			},
+			hostUsrVol,
+			apparmorVol,
 			{
 				Name: "containerd-sock-path",
 				VolumeSource: corev1.VolumeSource{
@@ -100,10 +138,8 @@ var defaultConfigs = map[string]DaemonSetConfig{
 			"-enableKubeArmorHostPolicy",
 		},
 		VolumeMounts: []corev1.VolumeMount{
-			{
-				Name:      "etc-apparmor-d-path",
-				MountPath: "/etc/apparmor.d",
-			},
+			hostUsrVolMnt,
+			apparmorVolMnt,
 			{
 				Name:      "docker-sock-path", // docker
 				MountPath: "/var/run/docker.sock",
@@ -116,15 +152,8 @@ var defaultConfigs = map[string]DaemonSetConfig{
 			},
 		},
 		Volumes: []corev1.Volume{
-			{
-				Name: "etc-apparmor-d-path",
-				VolumeSource: corev1.VolumeSource{
-					HostPath: &corev1.HostPathVolumeSource{
-						Path: "/etc/apparmor.d",
-						Type: &hostPathDirectoryOrCreate,
-					},
-				},
-			},
+			hostUsrVol,
+			apparmorVol,
 			{
 				Name: "docker-sock-path",
 				VolumeSource: corev1.VolumeSource{
@@ -148,10 +177,8 @@ var defaultConfigs = map[string]DaemonSetConfig{
 	"minikube": {
 		Args: []string{},
 		VolumeMounts: []corev1.VolumeMount{
-			{
-				Name:      "etc-apparmor-d-path",
-				MountPath: "/etc/apparmor.d",
-			},
+			hostUsrVolMnt,
+			apparmorVolMnt,
 			{
 				Name:      "docker-sock-path", // docker
 				MountPath: "/var/run/docker.sock",
@@ -164,15 +191,8 @@ var defaultConfigs = map[string]DaemonSetConfig{
 			},
 		},
 		Volumes: []corev1.Volume{
-			{
-				Name: "etc-apparmor-d-path",
-				VolumeSource: corev1.VolumeSource{
-					HostPath: &corev1.HostPathVolumeSource{
-						Path: "/etc/apparmor.d",
-						Type: &hostPathDirectoryOrCreate,
-					},
-				},
-			},
+			hostUsrVol,
+			apparmorVol,
 			{
 				Name: "docker-sock-path",
 				VolumeSource: corev1.VolumeSource{
@@ -198,10 +218,8 @@ var defaultConfigs = map[string]DaemonSetConfig{
 			"-enableKubeArmorHostPolicy",
 		},
 		VolumeMounts: []corev1.VolumeMount{
-			{
-				Name:      "etc-apparmor-d-path",
-				MountPath: "/etc/apparmor.d",
-			},
+			hostUsrVolMnt,
+			apparmorVolMnt,
 			{
 				Name:      "containerd-sock-path", // containerd
 				MountPath: "/var/snap/microk8s/common/run/containerd.sock",
@@ -214,15 +232,8 @@ var defaultConfigs = map[string]DaemonSetConfig{
 			},
 		},
 		Volumes: []corev1.Volume{
-			{
-				Name: "etc-apparmor-d-path",
-				VolumeSource: corev1.VolumeSource{
-					HostPath: &corev1.HostPathVolumeSource{
-						Path: "/etc/apparmor.d",
-						Type: &hostPathDirectoryOrCreate,
-					},
-				},
-			},
+			hostUsrVol,
+			apparmorVol,
 			{
 				Name: "containerd-sock-path",
 				VolumeSource: corev1.VolumeSource{
@@ -248,10 +259,8 @@ var defaultConfigs = map[string]DaemonSetConfig{
 			"-enableKubeArmorHostPolicy",
 		},
 		VolumeMounts: []corev1.VolumeMount{
-			{
-				Name:      "etc-apparmor-d-path",
-				MountPath: "/etc/apparmor.d",
-			},
+			hostUsrVolMnt,
+			apparmorVolMnt,
 			{
 				Name:      "containerd-sock-path", // containerd
 				MountPath: "/var/run/containerd/containerd.sock",
@@ -264,15 +273,8 @@ var defaultConfigs = map[string]DaemonSetConfig{
 			},
 		},
 		Volumes: []corev1.Volume{
-			{
-				Name: "etc-apparmor-d-path",
-				VolumeSource: corev1.VolumeSource{
-					HostPath: &corev1.HostPathVolumeSource{
-						Path: "/etc/apparmor.d",
-						Type: &hostPathDirectoryOrCreate,
-					},
-				},
-			},
+			hostUsrVol,
+			apparmorVol,
 			{
 				Name: "containerd-sock-path",
 				VolumeSource: corev1.VolumeSource{
@@ -298,10 +300,8 @@ var defaultConfigs = map[string]DaemonSetConfig{
 			"-enableKubeArmorHostPolicy",
 		},
 		VolumeMounts: []corev1.VolumeMount{
-			{
-				Name:      "etc-apparmor-d-path",
-				MountPath: "/etc/apparmor.d",
-			},
+			gkeHostUsrVolMnt,
+			apparmorVolMnt,
 			{
 				Name:      "containerd-sock-path", // containerd
 				MountPath: "/var/run/containerd/containerd.sock",
@@ -319,15 +319,8 @@ var defaultConfigs = map[string]DaemonSetConfig{
 			},
 		},
 		Volumes: []corev1.Volume{
-			{
-				Name: "etc-apparmor-d-path",
-				VolumeSource: corev1.VolumeSource{
-					HostPath: &corev1.HostPathVolumeSource{
-						Path: "/etc/apparmor.d",
-						Type: &hostPathDirectoryOrCreate,
-					},
-				},
-			},
+			gkeHostUsrVol,
+			apparmorVol,
 			{
 				Name: "containerd-sock-path",
 				VolumeSource: corev1.VolumeSource{
@@ -362,10 +355,8 @@ var defaultConfigs = map[string]DaemonSetConfig{
 			"-enableKubeArmorHostPolicy",
 		},
 		VolumeMounts: []corev1.VolumeMount{
-			{
-				Name:      "etc-apparmor-d-path",
-				MountPath: "/etc/apparmor.d",
-			},
+			hostUsrVolMnt,
+			apparmorVolMnt,
 			{
 				Name:      "containerd-sock-path", // containerd
 				MountPath: "/var/run/containerd/containerd.sock",
@@ -383,15 +374,8 @@ var defaultConfigs = map[string]DaemonSetConfig{
 			},
 		},
 		Volumes: []corev1.Volume{
-			{
-				Name: "etc-apparmor-d-path",
-				VolumeSource: corev1.VolumeSource{
-					HostPath: &corev1.HostPathVolumeSource{
-						Path: "/etc/apparmor.d",
-						Type: &hostPathDirectoryOrCreate,
-					},
-				},
-			},
+			hostUsrVol,
+			apparmorVol,
 			{
 				Name: "containerd-sock-path",
 				VolumeSource: corev1.VolumeSource{

--- a/deployments/get/objects.go
+++ b/deployments/get/objects.go
@@ -364,12 +364,8 @@ func GenerateDaemonSet(env, namespace string) *appsv1.DaemonSet {
 		"-gRPC=" + strconv.Itoa(int(port)),
 		"-logPath=/tmp/kubearmor.log",
 	}
+
 	var volumeMounts = []corev1.VolumeMount{
-		{
-			Name:      "usr-src-path", //BPF (read-only)
-			MountPath: "/usr/src",
-			ReadOnly:  true,
-		},
 		{
 			Name:      "lib-modules-path", //BPF (read-only)
 			MountPath: "/lib/modules",
@@ -395,15 +391,6 @@ func GenerateDaemonSet(env, namespace string) *appsv1.DaemonSet {
 	}
 
 	var volumes = []corev1.Volume{
-		{
-			Name: "usr-src-path",
-			VolumeSource: corev1.VolumeSource{
-				HostPath: &corev1.HostPathVolumeSource{
-					Path: "/usr/src",
-					Type: &hostPathDirectory,
-				},
-			},
-		},
 		{
 			Name: "lib-modules-path",
 			VolumeSource: corev1.VolumeSource{

--- a/deployments/k3s/kubearmor.yaml
+++ b/deployments/k3s/kubearmor.yaml
@@ -100,9 +100,6 @@ spec:
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:
-        - mountPath: /usr/src
-          name: usr-src-path
-          readOnly: true
         - mountPath: /lib/modules
           name: lib-modules-path
           readOnly: true
@@ -114,6 +111,9 @@ spec:
           name: sys-kernel-debug-path
         - mountPath: /media/root/etc/os-release
           name: os-release-path
+          readOnly: true
+        - mountPath: /usr/src
+          name: usr-src-path
           readOnly: true
         - mountPath: /etc/apparmor.d
           name: etc-apparmor-d-path
@@ -135,10 +135,6 @@ spec:
       - operator: Exists
       volumes:
       - hostPath:
-          path: /usr/src
-          type: Directory
-        name: usr-src-path
-      - hostPath:
           path: /lib/modules
           type: Directory
         name: lib-modules-path
@@ -158,6 +154,10 @@ spec:
           path: /etc/os-release
           type: File
         name: os-release-path
+      - hostPath:
+          path: /usr/src
+          type: Directory
+        name: usr-src-path
       - hostPath:
           path: /etc/apparmor.d
           type: DirectoryOrCreate

--- a/deployments/microk8s/kubearmor.yaml
+++ b/deployments/microk8s/kubearmor.yaml
@@ -100,9 +100,6 @@ spec:
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:
-        - mountPath: /usr/src
-          name: usr-src-path
-          readOnly: true
         - mountPath: /lib/modules
           name: lib-modules-path
           readOnly: true
@@ -114,6 +111,9 @@ spec:
           name: sys-kernel-debug-path
         - mountPath: /media/root/etc/os-release
           name: os-release-path
+          readOnly: true
+        - mountPath: /usr/src
+          name: usr-src-path
           readOnly: true
         - mountPath: /etc/apparmor.d
           name: etc-apparmor-d-path
@@ -135,10 +135,6 @@ spec:
       - operator: Exists
       volumes:
       - hostPath:
-          path: /usr/src
-          type: Directory
-        name: usr-src-path
-      - hostPath:
           path: /lib/modules
           type: Directory
         name: lib-modules-path
@@ -158,6 +154,10 @@ spec:
           path: /etc/os-release
           type: File
         name: os-release-path
+      - hostPath:
+          path: /usr/src
+          type: Directory
+        name: usr-src-path
       - hostPath:
           path: /etc/apparmor.d
           type: DirectoryOrCreate

--- a/deployments/minikube/kubearmor.yaml
+++ b/deployments/minikube/kubearmor.yaml
@@ -99,9 +99,6 @@ spec:
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:
-        - mountPath: /usr/src
-          name: usr-src-path
-          readOnly: true
         - mountPath: /lib/modules
           name: lib-modules-path
           readOnly: true
@@ -113,6 +110,9 @@ spec:
           name: sys-kernel-debug-path
         - mountPath: /media/root/etc/os-release
           name: os-release-path
+          readOnly: true
+        - mountPath: /usr/src
+          name: usr-src-path
           readOnly: true
         - mountPath: /etc/apparmor.d
           name: etc-apparmor-d-path
@@ -134,10 +134,6 @@ spec:
       - operator: Exists
       volumes:
       - hostPath:
-          path: /usr/src
-          type: Directory
-        name: usr-src-path
-      - hostPath:
           path: /lib/modules
           type: Directory
         name: lib-modules-path
@@ -157,6 +153,10 @@ spec:
           path: /etc/os-release
           type: File
         name: os-release-path
+      - hostPath:
+          path: /usr/src
+          type: Directory
+        name: usr-src-path
       - hostPath:
           path: /etc/apparmor.d
           type: DirectoryOrCreate


### PR DESCRIPTION
* latest GKE COS images do not have path for /usr/src.
* deploygen updated to create kubearmor.yamls accordingly

Detailed description:
GKE supports multiple images types, viz COS and non-COS(Ubuntu, Debian
etc). In case of non-COS images, the `/usr/src` contains the kernel
headers. In case of COS, kubearmor internally downloads the kernel
headers but still it used to mount `/usr/src` since we used a single yaml
for COS and non-COS images. In the latest releases of COS images
(for e.g., 1.22.6-gke-1000), the `/usr/src` folder is no longer
present. The current changes now mounts /usr to `/media/root/usr` folder for
GKE (only). The kubearmor code internally sets `BCC_KERNEL_SOURCE` to
`/media/root/usr/src/linux-headers-KERNELVER`.

Fixes #579

Signed-off-by: Rahul Jadhav <nyrahul@gmail.com>