### PR TITLE
update KubeArmorPolicy and KubeArmorHostPolicy

### DIFF
--- a/KubeArmor/build/kubearmor-test-containerd.yaml
+++ b/KubeArmor/build/kubearmor-test-containerd.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -8,6 +9,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: kubearmor
+  namespace: kube-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -20,128 +22,127 @@ subjects:
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  name: kubearmor
-  namespace: kube-system
   labels:
     kubearmor-app: kubearmor
+  name: kubearmor
+  namespace: kube-system
 spec:
   selector:
     matchLabels:
       kubearmor-app: kubearmor
   template:
     metadata:
-      labels:
-        kubearmor-app: kubearmor
       annotations:
         container.apparmor.security.beta.kubernetes.io/kubearmor: unconfined
+      labels:
+        kubearmor-app: kubearmor
     spec:
-      serviceAccountName: kubearmor
-      nodeSelector:
-        kubernetes.io/os: linux
-      tolerations:
-      - operator: Exists
-      hostPID: true
-      hostNetwork: true
-      restartPolicy: Always
-      dnsPolicy: ClusterFirstWithHostNet
       containers:
-      - name: kubearmor
+      - args:
+        - -gRPC=32767
+        - -logPath=/tmp/kubearmor.log
+        - -enableKubeArmorHostPolicy
         image: kubearmor/kubearmor:latest
         imagePullPolicy: Never
-        securityContext:
-          privileged: true
-        args: ["-gRPC=32767", "-logPath=/tmp/kubearmor.log", "-enableKubeArmorHostPolicy"]
-        ports:
-        - containerPort: 32767
-        volumeMounts:
-        - name: containerd-sock-path # containerd (read-only)
-          mountPath: /var/run/containerd/containerd.sock
-          readOnly: true
-        - name: containerd-storage-path # containerd storage (read-only)
-          mountPath: /run/containerd
-          readOnly: true
-        - name: docker-storage-path # docker storage (read-only)
-          mountPath: /var/lib/docker
-          readOnly: true
-        - name: usr-src-path # BPF (read-only)
-          mountPath: /usr/src
-          readOnly: true
-        - name: lib-modules-path # BPF (read-only)
-          mountPath: /lib/modules
-          readOnly: true
-        - name: sys-fs-bpf-path # BPF (read-write)
-          mountPath: /sys/fs/bpf
-        - name: sys-kernel-debug-path # BPF (read-write)
-          mountPath: /sys/kernel/debug
-        - name: sys-kernel-security-path # LSM (read-write)
-          mountPath: /sys/kernel/security
-        - name: etc-apparmor-d-path # AppArmor (read-write)
-          mountPath: /etc/apparmor.d
-        - name: os-release-path # OS (read-only)
-          mountPath: /media/root/etc/os-release
-          readOnly: true
         livenessProbe:
           exec:
             command:
             - /bin/bash
             - -c
-            - |
-              if [ -z $(pgrep kubearmor) ]; then
-                exit 1;
-              fi;
+            - if [ -z $(pgrep kubearmor) ]; then exit 1; fi;
           initialDelaySeconds: 60
           periodSeconds: 10
-        terminationMessagePolicy: File
+        name: kubearmor
+        ports:
+        - containerPort: 32767
+        securityContext:
+          privileged: true
         terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /lib/modules
+          name: lib-modules-path
+          readOnly: true
+        - mountPath: /sys/fs/bpf
+          name: sys-fs-bpf-path
+        - mountPath: /sys/kernel/security
+          name: sys-kernel-security-path
+        - mountPath: /sys/kernel/debug
+          name: sys-kernel-debug-path
+        - mountPath: /media/root/etc/os-release
+          name: os-release-path
+          readOnly: true
+        - mountPath: /usr/src
+          name: usr-src-path
+          readOnly: true
+        - mountPath: /etc/apparmor.d
+          name: etc-apparmor-d-path
+        - mountPath: /var/run/containerd/containerd.sock
+          name: containerd-sock-path
+          readOnly: true
+        - mountPath: /run/containerd
+          name: containerd-storage-path
+          readOnly: true
+        - mountPath: /var/lib/docker
+          name: docker-storage-path
+          readOnly: true
+      dnsPolicy: ClusterFirstWithHostNet
+      hostNetwork: true
+      hostPID: true
+      nodeSelector:
+        kubernetes.io/os: linux
+      restartPolicy: Always
+      serviceAccountName: kubearmor
       terminationGracePeriodSeconds: 30
+      tolerations:
+      - operator: Exists
       volumes:
-      - name: containerd-sock-path # containerd
-        hostPath:
-          path: /var/run/containerd/containerd.sock
-          type: Socket
-      - name: containerd-storage-path # containerd
-        hostPath:
-          path: /run/containerd
-          type: DirectoryOrCreate
-      - name: docker-storage-path # docker
-        hostPath:
-          path: /var/lib/docker
-          type: DirectoryOrCreate
-      - name: usr-src-path # BPF
-        hostPath:
-          path: /usr/src
-          type: Directory
-      - name: lib-modules-path # BPF
-        hostPath:
+      - hostPath:
           path: /lib/modules
           type: Directory
-      - name: sys-fs-bpf-path # BPF
-        hostPath:
+        name: lib-modules-path
+      - hostPath:
           path: /sys/fs/bpf
           type: Directory
-      - name: sys-kernel-debug-path # BPF
-        hostPath:
-          path: /sys/kernel/debug
-          type: Directory
-      - name: sys-kernel-security-path # LSM
-        hostPath:
+        name: sys-fs-bpf-path
+      - hostPath:
           path: /sys/kernel/security
           type: Directory
-      - name: etc-apparmor-d-path # AppArmor
-        hostPath:
-          path: /etc/apparmor.d
-          type: DirectoryOrCreate
-      - name: os-release-path # OS
-        hostPath:
+        name: sys-kernel-security-path
+      - hostPath:
+          path: /sys/kernel/debug
+          type: Directory
+        name: sys-kernel-debug-path
+      - hostPath:
           path: /etc/os-release
           type: File
+        name: os-release-path
+      - hostPath:
+          path: /usr/src
+          type: Directory
+        name: usr-src-path
+      - hostPath:
+          path: /etc/apparmor.d
+          type: DirectoryOrCreate
+        name: etc-apparmor-d-path
+      - hostPath:
+          path: /var/run/containerd/containerd.sock
+          type: Socket
+        name: containerd-sock-path
+      - hostPath:
+          path: /run/containerd
+          type: DirectoryOrCreate
+        name: containerd-storage-path
+      - hostPath:
+          path: /var/lib/docker
+          type: DirectoryOrCreate
+        name: docker-storage-path
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.5
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.4.1
   name: kubearmorpolicies.security.kubearmor.com
 spec:
   group: security.kubearmor.com
@@ -206,7 +207,7 @@ spec:
                           items:
                             properties:
                               path:
-                                pattern: ^\/([A-z0-9-_.]+\/)*([A-z0-9-_.]+)$
+                                pattern: ^\/+.*[^\/]$
                                 type: string
                             type: object
                           type: array
@@ -255,13 +256,13 @@ spec:
                           - Block
                           type: string
                         dir:
-                          pattern: ^\/([A-z0-9-_.]+\/)*([A-z0-9-_.]+)+\/$
+                          pattern: ^\/$|^\/.*\/$
                           type: string
                         fromSource:
                           items:
                             properties:
                               path:
-                                pattern: ^\/([A-z0-9-_.]+\/)*([A-z0-9-_.]+)$
+                                pattern: ^\/+.*[^\/]$
                                 type: string
                             type: object
                           type: array
@@ -298,7 +299,7 @@ spec:
                           items:
                             properties:
                               path:
-                                pattern: ^\/([A-z0-9-_.]+\/)*([A-z0-9-_.]+)$
+                                pattern: ^\/+.*[^\/]$
                                 type: string
                             type: object
                           type: array
@@ -307,7 +308,7 @@ spec:
                         ownerOnly:
                           type: boolean
                         path:
-                          pattern: ^\/([A-z0-9-_.]+\/)*([A-z0-9-_.]+)$
+                          pattern: ^\/+.*[^\/]$
                           type: string
                         readOnly:
                           type: boolean
@@ -386,7 +387,7 @@ spec:
                           items:
                             properties:
                               path:
-                                pattern: ^\/([A-z0-9-_.]+\/)*([A-z0-9-_.]+)$
+                                pattern: ^\/+.*[^\/]$
                                 type: string
                             type: object
                           type: array
@@ -438,13 +439,13 @@ spec:
                           - Block
                           type: string
                         dir:
-                          pattern: ^\/([A-z0-9-_.]+\/)*([A-z0-9-_.]+)+\/$
+                          pattern: ^\/$|^\/.*\/$
                           type: string
                         fromSource:
                           items:
                             properties:
                               path:
-                                pattern: ^\/([A-z0-9-_.]+\/)*([A-z0-9-_.]+)$
+                                pattern: ^\/+.*[^\/]$
                                 type: string
                             type: object
                           type: array
@@ -479,7 +480,7 @@ spec:
                           items:
                             properties:
                               path:
-                                pattern: ^\/([A-z0-9-_.]+\/)*([A-z0-9-_.]+)$
+                                pattern: ^\/+.*[^\/]$
                                 type: string
                             type: object
                           type: array
@@ -488,7 +489,7 @@ spec:
                         ownerOnly:
                           type: boolean
                         path:
-                          pattern: ^\/([A-z0-9-_.]+\/)*([A-z0-9-_.]+)$
+                          pattern: ^\/+.*[^\/]$
                           type: string
                         severity:
                           maximum: 10
@@ -547,56 +548,6 @@ spec:
                       type: string
                     type: object
                 type: object
