### PR TITLE
use random grpc port

### DIFF
--- a/KubeArmor/config/config.go
+++ b/KubeArmor/config/config.go
@@ -35,6 +35,9 @@ type KubearmorConfig struct {
 // PolicyDir policy dir path for host policies backup
 const PolicyDir string = "/opt/kubearmor/policies/"
 
+// PIDFilePath for pid file path
+const PIDFilePath string = "/opt/kubearmor/kubearmor.pid"
+
 // GlobalCfg Global configuration for Kubearmor
 var GlobalCfg KubearmorConfig
 

--- a/KubeArmor/core/kubeArmor.go
+++ b/KubeArmor/core/kubeArmor.go
@@ -177,7 +177,11 @@ func (dm *KubeArmorDaemon) DestroyKubeArmorDaemon() {
 	// delete pid file
 	if _, err := os.Stat(cfg.PIDFilePath); err == nil {
 		kg.Print("Deleting PID file")
-		os.Remove(cfg.PIDFilePath)
+		
+		err := os.Remove(cfg.PIDFilePath)
+		if err != nil {
+			kg.Errf("Failed to delete PID file")
+		}
 	}
 }
 

--- a/KubeArmor/core/kubeArmor.go
+++ b/KubeArmor/core/kubeArmor.go
@@ -173,6 +173,12 @@ func (dm *KubeArmorDaemon) DestroyKubeArmorDaemon() {
 	// wait for other routines
 	kg.Print("Waiting for routine terminations")
 	dm.WgDaemon.Wait()
+
+	// delete pid file
+	if _, err := os.Stat(cfg.PIDFilePath); err == nil {
+		kg.Print("Deleting PID file")
+		os.Remove(cfg.PIDFilePath)
+	}
 }
 
 // ============ //

--- a/KubeArmor/feeder/feeder.go
+++ b/KubeArmor/feeder/feeder.go
@@ -329,7 +329,9 @@ func NewFeeder(node *tp.Node) *Feeder {
 			return nil
 		}
 
-		defer pidFile.Close()
+		defer func() {
+			pidFile.Close()
+		}()
 
 		port := fmt.Sprintf("%d", listener.Addr().(*net.TCPAddr).Port)
 		fd.Port = fmt.Sprintf(":%s", port)

--- a/KubeArmor/feeder/feeder.go
+++ b/KubeArmor/feeder/feeder.go
@@ -329,6 +329,8 @@ func NewFeeder(node *tp.Node) *Feeder {
 			return nil
 		}
 
+		defer pidFile.Close()
+
 		port := fmt.Sprintf("%d", listener.Addr().(*net.TCPAddr).Port)
 		fd.Port = fmt.Sprintf(":%s", port)
 

--- a/KubeArmor/feeder/feeder.go
+++ b/KubeArmor/feeder/feeder.go
@@ -322,6 +322,23 @@ func NewFeeder(node *tp.Node) *Feeder {
 	}
 	fd.Listener = listener
 
+	if cfg.GlobalCfg.GRPC == "0" {
+		pidFile, err := os.Create(cfg.PIDFilePath)
+		if err != nil {
+			kg.Errf("Failed to create file %s", cfg.PIDFilePath)
+			return nil
+		}
+
+		port := fmt.Sprintf("%d", listener.Addr().(*net.TCPAddr).Port)
+		fd.Port = port
+
+		_, err = pidFile.WriteString(port)
+		if err != nil {
+			kg.Errf("Failed to write file %s", cfg.PIDFilePath)
+			return nil
+		}
+	}
+
 	// create a log server
 	fd.LogServer = grpc.NewServer()
 

--- a/KubeArmor/feeder/feeder.go
+++ b/KubeArmor/feeder/feeder.go
@@ -330,7 +330,7 @@ func NewFeeder(node *tp.Node) *Feeder {
 		}
 
 		port := fmt.Sprintf("%d", listener.Addr().(*net.TCPAddr).Port)
-		fd.Port = port
+		fd.Port = fmt.Sprintf(":%s", port)
 
 		_, err = pidFile.WriteString(port)
 		if err != nil {

--- a/KubeArmor/feeder/feeder.go
+++ b/KubeArmor/feeder/feeder.go
@@ -330,7 +330,10 @@ func NewFeeder(node *tp.Node) *Feeder {
 		}
 
 		defer func() {
-			pidFile.Close()
+			err := pidFile.Close()
+			if err != nil {
+				kg.Errf("Failed to close file %s", cfg.PIDFilePath)
+			}
 		}()
 
 		port := fmt.Sprintf("%d", listener.Addr().(*net.TCPAddr).Port)


### PR DESCRIPTION
KubeArmor/config/config.go : define a constant for the pid file path
KubeArmor/feeder/feeder.go : use a random grpc port number and save it to a file

previously we can't use random grpc port

now we can use random grpc port number by specifying "0" as the port number, by using port number 0, we will listen on random port and then we save the random port number to a pid file located in /opt/kubearmor

Signed-off-by: nthnieljson <nthnieljson@gmail.com>