### PR TITLE
GH-actions: release from upstream repo only

### DIFF
--- a/.github/workflows/latest-release.yml
+++ b/.github/workflows/latest-release.yml
@@ -19,6 +19,7 @@ name: Create KubeArmor release after testing the image
 jobs:
   build:
     name: Create KubeArmor Release
+    if: github.repository == 'kubearmor/kubearmor'
     runs-on: ubuntu-18.04
     timeout-minutes: 20
     steps:


### PR DESCRIPTION
Currently, this ([latest-release.yml](https://github.com/kubearmor/KubeArmor/pull/654/files#diff-28c4ceeee740d706ecc91beee3d53e16f0815ddc765261c9dc60669d8a40973e)) GH-action is fired from every individual forked repo and
since it doesn't have the docker credentials the action fails. This
GH-action should be executed only in the context of the upstream repo.

Signed-off-by: Rahul Jadhav <nyrahul@gmail.com>