-              selinux:
-                properties:
-                  action:
-                    enum:
-                    - Allow
-                    - Audit
-                    - Block
-                    type: string
-                  matchVolumeMounts:
-                    items:
-                      properties:
-                        action:
-                          enum:
-                          - Allow
-                          - Audit
-                          - Block
-                          type: string
-                        dir:
-                          pattern: ^\/([A-z0-9-_.]+\/)*([A-z0-9-_.]+)+\/$
-                          type: string
-                        message:
-                          type: string
-                        path:
-                          pattern: ^\/([A-z0-9-_.]+\/)*([A-z0-9-_.]+)$
-                          type: string
-                        readOnly:
-                          type: boolean
-                        severity:
-                          maximum: 10
-                          minimum: 1
-                          type: integer
-                        tags:
-                          items:
-                            type: string
-                          type: array
-                      type: object
-                    type: array
-                  message:
-                    type: string
-                  severity:
-                    maximum: 10
-                    minimum: 1
-                    type: integer
-                  tags:
-                    items:
-                      type: string
-                    type: array
-                required:
-                - matchVolumeMounts
-                type: object
               severity:
                 maximum: 10
                 minimum: 1
@@ -619,19 +570,12 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.5
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.4.1
   name: kubearmorhostpolicies.security.kubearmor.com
 spec:
   group: security.kubearmor.com
@@ -697,7 +641,7 @@ spec:
                           items:
                             properties:
                               path:
-                                pattern: ^\/([A-z0-9-_.]+\/)*([A-z0-9-_.]+)$
+                                pattern: ^\/+.*[^\/]$
                                 type: string
                             type: object
                           type: array
@@ -747,13 +691,13 @@ spec:
                           - Block
                           type: string
                         dir:
-                          pattern: ^\/([A-z0-9-_.]+\/)*([A-z0-9-_.]+)+\/$
+                          pattern: ^\/$|^\/.*\/$
                           type: string
                         fromSource:
                           items:
                             properties:
                               path:
-                                pattern: ^\/([A-z0-9-_.]+\/)*([A-z0-9-_.]+)$
+                                pattern: ^\/+.*[^\/]$
                                 type: string
                             type: object
                           type: array
@@ -790,7 +734,7 @@ spec:
                           items:
                             properties:
                               path:
-                                pattern: ^\/([A-z0-9-_.]+\/)*([A-z0-9-_.]+)$
+                                pattern: ^\/+.*[^\/]$
                                 type: string
                             type: object
                           type: array
@@ -799,7 +743,7 @@ spec:
                         ownerOnly:
                           type: boolean
                         path:
-                          pattern: ^\/([A-z0-9-_.]+\/)*([A-z0-9-_.]+)$
+                          pattern: ^\/+.*[^\/]$
                           type: string
                         readOnly:
                           type: boolean
@@ -878,7 +822,7 @@ spec:
                           items:
                             properties:
                               path:
-                                pattern: ^\/([A-z0-9-_.]+\/)*([A-z0-9-_.]+)$
+                                pattern: ^\/+.*[^\/]$
                                 type: string
                             type: object
                           type: array
@@ -938,13 +882,13 @@ spec:
                           - Block
                           type: string
                         dir:
-                          pattern: ^\/([A-z0-9-_.]+\/)*([A-z0-9-_.]+)+\/$
+                          pattern: ^\/$|^\/.*\/$
                           type: string
                         fromSource:
                           items:
                             properties:
                               path:
-                                pattern: ^\/([A-z0-9-_.]+\/)*([A-z0-9-_.]+)$
+                                pattern: ^\/+.*[^\/]$
                                 type: string
                             type: object
                           type: array
@@ -979,7 +923,7 @@ spec:
                           items:
                             properties:
                               path:
-                                pattern: ^\/([A-z0-9-_.]+\/)*([A-z0-9-_.]+)$
+                                pattern: ^\/+.*[^\/]$
                                 type: string
                             type: object
                           type: array
@@ -988,7 +932,7 @@ spec:
                         ownerOnly:
                           type: boolean
                         path:
-                          pattern: ^\/([A-z0-9-_.]+\/)*([A-z0-9-_.]+)$
+                          pattern: ^\/+.*[^\/]$
                           type: string
                         severity:
                           maximum: 10
@@ -1062,9 +1006,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/KubeArmor/build/kubearmor-test-docker.yaml
+++ b/KubeArmor/build/kubearmor-test-docker.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -8,6 +9,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: kubearmor
+  namespace: kube-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -20,121 +22,120 @@ subjects:
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  name: kubearmor
-  namespace: kube-system
   labels:
     kubearmor-app: kubearmor
+  name: kubearmor
+  namespace: kube-system
 spec:
   selector:
     matchLabels:
       kubearmor-app: kubearmor
   template:
     metadata:
-      labels:
-        kubearmor-app: kubearmor
       annotations:
         container.apparmor.security.beta.kubernetes.io/kubearmor: unconfined
+      labels:
+        kubearmor-app: kubearmor
     spec:
-      serviceAccountName: kubearmor
-      nodeSelector:
-        kubernetes.io/os: linux
-      tolerations:
-      - operator: Exists
-      hostPID: true
-      hostNetwork: true
-      restartPolicy: Always
-      dnsPolicy: ClusterFirstWithHostNet
       containers:
-      - name: kubearmor
+      - args:
+        - -gRPC=32767
+        - -logPath=/tmp/kubearmor.log
+        - -enableKubeArmorHostPolicy
         image: kubearmor/kubearmor:latest
         imagePullPolicy: Never
-        securityContext:
-          privileged: true
-        args: ["-gRPC=32767", "-logPath=/tmp/kubearmor.log", "-enableKubeArmorHostPolicy"]
-        ports:
-        - containerPort: 32767
-        volumeMounts:
-        - name: docker-sock-path # docker (read-only)
-          mountPath: /var/run/docker.sock
-          readOnly: true
-        - name: docker-storage-path # docker storage (read-only)
-          mountPath: /var/lib/docker
-          readOnly: true
-        - name: usr-src-path # BPF (read-only)
-          mountPath: /usr/src
-          readOnly: true
-        - name: lib-modules-path # BPF (read-only)
-          mountPath: /lib/modules
-          readOnly: true
-        - name: sys-fs-bpf-path # BPF (read-write)
-          mountPath: /sys/fs/bpf
-        - name: sys-kernel-debug-path # BPF (read-write)
-          mountPath: /sys/kernel/debug
-        - name: sys-kernel-security-path # LSM (read-write)
-          mountPath: /sys/kernel/security
-        - name: etc-apparmor-d-path # AppArmor (read-write)
-          mountPath: /etc/apparmor.d
-        - name: os-release-path # OS (read-only)
-          mountPath: /media/root/etc/os-release
-          readOnly: true
         livenessProbe:
           exec:
             command:
             - /bin/bash
             - -c
-            - |
-              if [ -z $(pgrep kubearmor) ]; then
-                exit 1;
-              fi;
+            - if [ -z $(pgrep kubearmor) ]; then exit 1; fi;
           initialDelaySeconds: 60
           periodSeconds: 10
-        terminationMessagePolicy: File
+        name: kubearmor
+        ports:
+        - containerPort: 32767
+        securityContext:
+          privileged: true
         terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /lib/modules
+          name: lib-modules-path
+          readOnly: true
+        - mountPath: /sys/fs/bpf
+          name: sys-fs-bpf-path
+        - mountPath: /sys/kernel/security
+          name: sys-kernel-security-path
+        - mountPath: /sys/kernel/debug
+          name: sys-kernel-debug-path
+        - mountPath: /media/root/etc/os-release
+          name: os-release-path
+          readOnly: true
+        - mountPath: /usr/src
+          name: usr-src-path
+          readOnly: true
+        - mountPath: /etc/apparmor.d
+          name: etc-apparmor-d-path
+        - mountPath: /var/run/docker.sock
+          name: docker-sock-path
+          readOnly: true
+        - mountPath: /var/lib/docker
+          name: docker-storage-path
+          readOnly: true
+      dnsPolicy: ClusterFirstWithHostNet
+      hostNetwork: true
+      hostPID: true
+      nodeSelector:
+        kubernetes.io/os: linux
+      restartPolicy: Always
+      serviceAccountName: kubearmor
       terminationGracePeriodSeconds: 30
+      tolerations:
+      - operator: Exists
       volumes:
-      - name: docker-sock-path # docker
-        hostPath:
-          path: /var/run/docker.sock
-          type: Socket
-      - name: docker-storage-path # docker
-        hostPath:
-          path: /var/lib/docker
-          type: Directory
-      - name: usr-src-path # BPF
-        hostPath:
-          path: /usr/src
-          type: Directory
-      - name: lib-modules-path # BPF
-        hostPath:
+      - hostPath:
           path: /lib/modules
           type: Directory
-      - name: sys-fs-bpf-path # BPF
-        hostPath:
+        name: lib-modules-path
+      - hostPath:
           path: /sys/fs/bpf
           type: Directory
-      - name: sys-kernel-debug-path # BPF
-        hostPath:
-          path: /sys/kernel/debug
-          type: Directory
-      - name: sys-kernel-security-path # LSM
-        hostPath:
+        name: sys-fs-bpf-path
+      - hostPath:
           path: /sys/kernel/security
           type: Directory
-      - name: etc-apparmor-d-path # AppArmor
-        hostPath:
-          path: /etc/apparmor.d
-          type: DirectoryOrCreate
-      - name: os-release-path # OS
-        hostPath:
+        name: sys-kernel-security-path
+      - hostPath:
+          path: /sys/kernel/debug
+          type: Directory
+        name: sys-kernel-debug-path
+      - hostPath:
           path: /etc/os-release
           type: File
+        name: os-release-path
+      - hostPath:
+          path: /usr/src
+          type: Directory
+        name: usr-src-path
+      - hostPath:
+          path: /etc/apparmor.d
+          type: DirectoryOrCreate
+        name: etc-apparmor-d-path
+      - hostPath:
+          path: /var/run/docker.sock
+          type: Socket
+        name: docker-sock-path
+      - hostPath:
+          path: /var/lib/docker
+          type: DirectoryOrCreate
+        name: docker-storage-path
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.5
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.4.1
   name: kubearmorpolicies.security.kubearmor.com
 spec:
   group: security.kubearmor.com
@@ -199,7 +200,7 @@ spec:
                           items:
                             properties:
                               path:
-                                pattern: ^\/([A-z0-9-_.]+\/)*([A-z0-9-_.]+)$
+                                pattern: ^\/+.*[^\/]$
                                 type: string
                             type: object
                           type: array
@@ -248,13 +249,13 @@ spec:
                           - Block
                           type: string
                         dir:
-                          pattern: ^\/([A-z0-9-_.]+\/)*([A-z0-9-_.]+)+\/$
+                          pattern: ^\/$|^\/.*\/$
                           type: string
                         fromSource:
                           items:
                             properties:
                               path:
-                                pattern: ^\/([A-z0-9-_.]+\/)*([A-z0-9-_.]+)$
+                                pattern: ^\/+.*[^\/]$
                                 type: string
                             type: object
                           type: array
@@ -291,7 +292,7 @@ spec:
                           items:
                             properties:
                               path:
-                                pattern: ^\/([A-z0-9-_.]+\/)*([A-z0-9-_.]+)$
+                                pattern: ^\/+.*[^\/]$
                                 type: string
                             type: object
                           type: array
@@ -300,7 +301,7 @@ spec:
                         ownerOnly:
                           type: boolean
                         path:
-                          pattern: ^\/([A-z0-9-_.]+\/)*([A-z0-9-_.]+)$
+                          pattern: ^\/+.*[^\/]$
                           type: string
                         readOnly:
                           type: boolean
@@ -379,7 +380,7 @@ spec:
                           items:
                             properties:
                               path:
-                                pattern: ^\/([A-z0-9-_.]+\/)*([A-z0-9-_.]+)$
+                                pattern: ^\/+.*[^\/]$
                                 type: string
                             type: object
                           type: array
@@ -431,13 +432,13 @@ spec:
                           - Block
                           type: string
                         dir:
-                          pattern: ^\/([A-z0-9-_.]+\/)*([A-z0-9-_.]+)+\/$
+                          pattern: ^\/$|^\/.*\/$
                           type: string
                         fromSource:
                           items:
                             properties:
                               path:
-                                pattern: ^\/([A-z0-9-_.]+\/)*([A-z0-9-_.]+)$
+                                pattern: ^\/+.*[^\/]$
                                 type: string
                             type: object
                           type: array
@@ -472,7 +473,7 @@ spec:
                           items:
                             properties:
                               path:
-                                pattern: ^\/([A-z0-9-_.]+\/)*([A-z0-9-_.]+)$
+                                pattern: ^\/+.*[^\/]$
                                 type: string
                             type: object
                           type: array
@@ -481,7 +482,7 @@ spec:
                         ownerOnly:
                           type: boolean
                         path:
-                          pattern: ^\/([A-z0-9-_.]+\/)*([A-z0-9-_.]+)$
+                          pattern: ^\/+.*[^\/]$
                           type: string
                         severity:
                           maximum: 10
@@ -540,56 +541,6 @@ spec:
                       type: string
                     type: object
                 type: object
-              selinux:
-                properties:
-                  action:
-                    enum:
-                    - Allow
-                    - Audit
-                    - Block
-                    type: string
-                  matchVolumeMounts:
-                    items:
-                      properties:
-                        action:
-                          enum:
-                          - Allow
-                          - Audit
-                          - Block
-                          type: string
-                        dir:
-                          pattern: ^\/([A-z0-9-_.]+\/)*([A-z0-9-_.]+)+\/$
-                          type: string
-                        message:
-                          type: string
-                        path:
-                          pattern: ^\/([A-z0-9-_.]+\/)*([A-z0-9-_.]+)$
-                          type: string
-                        readOnly:
-                          type: boolean
-                        severity:
-                          maximum: 10
-                          minimum: 1
-                          type: integer
-                        tags:
-                          items:
-                            type: string
-                          type: array
-                      type: object
-                    type: array
-                  message:
-                    type: string
-                  severity:
-                    maximum: 10
-                    minimum: 1
-                    type: integer
-                  tags:
-                    items:
-                      type: string
-                    type: array
-                required:
-                - matchVolumeMounts
-                type: object
               severity:
                 maximum: 10
                 minimum: 1
@@ -612,19 +563,12 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.5
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.4.1
   name: kubearmorhostpolicies.security.kubearmor.com
 spec:
   group: security.kubearmor.com
@@ -690,7 +634,7 @@ spec:
                           items:
                             properties:
                               path:
-                                pattern: ^\/([A-z0-9-_.]+\/)*([A-z0-9-_.]+)$
+                                pattern: ^\/+.*[^\/]$
                                 type: string
                             type: object
                           type: array
@@ -740,13 +684,13 @@ spec:
                           - Block
                           type: string
                         dir:
-                          pattern: ^\/([A-z0-9-_.]+\/)*([A-z0-9-_.]+)+\/$
+                          pattern: ^\/$|^\/.*\/$
                           type: string
                         fromSource:
                           items:
                             properties:
                               path:
-                                pattern: ^\/([A-z0-9-_.]+\/)*([A-z0-9-_.]+)$
+                                pattern: ^\/+.*[^\/]$
                                 type: string
                             type: object
                           type: array
@@ -783,7 +727,7 @@ spec:
                           items:
                             properties:
                               path:
-                                pattern: ^\/([A-z0-9-_.]+\/)*([A-z0-9-_.]+)$
+                                pattern: ^\/+.*[^\/]$
                                 type: string
                             type: object
                           type: array
@@ -792,7 +736,7 @@ spec:
                         ownerOnly:
                           type: boolean
                         path:
-                          pattern: ^\/([A-z0-9-_.]+\/)*([A-z0-9-_.]+)$
+                          pattern: ^\/+.*[^\/]$
                           type: string
                         readOnly:
                           type: boolean
@@ -871,7 +815,7 @@ spec:
                           items:
                             properties:
                               path:
-                                pattern: ^\/([A-z0-9-_.]+\/)*([A-z0-9-_.]+)$
+                                pattern: ^\/+.*[^\/]$
                                 type: string
                             type: object
                           type: array
@@ -931,13 +875,13 @@ spec:
                           - Block
                           type: string
                         dir:
-                          pattern: ^\/([A-z0-9-_.]+\/)*([A-z0-9-_.]+)+\/$
+                          pattern: ^\/$|^\/.*\/$
                           type: string
                         fromSource:
                           items:
                             properties:
                               path:
-                                pattern: ^\/([A-z0-9-_.]+\/)*([A-z0-9-_.]+)$
+                                pattern: ^\/+.*[^\/]$
                                 type: string
                             type: object
                           type: array
@@ -972,7 +916,7 @@ spec:
                           items:
                             properties:
                               path:
-                                pattern: ^\/([A-z0-9-_.]+\/)*([A-z0-9-_.]+)$
+                                pattern: ^\/+.*[^\/]$
                                 type: string
                             type: object
                           type: array
@@ -981,7 +925,7 @@ spec:
                         ownerOnly:
                           type: boolean
                         path:
-                          pattern: ^\/([A-z0-9-_.]+\/)*([A-z0-9-_.]+)$
+                          pattern: ^\/+.*[^\/]$
                           type: string
                         severity:
                           maximum: 10
@@ -1055,9 +999,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/KubeArmor/build/kubearmor-test-k3s.yaml
+++ b/KubeArmor/build/kubearmor-test-k3s.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -8,6 +9,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: kubearmor
+  namespace: kube-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -17,125 +19,123 @@ subjects:
   name: kubearmor
   namespace: kube-system
 ---
-
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  name: kubearmor
-  namespace: kube-system
   labels:
     kubearmor-app: kubearmor
+  name: kubearmor
+  namespace: kube-system
 spec:
   selector:
     matchLabels:
       kubearmor-app: kubearmor
   template:
     metadata:
-      labels:
-        kubearmor-app: kubearmor
       annotations:
         container.apparmor.security.beta.kubernetes.io/kubearmor: unconfined
+      labels:
+        kubearmor-app: kubearmor
     spec:
-      serviceAccountName: kubearmor
-      nodeSelector:
-        kubernetes.io/os: linux
-      tolerations:
-      - operator: Exists
-      hostPID: true
-      hostNetwork: true
-      restartPolicy: Always
-      dnsPolicy: ClusterFirstWithHostNet
       containers:
-      - name: kubearmor
+      - args:
+        - -gRPC=32767
+        - -logPath=/tmp/kubearmor.log
+        - -enableKubeArmorHostPolicy
         image: kubearmor/kubearmor:latest
         imagePullPolicy: Never
-        securityContext:
-          privileged: true
-        args: ["-gRPC=32767", "-logPath=/tmp/kubearmor.log", "-enableKubeArmorHostPolicy"]
-        ports:
-        - containerPort: 32767
-        volumeMounts:
-        - name: docker-sock-path # docker (read-only)
-          mountPath: /var/run/docker.sock
-          readOnly: true 
-        - name: docker-storage-path # docker storage (read-only)
-          mountPath: /var/lib/docker
-          readOnly: true 
-        - name: usr-src-path # BPF (read-only)
-          mountPath: /usr/src
-          readOnly: true
-        - name: lib-modules-path # BPF (read-only)
-          mountPath: /lib/modules
-          readOnly: true
-        - name: sys-fs-bpf-path # BPF (read-write)
-          mountPath: /sys/fs/bpf
-        - name: sys-kernel-debug-path # BPF (read-write)
-          mountPath: /sys/kernel/debug
-        - name: sys-kernel-security-path # LSM (read-write)
-          mountPath: /sys/kernel/security
-        - name: etc-apparmor-d-path # AppArmor (read-write)
-          mountPath: /etc/apparmor.d
-        - name: os-release-path # OS (read-only)
-          mountPath: /media/root/etc/os-release
-          readOnly: true
         livenessProbe:
           exec:
             command:
             - /bin/bash
             - -c
-            - |
-              if [ -z $(pgrep kubearmor) ]; then
-                exit 1;
-              fi;
+            - if [ -z $(pgrep kubearmor) ]; then exit 1; fi;
           initialDelaySeconds: 60
           periodSeconds: 10
-        terminationMessagePolicy: File
+        name: kubearmor
+        ports:
+        - containerPort: 32767
+        securityContext:
+          privileged: true
         terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /lib/modules
+          name: lib-modules-path
+          readOnly: true
+        - mountPath: /sys/fs/bpf
+          name: sys-fs-bpf-path
+        - mountPath: /sys/kernel/security
+          name: sys-kernel-security-path
+        - mountPath: /sys/kernel/debug
+          name: sys-kernel-debug-path
+        - mountPath: /media/root/etc/os-release
+          name: os-release-path
+          readOnly: true
+        - mountPath: /usr/src
+          name: usr-src-path
+          readOnly: true
+        - mountPath: /etc/apparmor.d
+          name: etc-apparmor-d-path
+        - mountPath: /var/run/containerd/containerd.sock
+          name: containerd-sock-path
+          readOnly: true
+        - mountPath: /run/containerd
+          name: containerd-storage-path
+          readOnly: true
+      dnsPolicy: ClusterFirstWithHostNet
+      hostNetwork: true
+      hostPID: true
+      nodeSelector:
+        kubernetes.io/os: linux
+      restartPolicy: Always
+      serviceAccountName: kubearmor
       terminationGracePeriodSeconds: 30
+      tolerations:
+      - operator: Exists
       volumes:
-      - name: docker-sock-path # docker
-        hostPath:
-          path: /var/run/docker.sock
-          type: Socket
-      - name: docker-storage-path # docker
-        hostPath:
-          path: /var/lib/docker
-          type: Directory
-      - name: usr-src-path # BPF
-        hostPath:
-          path: /usr/src
-          type: Directory
-      - name: lib-modules-path # BPF
-        hostPath:
+      - hostPath:
           path: /lib/modules
           type: Directory
-      - name: sys-fs-bpf-path # BPF
-        hostPath:
+        name: lib-modules-path
+      - hostPath:
           path: /sys/fs/bpf
           type: Directory
-      - name: sys-kernel-debug-path # BPF
-        hostPath:
-          path: /sys/kernel/debug
-          type: Directory
-      - name: sys-kernel-security-path # LSM
-        hostPath:
+        name: sys-fs-bpf-path
+      - hostPath:
           path: /sys/kernel/security
           type: Directory
-      - name: etc-apparmor-d-path # AppArmor
-        hostPath:
-          path: /etc/apparmor.d
-          type: DirectoryOrCreate
-      - name: os-release-path # OS
-        hostPath:
+        name: sys-kernel-security-path
+      - hostPath:
+          path: /sys/kernel/debug
+          type: Directory
+        name: sys-kernel-debug-path
+      - hostPath:
           path: /etc/os-release
           type: File
+        name: os-release-path
+      - hostPath:
+          path: /usr/src
+          type: Directory
+        name: usr-src-path
+      - hostPath:
+          path: /etc/apparmor.d
+          type: DirectoryOrCreate
+        name: etc-apparmor-d-path
+      - hostPath:
+          path: /run/k3s/containerd/containerd.sock
+          type: Socket
+        name: containerd-sock-path
+      - hostPath:
+          path: /run/k3s/containerd
+          type: DirectoryOrCreate
+        name: containerd-storage-path
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.5
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.4.1
   name: kubearmorpolicies.security.kubearmor.com
 spec:
   group: security.kubearmor.com
@@ -200,7 +200,7 @@ spec:
                           items:
                             properties:
                               path:
-                                pattern: ^\/([A-z0-9-_.]+\/)*([A-z0-9-_.]+)$
+                                pattern: ^\/+.*[^\/]$
                                 type: string
                             type: object
                           type: array
@@ -249,13 +249,13 @@ spec:
                           - Block
                           type: string
                         dir:
-                          pattern: ^\/([A-z0-9-_.]+\/)*([A-z0-9-_.]+)+\/$
+                          pattern: ^\/$|^\/.*\/$
                           type: string
                         fromSource:
                           items:
                             properties:
                               path:
-                                pattern: ^\/([A-z0-9-_.]+\/)*([A-z0-9-_.]+)$
+                                pattern: ^\/+.*[^\/]$
                                 type: string
                             type: object
                           type: array
@@ -292,7 +292,7 @@ spec:
                           items:
                             properties:
                               path:
-                                pattern: ^\/([A-z0-9-_.]+\/)*([A-z0-9-_.]+)$
+                                pattern: ^\/+.*[^\/]$
                                 type: string
                             type: object
                           type: array
@@ -301,7 +301,7 @@ spec:
                         ownerOnly:
                           type: boolean
                         path:
-                          pattern: ^\/([A-z0-9-_.]+\/)*([A-z0-9-_.]+)$
+                          pattern: ^\/+.*[^\/]$
                           type: string
                         readOnly:
                           type: boolean
@@ -380,7 +380,7 @@ spec:
                           items:
                             properties:
                               path:
-                                pattern: ^\/([A-z0-9-_.]+\/)*([A-z0-9-_.]+)$
+                                pattern: ^\/+.*[^\/]$
                                 type: string
                             type: object
                           type: array
@@ -432,13 +432,13 @@ spec:
                           - Block
                           type: string
                         dir:
-                          pattern: ^\/([A-z0-9-_.]+\/)*([A-z0-9-_.]+)+\/$
+                          pattern: ^\/$|^\/.*\/$
                           type: string
                         fromSource:
                           items:
                             properties:
                               path:
-                                pattern: ^\/([A-z0-9-_.]+\/)*([A-z0-9-_.]+)$
+                                pattern: ^\/+.*[^\/]$
                                 type: string
                             type: object
                           type: array
@@ -473,7 +473,7 @@ spec:
                           items:
                             properties:
                               path:
-                                pattern: ^\/([A-z0-9-_.]+\/)*([A-z0-9-_.]+)$
+                                pattern: ^\/+.*[^\/]$
                                 type: string
                             type: object
                           type: array
@@ -482,7 +482,7 @@ spec:
                         ownerOnly:
                           type: boolean
                         path:
-                          pattern: ^\/([A-z0-9-_.]+\/)*([A-z0-9-_.]+)$
+                          pattern: ^\/+.*[^\/]$
                           type: string
                         severity:
                           maximum: 10
@@ -541,56 +541,6 @@ spec:
                       type: string
                     type: object
                 type: object
-              selinux:
-                properties:
-                  action:
-                    enum:
-                    - Allow
-                    - Audit
-                    - Block
-                    type: string
-                  matchVolumeMounts:
-                    items:
-                      properties:
-                        action:
-                          enum:
-                          - Allow
-                          - Audit
-                          - Block
-                          type: string
-                        dir:
-                          pattern: ^\/([A-z0-9-_.]+\/)*([A-z0-9-_.]+)+\/$
-                          type: string
-                        message:
-                          type: string
-                        path:
-                          pattern: ^\/([A-z0-9-_.]+\/)*([A-z0-9-_.]+)$
-                          type: string
-                        readOnly:
-                          type: boolean
-                        severity:
-                          maximum: 10
-                          minimum: 1
-                          type: integer
-                        tags:
-                          items:
-                            type: string
-                          type: array
-                      type: object
-                    type: array
-                  message:
-                    type: string
-                  severity:
-                    maximum: 10
-                    minimum: 1
-                    type: integer
-                  tags:
-                    items:
-                      type: string
-                    type: array
-                required:
-                - matchVolumeMounts
-                type: object
               severity:
                 maximum: 10
                 minimum: 1
@@ -613,19 +563,12 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.5
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.4.1
   name: kubearmorhostpolicies.security.kubearmor.com
 spec:
   group: security.kubearmor.com
@@ -691,7 +634,7 @@ spec:
                           items:
                             properties:
                               path:
-                                pattern: ^\/([A-z0-9-_.]+\/)*([A-z0-9-_.]+)$
+                                pattern: ^\/+.*[^\/]$
                                 type: string
                             type: object
                           type: array
@@ -741,13 +684,13 @@ spec:
                           - Block
                           type: string
                         dir:
-                          pattern: ^\/([A-z0-9-_.]+\/)*([A-z0-9-_.]+)+\/$
+                          pattern: ^\/$|^\/.*\/$
                           type: string
                         fromSource:
                           items:
                             properties:
                               path:
-                                pattern: ^\/([A-z0-9-_.]+\/)*([A-z0-9-_.]+)$
+                                pattern: ^\/+.*[^\/]$
                                 type: string
                             type: object
                           type: array
@@ -784,7 +727,7 @@ spec:
                           items:
                             properties:
                               path:
-                                pattern: ^\/([A-z0-9-_.]+\/)*([A-z0-9-_.]+)$
+                                pattern: ^\/+.*[^\/]$
                                 type: string
                             type: object
                           type: array
@@ -793,7 +736,7 @@ spec:
                         ownerOnly:
                           type: boolean
                         path:
-                          pattern: ^\/([A-z0-9-_.]+\/)*([A-z0-9-_.]+)$
+                          pattern: ^\/+.*[^\/]$
                           type: string
                         readOnly:
                           type: boolean
@@ -872,7 +815,7 @@ spec:
                           items:
                             properties:
                               path:
-                                pattern: ^\/([A-z0-9-_.]+\/)*([A-z0-9-_.]+)$
+                                pattern: ^\/+.*[^\/]$
                                 type: string
                             type: object
                           type: array
@@ -932,13 +875,13 @@ spec:
                           - Block
                           type: string
                         dir:
-                          pattern: ^\/([A-z0-9-_.]+\/)*([A-z0-9-_.]+)+\/$
+                          pattern: ^\/$|^\/.*\/$
                           type: string
                         fromSource:
                           items:
                             properties:
                               path:
-                                pattern: ^\/([A-z0-9-_.]+\/)*([A-z0-9-_.]+)$
+                                pattern: ^\/+.*[^\/]$
                                 type: string
                             type: object
                           type: array
@@ -973,7 +916,7 @@ spec:
                           items:
                             properties:
                               path:
-                                pattern: ^\/([A-z0-9-_.]+\/)*([A-z0-9-_.]+)$
+                                pattern: ^\/+.*[^\/]$
                                 type: string
                             type: object
                           type: array
@@ -982,7 +925,7 @@ spec:
                         ownerOnly:
                           type: boolean
                         path:
-                          pattern: ^\/([A-z0-9-_.]+\/)*([A-z0-9-_.]+)$
+                          pattern: ^\/+.*[^\/]$
                           type: string
                         severity:
                           maximum: 10
@@ -1056,10 +999,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
-

--- a/contribution/self-managed-k8s-selinux/k8s/install_kubernetes.sh
+++ b/contribution/self-managed-k8s-selinux/k8s/install_kubernetes.sh
@@ -30,8 +30,12 @@ gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cl
 EOF
 sudo mv kubernetes.repo /etc/yum.repos.d/
 
-# install k8s
-sudo dnf install -y kubeadm kubelet kubectl iproute-tc
+# install kubernetes
+if [ "$RUNTIME" == "containerd" ]; then
+    sudo dnf install -y kubeadm kubelet kubectl iproute-tc
+else # docker
+    sudo dnf install -y kubeadm-1.23.0 kubelet-1.23.0 kubectl-1.23.0 iproute-tc
+fi
 sudo systemctl enable kubelet
 
 # disable rp_filter

--- a/contribution/self-managed-k8s/k8s/install_kubernetes.sh
+++ b/contribution/self-managed-k8s/k8s/install_kubernetes.sh
@@ -18,7 +18,11 @@ echo "deb [signed-by=/usr/share/keyrings/kubernetes-archive-keyring.gpg] https:/
 sudo apt-get update
 
 # install kubernetes
-sudo apt-get install -y kubeadm kubelet kubectl
+if [ "$RUNTIME" == "containerd" ]; then
+    sudo apt-get install -y kubeadm kubelet kubectl
+else # docker
+    sudo apt-get install -y kubeadm=1.23.0-00 kubelet=1.23.0-00 kubectl=1.23.0-00
+fi
 
 # exclude kubernetes packages from updates
 sudo apt-mark hold kubeadm kubelet kubectl

--- a/contribution/vagrant/Vagrantfile
+++ b/contribution/vagrant/Vagrantfile
@@ -69,32 +69,48 @@ Vagrant.configure("2") do |config|
     # install base dependencies
     config.vm.provision :shell, path: kubearmor_home + "/contribution/self-managed-k8s-selinux/setup.sh"
 
-    # install Docker
-    config.vm.provision :shell, path: kubearmor_home + "/contribution/self-managed-k8s-selinux/docker/install_docker.sh"
+    if ENV['RUNTIME'] == "containerd" then # TODO: still use docker / need to support containerd
+      # install Docker
+      config.vm.provision :shell, path: kubearmor_home + "/contribution/self-managed-k8s-selinux/docker/install_docker.sh"
 
-    # install Kubernetes
-    config.vm.provision :shell, path: kubearmor_home + "/contribution/self-managed-k8s-selinux/k8s/install_kubernetes.sh"
+      # install Kubernetes
+      config.vm.provision :shell, :inline => "RUNTIME=docker /home/vagrant/KubeArmor/contribution/self-managed-k8s-selinux/k8s/install_kubernetes.sh"
+
+    else # default == 'docker'
+      # install Docker
+      config.vm.provision :shell, path: kubearmor_home + "/contribution/self-managed-k8s-selinux/docker/install_docker.sh"
+
+      # install Kubernetes
+      config.vm.provision :shell, :inline => "RUNTIME=docker /home/vagrant/KubeArmor/contribution/self-managed-k8s-selinux/k8s/install_kubernetes.sh"
+    end
 
     # initialize Kubernetes
-    config.vm.provision :shell, :inline => "MASTER=true /home/vagrant/KubeArmor/contribution/self-managed-k8s-selinux/k8s/initialize_kubernetes.sh"
+    config.vm.provision :shell, :inline => "CNI=cilium MASTER=true /home/vagrant/KubeArmor/contribution/self-managed-k8s-selinux/k8s/initialize_kubernetes.sh"
 
     # enable SELinux
     config.vm.provision :shell, path: kubearmor_home + "/contribution/self-managed-k8s-selinux/enable_selinux.sh"
+
   else # ubuntu
     # install base dependencies
     config.vm.provision :shell, path: kubearmor_home + "/contribution/self-managed-k8s/setup.sh"
 
     if ENV['RUNTIME'] == "containerd" then
+      # install Containerd
       config.vm.provision :shell, path: kubearmor_home + "/contribution/self-managed-k8s/containerd/install-containerd.sh"
+
+      # install Kubernetes
+      config.vm.provision :shell, :inline => "RUNTIME=containerd /home/vagrant/KubeArmor/contribution/self-managed-k8s/k8s/install_kubernetes.sh"
+
     else # default == 'docker'
+      # install Docker
       config.vm.provision :shell, path: kubearmor_home + "/contribution/self-managed-k8s/docker/install_docker.sh"
+
+      # install Kubernetes
+      config.vm.provision :shell, :inline => "RUNTIME=docker /home/vagrant/KubeArmor/contribution/self-managed-k8s/k8s/install_kubernetes.sh"
     end
 
-    # install Kubernetes
-    config.vm.provision :shell, path: kubearmor_home + "/contribution/self-managed-k8s/k8s/install_kubernetes.sh"
-
     # initialize Kubernetes
-    config.vm.provision :shell, :inline => "MASTER=true /home/vagrant/KubeArmor/contribution/self-managed-k8s/k8s/initialize_kubernetes.sh"
+    config.vm.provision :shell, :inline => "CNI=cilium MASTER=true /home/vagrant/KubeArmor/contribution/self-managed-k8s/k8s/initialize_kubernetes.sh"
   end
 
   # install karmor

--- a/deployments/CRD/KubeArmorHostPolicy.yaml
+++ b/deployments/CRD/KubeArmorHostPolicy.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.5
+    controller-gen.kubebuilder.io/version: v0.4.1
   creationTimestamp: null
   name: kubearmorhostpolicies.security.kubearmor.com
 spec:

--- a/deployments/CRD/KubeArmorPolicy.yaml
+++ b/deployments/CRD/KubeArmorPolicy.yaml
@@ -411,56 +411,6 @@ spec:
                       type: string
                     type: object
                 type: object
-              selinux:
-                properties:
-                  action:
-                    enum:
-                    - Allow
-                    - Audit
-                    - Block
-                    type: string
-                  matchVolumeMounts:
-                    items:
-                      properties:
-                        action:
-                          enum:
-                          - Allow
-                          - Audit
-                          - Block
-                          type: string
-                        dir:
-                          pattern: ^\/$|^\/.*\/$
-                          type: string
-                        message:
-                          type: string
-                        path:
-                          pattern: ^\/+.*[^\/]$
-                          type: string
-                        readOnly:
-                          type: boolean
-                        severity:
-                          maximum: 10
-                          minimum: 1
-                          type: integer
-                        tags:
-                          items:
-                            type: string
-                          type: array
-                      type: object
-                    type: array
-                  message:
-                    type: string
-                  severity:
-                    maximum: 10
-                    minimum: 1
-                    type: integer
-                  tags:
-                    items:
-                      type: string
-                    type: array
-                required:
-                - matchVolumeMounts
-                type: object
               severity:
                 maximum: 10
                 minimum: 1

--- a/deployments/CRD/KubeArmorPolicy.yaml
+++ b/deployments/CRD/KubeArmorPolicy.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.5
+    controller-gen.kubebuilder.io/version: v0.4.1
   creationTimestamp: null
   name: kubearmorpolicies.security.kubearmor.com
 spec:

--- a/deployments/EKS/kubearmor.yaml
+++ b/deployments/EKS/kubearmor.yaml
@@ -321,7 +321,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.5
+    controller-gen.kubebuilder.io/version: v0.4.1
   name: kubearmorpolicies.security.kubearmor.com
 spec:
   group: security.kubearmor.com
@@ -727,56 +727,6 @@ spec:
                       type: string
                     type: object
                 type: object
-              selinux:
-                properties:
-                  action:
-                    enum:
-                    - Allow
-                    - Audit
-                    - Block
-                    type: string
-                  matchVolumeMounts:
-                    items:
-                      properties:
-                        action:
-                          enum:
-                          - Allow
-                          - Audit
-                          - Block
-                          type: string
-                        dir:
-                          pattern: ^\/$|^\/.*\/$
-                          type: string
-                        message:
-                          type: string
-                        path:
-                          pattern: ^\/+.*[^\/]$
-                          type: string
-                        readOnly:
-                          type: boolean
-                        severity:
-                          maximum: 10
-                          minimum: 1
-                          type: integer
-                        tags:
-                          items:
-                            type: string
-                          type: array
-                      type: object
-                    type: array
-                  message:
-                    type: string
-                  severity:
-                    maximum: 10
-                    minimum: 1
-                    type: integer
-                  tags:
-                    items:
-                      type: string
-                    type: array
-                required:
-                - matchVolumeMounts
-                type: object
               severity:
                 maximum: 10
                 minimum: 1
@@ -804,7 +754,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.5
+    controller-gen.kubebuilder.io/version: v0.4.1
   name: kubearmorhostpolicies.security.kubearmor.com
 spec:
   group: security.kubearmor.com

--- a/deployments/GKE/kubearmor.yaml
+++ b/deployments/GKE/kubearmor.yaml
@@ -321,7 +321,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.5
+    controller-gen.kubebuilder.io/version: v0.4.1
   name: kubearmorpolicies.security.kubearmor.com
 spec:
   group: security.kubearmor.com
@@ -727,56 +727,6 @@ spec:
                       type: string
                     type: object
                 type: object
-              selinux:
-                properties:
-                  action:
-                    enum:
-                    - Allow
-                    - Audit
-                    - Block
-                    type: string
-                  matchVolumeMounts:
-                    items:
-                      properties:
-                        action:
-                          enum:
-                          - Allow
-                          - Audit
-                          - Block
-                          type: string
-                        dir:
-                          pattern: ^\/$|^\/.*\/$
-                          type: string
-                        message:
-                          type: string
-                        path:
-                          pattern: ^\/+.*[^\/]$
-                          type: string
-                        readOnly:
-                          type: boolean
-                        severity:
-                          maximum: 10
-                          minimum: 1
-                          type: integer
-                        tags:
-                          items:
-                            type: string
-                          type: array
-                      type: object
-                    type: array
-                  message:
-                    type: string
-                  severity:
-                    maximum: 10
-                    minimum: 1
-                    type: integer
-                  tags:
-                    items:
-                      type: string
-                    type: array
-                required:
-                - matchVolumeMounts
-                type: object
               severity:
                 maximum: 10
                 minimum: 1
@@ -804,7 +754,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.5
+    controller-gen.kubebuilder.io/version: v0.4.1
   name: kubearmorhostpolicies.security.kubearmor.com
 spec:
   group: security.kubearmor.com

--- a/deployments/docker/kubearmor.yaml
+++ b/deployments/docker/kubearmor.yaml
@@ -314,7 +314,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.5
+    controller-gen.kubebuilder.io/version: v0.4.1
   name: kubearmorpolicies.security.kubearmor.com
 spec:
   group: security.kubearmor.com
@@ -720,56 +720,6 @@ spec:
                       type: string
                     type: object
                 type: object
-              selinux:
-                properties:
-                  action:
-                    enum:
-                    - Allow
-                    - Audit
-                    - Block
-                    type: string
-                  matchVolumeMounts:
-                    items:
-                      properties:
-                        action:
-                          enum:
-                          - Allow
-                          - Audit
-                          - Block
-                          type: string
-                        dir:
-                          pattern: ^\/$|^\/.*\/$
-                          type: string
-                        message:
-                          type: string
-                        path:
-                          pattern: ^\/+.*[^\/]$
-                          type: string
-                        readOnly:
-                          type: boolean
-                        severity:
-                          maximum: 10
-                          minimum: 1
-                          type: integer
-                        tags:
-                          items:
-                            type: string
-                          type: array
-                      type: object
-                    type: array
-                  message:
-                    type: string
-                  severity:
-                    maximum: 10
-                    minimum: 1
-                    type: integer
-                  tags:
-                    items:
-                      type: string
-                    type: array
-                required:
-                - matchVolumeMounts
-                type: object
               severity:
                 maximum: 10
                 minimum: 1
@@ -797,7 +747,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.5
+    controller-gen.kubebuilder.io/version: v0.4.1
   name: kubearmorhostpolicies.security.kubearmor.com
 spec:
   group: security.kubearmor.com

--- a/deployments/generic/kubearmor.yaml
+++ b/deployments/generic/kubearmor.yaml
@@ -321,7 +321,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.5
+    controller-gen.kubebuilder.io/version: v0.4.1
   name: kubearmorpolicies.security.kubearmor.com
 spec:
   group: security.kubearmor.com
@@ -727,56 +727,6 @@ spec:
                       type: string
                     type: object
                 type: object
-              selinux:
-                properties:
-                  action:
-                    enum:
-                    - Allow
-                    - Audit
-                    - Block
-                    type: string
-                  matchVolumeMounts:
-                    items:
-                      properties:
-                        action:
-                          enum:
-                          - Allow
-                          - Audit
-                          - Block
-                          type: string
-                        dir:
-                          pattern: ^\/$|^\/.*\/$
-                          type: string
-                        message:
-                          type: string
-                        path:
-                          pattern: ^\/+.*[^\/]$
-                          type: string
-                        readOnly:
-                          type: boolean
-                        severity:
-                          maximum: 10
-                          minimum: 1
-                          type: integer
-                        tags:
-                          items:
-                            type: string
-                          type: array
-                      type: object
-                    type: array
-                  message:
-                    type: string
-                  severity:
-                    maximum: 10
-                    minimum: 1
-                    type: integer
-                  tags:
-                    items:
-                      type: string
-                    type: array
-                required:
-                - matchVolumeMounts
-                type: object
               severity:
                 maximum: 10
                 minimum: 1
@@ -804,7 +754,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.5
+    controller-gen.kubebuilder.io/version: v0.4.1
   name: kubearmorhostpolicies.security.kubearmor.com
 spec:
   group: security.kubearmor.com

--- a/deployments/k3s/kubearmor.yaml
+++ b/deployments/k3s/kubearmor.yaml
@@ -314,7 +314,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.5
+    controller-gen.kubebuilder.io/version: v0.4.1
   name: kubearmorpolicies.security.kubearmor.com
 spec:
   group: security.kubearmor.com
@@ -720,56 +720,6 @@ spec:
                       type: string
                     type: object
                 type: object
-              selinux:
-                properties:
-                  action:
-                    enum:
-                    - Allow
-                    - Audit
-                    - Block
-                    type: string
-                  matchVolumeMounts:
-                    items:
-                      properties:
-                        action:
-                          enum:
-                          - Allow
-                          - Audit
-                          - Block
-                          type: string
-                        dir:
-                          pattern: ^\/$|^\/.*\/$
-                          type: string
-                        message:
-                          type: string
-                        path:
-                          pattern: ^\/+.*[^\/]$
-                          type: string
-                        readOnly:
-                          type: boolean
-                        severity:
-                          maximum: 10
-                          minimum: 1
-                          type: integer
-                        tags:
-                          items:
-                            type: string
-                          type: array
-                      type: object
-                    type: array
-                  message:
-                    type: string
-                  severity:
-                    maximum: 10
-                    minimum: 1
-                    type: integer
-                  tags:
-                    items:
-                      type: string
-                    type: array
-                required:
-                - matchVolumeMounts
-                type: object
               severity:
                 maximum: 10
                 minimum: 1
@@ -797,7 +747,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.5
+    controller-gen.kubebuilder.io/version: v0.4.1
   name: kubearmorhostpolicies.security.kubearmor.com
 spec:
   group: security.kubearmor.com

--- a/deployments/microk8s/kubearmor.yaml
+++ b/deployments/microk8s/kubearmor.yaml
@@ -314,7 +314,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.5
+    controller-gen.kubebuilder.io/version: v0.4.1
   name: kubearmorpolicies.security.kubearmor.com
 spec:
   group: security.kubearmor.com
@@ -720,56 +720,6 @@ spec:
                       type: string
                     type: object
                 type: object
-              selinux:
-                properties:
-                  action:
-                    enum:
-                    - Allow
-                    - Audit
-                    - Block
-                    type: string
-                  matchVolumeMounts:
-                    items:
-                      properties:
-                        action:
-                          enum:
-                          - Allow
-                          - Audit
-                          - Block
-                          type: string
-                        dir:
-                          pattern: ^\/$|^\/.*\/$
-                          type: string
-                        message:
-                          type: string
-                        path:
-                          pattern: ^\/+.*[^\/]$
-                          type: string
-                        readOnly:
-                          type: boolean
-                        severity:
-                          maximum: 10
-                          minimum: 1
-                          type: integer
-                        tags:
-                          items:
-                            type: string
-                          type: array
-                      type: object
-                    type: array
-                  message:
-                    type: string
-                  severity:
-                    maximum: 10
-                    minimum: 1
-                    type: integer
-                  tags:
-                    items:
-                      type: string
-                    type: array
-                required:
-                - matchVolumeMounts
-                type: object
               severity:
                 maximum: 10
                 minimum: 1
@@ -797,7 +747,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.5
+    controller-gen.kubebuilder.io/version: v0.4.1
   name: kubearmorhostpolicies.security.kubearmor.com
 spec:
   group: security.kubearmor.com

--- a/deployments/minikube/kubearmor.yaml
+++ b/deployments/minikube/kubearmor.yaml
@@ -313,7 +313,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.5
+    controller-gen.kubebuilder.io/version: v0.4.1
   name: kubearmorpolicies.security.kubearmor.com
 spec:
   group: security.kubearmor.com
@@ -719,56 +719,6 @@ spec:
                       type: string
                     type: object
                 type: object
-              selinux:
-                properties:
-                  action:
-                    enum:
-                    - Allow
-                    - Audit
-                    - Block
-                    type: string
-                  matchVolumeMounts:
-                    items:
-                      properties:
-                        action:
-                          enum:
-                          - Allow
-                          - Audit
-                          - Block
-                          type: string
-                        dir:
-                          pattern: ^\/$|^\/.*\/$
-                          type: string
-                        message:
-                          type: string
-                        path:
-                          pattern: ^\/+.*[^\/]$
-                          type: string
-                        readOnly:
-                          type: boolean
-                        severity:
-                          maximum: 10
-                          minimum: 1
-                          type: integer
-                        tags:
-                          items:
-                            type: string
-                          type: array
-                      type: object
-                    type: array
-                  message:
-                    type: string
-                  severity:
-                    maximum: 10
-                    minimum: 1
-                    type: integer
-                  tags:
-                    items:
-                      type: string
-                    type: array
-                required:
-                - matchVolumeMounts
-                type: object
               severity:
                 maximum: 10
                 minimum: 1
@@ -796,7 +746,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.5
+    controller-gen.kubebuilder.io/version: v0.4.1
   name: kubearmorhostpolicies.security.kubearmor.com
 spec:
   group: security.kubearmor.com

--- a/pkg/KubeArmorHostPolicy/Dockerfile
+++ b/pkg/KubeArmorHostPolicy/Dockerfile
@@ -2,7 +2,7 @@
 # Copyright 2021 Authors of KubeArmor
 
 # Build the manager binary
-FROM golang:1.13 as builder
+FROM golang:1.17 as builder
 
 WORKDIR /workspace
 

--- a/pkg/KubeArmorHostPolicy/Makefile
+++ b/pkg/KubeArmorHostPolicy/Makefile
@@ -1,8 +1,12 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2021 Authors of KubeArmor
 
+CURDIR := $(shell pwd)
+
 # Image URL to use all building/pushing image targets
-IMG ?= kubearmor/kubearmor-host-policy-manager:latest
+IMG ?= kubearmor/kubearmor-host-policy-manager
+# Image Tag to use all building/pushing image targets
+TAG ?= v0.1
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
 CRD_OPTIONS ?= "crd:crdVersions=v1"
 
@@ -37,8 +41,12 @@ uninstall: manifests
 
 # Deploy controller in the configured Kubernetes cluster in ~/.kube/config
 deploy: manifests
-	cd config/manager && kustomize edit set image controller=${IMG}
-	kustomize build config/default | kubectl apply -f -
+	cd config/manager; kustomize edit set image controller=${IMG}:latest
+	cd $(CURDIR); kustomize build config/default | sed 's/latest/${TAG}/g' | kubectl apply -f -
+
+# Delete controller from the K8s cluster specified in ~/.kube/config.
+delete: manifests
+	kustomize build config/default | kubectl delete -f -
 
 # Generate manifests e.g. CRD, RBAC etc.
 manifests: controller-gen
@@ -49,8 +57,8 @@ manifests: controller-gen
 
 # Generate deployments
 deployment: manifests
-	cd config/manager && kustomize edit set image controller=${IMG}
-	kustomize build config/default > /tmp/KubeArmorHostPolicy.yaml
+	cd config/manager; kustomize edit set image controller=${IMG}:latest
+	cd $(CURDIR); kustomize build config/default > /tmp/kubearmor-host-policy-manager.yaml
 
 # Run go fmt against code
 fmt:
@@ -62,16 +70,16 @@ vet:
 
 # Generate code
 generate: controller-gen
-	go mod tidy
-	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./..."
+	go mod tidy; $(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./..."
 
 # Build the docker image
 docker-build:
-	docker build . -t ${IMG}
+	docker build -t ${IMG}:${TAG} -t ${IMG}:latest .
 
 # Push the docker image
 docker-push:
-	docker push ${IMG}
+	docker push ${IMG}:${TAG}
+	docker push ${IMG}:latest
 
 client/gen:
 	@echo "--> Running code-generator to generate clients"
@@ -93,7 +101,8 @@ ifeq (, $(shell which controller-gen))
 	CONTROLLER_GEN_TMP_DIR=$$(mktemp -d) ;\
 	cd $$CONTROLLER_GEN_TMP_DIR ;\
 	go mod init tmp ;\
-	go get sigs.k8s.io/controller-tools/cmd/controller-gen@v0.2.5 ;\
+	go get sigs.k8s.io/controller-tools/cmd/controller-gen@v0.4.1 ;\
+	go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.4.1 ;\
 	rm -rf $$CONTROLLER_GEN_TMP_DIR ;\
 	}
 CONTROLLER_GEN=$(GOBIN)/controller-gen
@@ -102,4 +111,4 @@ CONTROLLER_GEN=$(shell which controller-gen)
 endif
 
 clean:
-	rm -rf bin go.sum cover.out /tmp/KubeArmorHostPolicy.yaml
+	rm -rf bin go.sum cover.out /tmp/kubearmor-host-policy-manager.yaml

--- a/pkg/KubeArmorHostPolicy/config/crd/bases/security.kubearmor.com_kubearmorhostpolicies.yaml
+++ b/pkg/KubeArmorHostPolicy/config/crd/bases/security.kubearmor.com_kubearmorhostpolicies.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.5
+    controller-gen.kubebuilder.io/version: v0.4.1
   creationTimestamp: null
   name: kubearmorhostpolicies.security.kubearmor.com
 spec:

--- a/pkg/KubeArmorHostPolicy/config/rbac/auth_proxy_client_clusterrole.yaml
+++ b/pkg/KubeArmorHostPolicy/config/rbac/auth_proxy_client_clusterrole.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: metrics-reader

--- a/pkg/KubeArmorHostPolicy/controllers/kubearmorhostpolicy_controller.go
+++ b/pkg/KubeArmorHostPolicy/controllers/kubearmorhostpolicy_controller.go
@@ -65,11 +65,9 @@ func (r *KubeArmorHostPolicyReconciler) Reconcile(ctx context.Context, req ctrl.
 POLICYERROR:
 	if policyErr != nil {
 		// Update PolicyStatus
-		policy.Status.PolicyStatus = "Not OK"
+		policy.Status.PolicyStatus = "Invalid"
 		err := r.Status().Update(ctx, policy)
-		log.Info("Invalid KubeArmorHostPolicy")
-		// delete the invalid KubeArmorPolicy
-		// err := r.Delete(ctx, policy)
+		log.Info("Failed to fetch KubeArmorHostPolicy")
 		return ctrl.Result{}, err
 	}
 

--- a/pkg/KubeArmorHostPolicy/crd/KubeArmorHostPolicy.yaml
+++ b/pkg/KubeArmorHostPolicy/crd/KubeArmorHostPolicy.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.5
+    controller-gen.kubebuilder.io/version: v0.4.1
   creationTimestamp: null
   name: kubearmorhostpolicies.security.kubearmor.com
 spec:

--- a/pkg/KubeArmorHostPolicy/go.mod
+++ b/pkg/KubeArmorHostPolicy/go.mod
@@ -1,6 +1,6 @@
 module github.com/kubearmor/KubeArmor/pkg/KubeArmorHostPolicy
 
-go 1.16
+go 1.17
 
 require (
 	github.com/go-logr/logr v0.4.0
@@ -9,7 +9,57 @@ require (
 	k8s.io/apiextensions-apiserver v0.22.1
 	k8s.io/apimachinery v0.22.1
 	k8s.io/client-go v0.22.1
-	k8s.io/klog/v2 v2.10.0 // indirect
 	sigs.k8s.io/controller-runtime v0.10.0
 	sigs.k8s.io/yaml v1.2.0
+)
+
+require (
+	cloud.google.com/go v0.54.0 // indirect
+	github.com/beorn7/perks v1.0.1 // indirect
+	github.com/cespare/xxhash/v2 v2.1.1 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/evanphx/json-patch v4.11.0+incompatible // indirect
+	github.com/fsnotify/fsnotify v1.4.9 // indirect
+	github.com/go-logr/zapr v0.4.0 // indirect
+	github.com/gogo/protobuf v1.3.2 // indirect
+	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
+	github.com/golang/protobuf v1.5.2 // indirect
+	github.com/google/go-cmp v0.5.5 // indirect
+	github.com/google/gofuzz v1.1.0 // indirect
+	github.com/google/uuid v1.1.2 // indirect
+	github.com/googleapis/gnostic v0.5.5 // indirect
+	github.com/imdario/mergo v0.3.12 // indirect
+	github.com/json-iterator/go v1.1.11 // indirect
+	github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 // indirect
+	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
+	github.com/modern-go/reflect2 v1.0.1 // indirect
+	github.com/nxadm/tail v1.4.8 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
+	github.com/prometheus/client_golang v1.11.0 // indirect
+	github.com/prometheus/client_model v0.2.0 // indirect
+	github.com/prometheus/common v0.26.0 // indirect
+	github.com/prometheus/procfs v0.6.0 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
+	go.uber.org/atomic v1.7.0 // indirect
+	go.uber.org/multierr v1.6.0 // indirect
+	go.uber.org/zap v1.19.0 // indirect
+	golang.org/x/net v0.0.0-20210520170846-37e1c6afe023 // indirect
+	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d // indirect
+	golang.org/x/sys v0.0.0-20210817190340-bfb29a6856f2 // indirect
+	golang.org/x/term v0.0.0-20210220032956-6a3ed077a48d // indirect
+	golang.org/x/text v0.3.6 // indirect
+	golang.org/x/time v0.0.0-20210723032227-1f47c861a9ac // indirect
+	gomodules.xyz/jsonpatch/v2 v2.2.0 // indirect
+	google.golang.org/appengine v1.6.7 // indirect
+	google.golang.org/protobuf v1.26.0 // indirect
+	gopkg.in/inf.v0 v0.9.1 // indirect
+	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
+	k8s.io/api v0.22.1 // indirect
+	k8s.io/component-base v0.22.1 // indirect
+	k8s.io/klog/v2 v2.10.0 // indirect
+	k8s.io/kube-openapi v0.0.0-20210421082810-95288971da7e // indirect
+	k8s.io/utils v0.0.0-20210802155522-efc7438f0176 // indirect
+	sigs.k8s.io/structured-merge-diff/v4 v4.1.2 // indirect
 )

--- a/pkg/KubeArmorPolicy/Dockerfile
+++ b/pkg/KubeArmorPolicy/Dockerfile
@@ -2,7 +2,7 @@
 # Copyright 2021 Authors of KubeArmor
 
 # Build the manager binary
-FROM golang:1.13 as builder
+FROM golang:1.17 as builder
 
 WORKDIR /workspace
 

--- a/pkg/KubeArmorPolicy/Makefile
+++ b/pkg/KubeArmorPolicy/Makefile
@@ -1,8 +1,12 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2021 Authors of KubeArmor
 
+CURDIR := $(shell pwd)
+
 # Image URL to use all building/pushing image targets
-IMG ?= kubearmor/kubearmor-policy-manager:latest
+IMG ?= kubearmor/kubearmor-policy-manager
+# Image Tag to use all building/pushing image targets
+TAG ?= v0.1
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
 CRD_OPTIONS ?= "crd:crdVersions=v1"
 
@@ -37,8 +41,12 @@ uninstall: manifests
 
 # Deploy controller in the configured Kubernetes cluster in ~/.kube/config
 deploy: manifests
-	cd config/manager && kustomize edit set image controller=${IMG}
-	kustomize build config/default | kubectl apply -f -
+	cd config/manager; kustomize edit set image controller=${IMG}:latest
+	cd $(CURDIR); kustomize build config/default | sed 's/latest/${TAG}/g' | kubectl apply -f -
+
+# Delete controller from the K8s cluster specified in ~/.kube/config.
+delete: manifests
+	kustomize build config/default | kubectl delete -f -
 
 # Generate manifests e.g. CRD, RBAC etc.
 manifests: controller-gen
@@ -48,8 +56,8 @@ manifests: controller-gen
 
 # Generate deployments
 deployment: manifests
-	cd config/manager && kustomize edit set image controller=${IMG}
-	kustomize build config/default > /tmp/KubeArmorPolicy.yaml
+	cd config/manager; kustomize edit set image controller=${IMG}:latest
+	cd $(CURDIR); kustomize build config/default > /tmp/kubearmor-policy-manager.yaml
 
 # Run go fmt against code
 fmt:
@@ -61,16 +69,16 @@ vet:
 
 # Generate code
 generate: controller-gen
-	go mod tidy
-	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./..."
+	go mod tidy; $(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./..."
 
 # Build the docker image
 docker-build:
-	docker build . -t ${IMG}
+	docker build -t ${IMG}:${TAG} -t ${IMG}:latest .
 
 # Push the docker image
 docker-push:
-	docker push ${IMG}
+	docker push ${IMG}:${TAG}
+	docker push ${IMG}:latest
 
 client/gen:
 	@echo "--> Running code-generator to generate clients"
@@ -83,7 +91,6 @@ client/gen:
 	@cp -r ./github.com/kubearmor/KubeArmor/pkg/KubeArmorPolicy/client/* ./client/
 	@rm -rf ./github.com ./tmp/code-generator
 
-
 # find or download controller-gen
 # download controller-gen if necessary
 controller-gen:
@@ -93,7 +100,8 @@ ifeq (, $(shell which controller-gen))
 	CONTROLLER_GEN_TMP_DIR=$$(mktemp -d) ;\
 	cd $$CONTROLLER_GEN_TMP_DIR ;\
 	go mod init tmp ;\
-	go get sigs.k8s.io/controller-tools/cmd/controller-gen@v0.2.5 ;\
+	go get sigs.k8s.io/controller-tools/cmd/controller-gen@v0.4.1 ;\
+	go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.4.1 ;\
 	rm -rf $$CONTROLLER_GEN_TMP_DIR ;\
 	}
 CONTROLLER_GEN=$(GOBIN)/controller-gen
@@ -102,4 +110,4 @@ CONTROLLER_GEN=$(shell which controller-gen)
 endif
 
 clean:
-	rm -rf bin go.sum cover.out /tmp/KubeArmorPolicy.yaml
+	rm -rf bin go.sum cover.out /tmp/kubearmor-policy-manager.yaml

--- a/pkg/KubeArmorPolicy/api/security.kubearmor.com/v1/kubearmorpolicy_types.go
+++ b/pkg/KubeArmorPolicy/api/security.kubearmor.com/v1/kubearmorpolicy_types.go
@@ -280,8 +280,7 @@ type KubeArmorPolicySpec struct {
 	Network      NetworkType      `json:"network,omitempty"`
 	Capabilities CapabilitiesType `json:"capabilities,omitempty"`
 
-	AppArmor string      `json:"apparmor,omitempty"`
-	SELinux  SELinuxType `json:"selinux,omitempty"`
+	AppArmor string `json:"apparmor,omitempty"`
 
 	// +kubebuilder:validation:optional
 	Severity SeverityType `json:"severity,omitempty"`

--- a/pkg/KubeArmorPolicy/api/security.kubearmor.com/v1/zz_generated.deepcopy.go
+++ b/pkg/KubeArmorPolicy/api/security.kubearmor.com/v1/zz_generated.deepcopy.go
@@ -217,7 +217,6 @@ func (in *KubeArmorPolicySpec) DeepCopyInto(out *KubeArmorPolicySpec) {
 	in.File.DeepCopyInto(&out.File)
 	in.Network.DeepCopyInto(&out.Network)
 	in.Capabilities.DeepCopyInto(&out.Capabilities)
-	in.SELinux.DeepCopyInto(&out.SELinux)
 	if in.Tags != nil {
 		in, out := &in.Tags, &out.Tags
 		*out = make([]string, len(*in))

--- a/pkg/KubeArmorPolicy/config/crd/bases/security.kubearmor.com_kubearmorpolicies.yaml
+++ b/pkg/KubeArmorPolicy/config/crd/bases/security.kubearmor.com_kubearmorpolicies.yaml
@@ -411,56 +411,6 @@ spec:
                       type: string
                     type: object
                 type: object
-              selinux:
-                properties:
-                  action:
-                    enum:
-                    - Allow
-                    - Audit
-                    - Block
-                    type: string
-                  matchVolumeMounts:
-                    items:
-                      properties:
-                        action:
-                          enum:
-                          - Allow
-                          - Audit
-                          - Block
-                          type: string
-                        dir:
-                          pattern: ^\/$|^\/.*\/$
-                          type: string
-                        message:
-                          type: string
-                        path:
-                          pattern: ^\/+.*[^\/]$
-                          type: string
-                        readOnly:
-                          type: boolean
-                        severity:
-                          maximum: 10
-                          minimum: 1
-                          type: integer
-                        tags:
-                          items:
-                            type: string
-                          type: array
-                      type: object
-                    type: array
-                  message:
-                    type: string
-                  severity:
-                    maximum: 10
-                    minimum: 1
-                    type: integer
-                  tags:
-                    items:
-                      type: string
-                    type: array
-                required:
-                - matchVolumeMounts
-                type: object
               severity:
                 maximum: 10
                 minimum: 1

--- a/pkg/KubeArmorPolicy/config/crd/bases/security.kubearmor.com_kubearmorpolicies.yaml
+++ b/pkg/KubeArmorPolicy/config/crd/bases/security.kubearmor.com_kubearmorpolicies.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.5
+    controller-gen.kubebuilder.io/version: v0.4.1
   creationTimestamp: null
   name: kubearmorpolicies.security.kubearmor.com
 spec:

--- a/pkg/KubeArmorPolicy/config/rbac/auth_proxy_client_clusterrole.yaml
+++ b/pkg/KubeArmorPolicy/config/rbac/auth_proxy_client_clusterrole.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: metrics-reader

--- a/pkg/KubeArmorPolicy/controllers/kubearmorpolicy_controller.go
+++ b/pkg/KubeArmorPolicy/controllers/kubearmorpolicy_controller.go
@@ -65,11 +65,9 @@ func (r *KubeArmorPolicyReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 POLICYERROR:
 	if policyErr != nil {
 		// Update PolicyStatus
-		policy.Status.PolicyStatus = "Not OK"
+		policy.Status.PolicyStatus = "Invalid"
 		err := r.Status().Update(ctx, policy)
-		log.Info("Invalid KubeArmorPolicy")
-		// delete the invalid KubeArmorPolicy
-		// err := r.Delete(ctx, policy)
+		log.Info("Failed to fetch KubeArmorPolicy")
 		return ctrl.Result{}, err
 	}
 

--- a/pkg/KubeArmorPolicy/crd/KubeArmorPolicy.yaml
+++ b/pkg/KubeArmorPolicy/crd/KubeArmorPolicy.yaml
@@ -411,56 +411,6 @@ spec:
                       type: string
                     type: object
                 type: object
-              selinux:
-                properties:
-                  action:
-                    enum:
-                    - Allow
-                    - Audit
-                    - Block
-                    type: string
-                  matchVolumeMounts:
-                    items:
-                      properties:
-                        action:
-                          enum:
-                          - Allow
-                          - Audit
-                          - Block
-                          type: string
-                        dir:
-                          pattern: ^\/$|^\/.*\/$
-                          type: string
-                        message:
-                          type: string
-                        path:
-                          pattern: ^\/+.*[^\/]$
-                          type: string
-                        readOnly:
-                          type: boolean
-                        severity:
-                          maximum: 10
-                          minimum: 1
-                          type: integer
-                        tags:
-                          items:
-                            type: string
-                          type: array
-                      type: object
-                    type: array
-                  message:
-                    type: string
-                  severity:
-                    maximum: 10
-                    minimum: 1
-                    type: integer
-                  tags:
-                    items:
-                      type: string
-                    type: array
-                required:
-                - matchVolumeMounts
-                type: object
               severity:
                 maximum: 10
                 minimum: 1

--- a/pkg/KubeArmorPolicy/crd/KubeArmorPolicy.yaml
+++ b/pkg/KubeArmorPolicy/crd/KubeArmorPolicy.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.5
+    controller-gen.kubebuilder.io/version: v0.4.1
   creationTimestamp: null
   name: kubearmorpolicies.security.kubearmor.com
 spec:

--- a/pkg/KubeArmorPolicy/go.mod
+++ b/pkg/KubeArmorPolicy/go.mod
@@ -1,6 +1,6 @@
 module github.com/kubearmor/KubeArmor/pkg/KubeArmorPolicy
 
-go 1.16
+go 1.17
 
 require (
 	github.com/go-logr/logr v0.4.0
@@ -9,7 +9,57 @@ require (
 	k8s.io/apiextensions-apiserver v0.22.1
 	k8s.io/apimachinery v0.22.1
 	k8s.io/client-go v0.22.1
-	k8s.io/klog/v2 v2.10.0 // indirect
 	sigs.k8s.io/controller-runtime v0.10.0
 	sigs.k8s.io/yaml v1.2.0
+)
+
+require (
+	cloud.google.com/go v0.54.0 // indirect
+	github.com/beorn7/perks v1.0.1 // indirect
+	github.com/cespare/xxhash/v2 v2.1.1 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/evanphx/json-patch v4.11.0+incompatible // indirect
+	github.com/fsnotify/fsnotify v1.4.9 // indirect
+	github.com/go-logr/zapr v0.4.0 // indirect
+	github.com/gogo/protobuf v1.3.2 // indirect
+	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
+	github.com/golang/protobuf v1.5.2 // indirect
+	github.com/google/go-cmp v0.5.5 // indirect
+	github.com/google/gofuzz v1.1.0 // indirect
+	github.com/google/uuid v1.1.2 // indirect
+	github.com/googleapis/gnostic v0.5.5 // indirect
+	github.com/imdario/mergo v0.3.12 // indirect
+	github.com/json-iterator/go v1.1.11 // indirect
+	github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 // indirect
+	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
+	github.com/modern-go/reflect2 v1.0.1 // indirect
+	github.com/nxadm/tail v1.4.8 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
+	github.com/prometheus/client_golang v1.11.0 // indirect
+	github.com/prometheus/client_model v0.2.0 // indirect
+	github.com/prometheus/common v0.26.0 // indirect
+	github.com/prometheus/procfs v0.6.0 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
+	go.uber.org/atomic v1.7.0 // indirect
+	go.uber.org/multierr v1.6.0 // indirect
+	go.uber.org/zap v1.19.0 // indirect
+	golang.org/x/net v0.0.0-20210520170846-37e1c6afe023 // indirect
+	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d // indirect
+	golang.org/x/sys v0.0.0-20210817190340-bfb29a6856f2 // indirect
+	golang.org/x/term v0.0.0-20210220032956-6a3ed077a48d // indirect
+	golang.org/x/text v0.3.6 // indirect
+	golang.org/x/time v0.0.0-20210723032227-1f47c861a9ac // indirect
+	gomodules.xyz/jsonpatch/v2 v2.2.0 // indirect
+	google.golang.org/appengine v1.6.7 // indirect
+	google.golang.org/protobuf v1.26.0 // indirect
+	gopkg.in/inf.v0 v0.9.1 // indirect
+	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
+	k8s.io/api v0.22.1 // indirect
+	k8s.io/component-base v0.22.1 // indirect
+	k8s.io/klog/v2 v2.10.0 // indirect
+	k8s.io/kube-openapi v0.0.0-20210421082810-95288971da7e // indirect
+	k8s.io/utils v0.0.0-20210802155522-efc7438f0176 // indirect
+	sigs.k8s.io/structured-merge-diff/v4 v4.1.2 // indirect
 )


### PR DESCRIPTION
- upgrade go version
- update Makefile to compile a controller, build a docker image, deploy the image in the k8s cluster, and test the controller
- update k8s scripts (if runtime = docker, use k8s 1.23 / otherwise, use the latest k8s)
- remove unused field (i.e., selinux) in KubeArmorPolicy