### PR TITLE
fixes k8s-nodeName, hostname mismatch issue

### DIFF
--- a/deployments/AKS/kubearmor.yaml
+++ b/deployments/AKS/kubearmor.yaml
@@ -83,6 +83,11 @@ spec:
         - -gRPC=32767
         - -logPath=/tmp/kubearmor.log
         - -enableKubeArmorHostPolicy
+        env:
+        - name: KUBEARMOR_NODENAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
         image: kubearmor/kubearmor:stable
         imagePullPolicy: Always
         livenessProbe:

--- a/deployments/EKS/kubearmor.yaml
+++ b/deployments/EKS/kubearmor.yaml
@@ -83,6 +83,11 @@ spec:
         - -gRPC=32767
         - -logPath=/tmp/kubearmor.log
         - -enableKubeArmorHostPolicy
+        env:
+        - name: KUBEARMOR_NODENAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
         image: kubearmor/kubearmor:stable
         imagePullPolicy: Always
         livenessProbe:

--- a/deployments/GKE/kubearmor.yaml
+++ b/deployments/GKE/kubearmor.yaml
@@ -83,6 +83,11 @@ spec:
         - -gRPC=32767
         - -logPath=/tmp/kubearmor.log
         - -enableKubeArmorHostPolicy
+        env:
+        - name: KUBEARMOR_NODENAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
         image: kubearmor/kubearmor:stable
         imagePullPolicy: Always
         livenessProbe:

--- a/deployments/docker/kubearmor.yaml
+++ b/deployments/docker/kubearmor.yaml
@@ -83,6 +83,11 @@ spec:
         - -gRPC=32767
         - -logPath=/tmp/kubearmor.log
         - -enableKubeArmorHostPolicy
+        env:
+        - name: KUBEARMOR_NODENAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
         image: kubearmor/kubearmor:stable
         imagePullPolicy: Always
         livenessProbe:

--- a/deployments/generic/kubearmor.yaml
+++ b/deployments/generic/kubearmor.yaml
@@ -83,6 +83,11 @@ spec:
         - -gRPC=32767
         - -logPath=/tmp/kubearmor.log
         - -enableKubeArmorHostPolicy
+        env:
+        - name: KUBEARMOR_NODENAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
         image: kubearmor/kubearmor:stable
         imagePullPolicy: Always
         livenessProbe:

--- a/deployments/get/defaults.go
+++ b/deployments/get/defaults.go
@@ -20,6 +20,7 @@ var hostPolicyManagerDeploymentName = "kubearmor-host-policy-manager"
 // DaemonSetConfig Structure
 type DaemonSetConfig struct {
 	Args         []string
+	Envs         []corev1.EnvVar
 	VolumeMounts []corev1.VolumeMount
 	Volumes      []corev1.Volume
 }
@@ -76,12 +77,24 @@ var apparmorVol = corev1.Volume{
 	},
 }
 
+var envVar = []corev1.EnvVar{
+	{
+		Name: "KUBEARMOR_NODENAME",
+		ValueFrom: &corev1.EnvVarSource{
+			FieldRef: &corev1.ObjectFieldSelector{
+				FieldPath: "spec.nodeName",
+			},
+		},
+	},
+}
+
 // Environment Specific Daemonset Configuration
 var defaultConfigs = map[string]DaemonSetConfig{
 	"generic": {
 		Args: []string{
 			"-enableKubeArmorHostPolicy",
 		},
+		Envs: envVar,
 		VolumeMounts: []corev1.VolumeMount{
 			hostUsrVolMnt,
 			apparmorVolMnt,
@@ -137,6 +150,7 @@ var defaultConfigs = map[string]DaemonSetConfig{
 		Args: []string{
 			"-enableKubeArmorHostPolicy",
 		},
+		Envs: envVar,
 		VolumeMounts: []corev1.VolumeMount{
 			hostUsrVolMnt,
 			apparmorVolMnt,
@@ -176,6 +190,7 @@ var defaultConfigs = map[string]DaemonSetConfig{
 	},
 	"minikube": {
 		Args: []string{},
+		Envs: envVar,
 		VolumeMounts: []corev1.VolumeMount{
 			hostUsrVolMnt,
 			apparmorVolMnt,
@@ -217,6 +232,7 @@ var defaultConfigs = map[string]DaemonSetConfig{
 		Args: []string{
 			"-enableKubeArmorHostPolicy",
 		},
+		Envs: envVar,
 		VolumeMounts: []corev1.VolumeMount{
 			hostUsrVolMnt,
 			apparmorVolMnt,
@@ -258,6 +274,7 @@ var defaultConfigs = map[string]DaemonSetConfig{
 		Args: []string{
 			"-enableKubeArmorHostPolicy",
 		},
+		Envs: envVar,
 		VolumeMounts: []corev1.VolumeMount{
 			hostUsrVolMnt,
 			apparmorVolMnt,
@@ -299,6 +316,7 @@ var defaultConfigs = map[string]DaemonSetConfig{
 		Args: []string{
 			"-enableKubeArmorHostPolicy",
 		},
+		Envs: envVar,
 		VolumeMounts: []corev1.VolumeMount{
 			gkeHostUsrVolMnt,
 			apparmorVolMnt,
@@ -354,6 +372,7 @@ var defaultConfigs = map[string]DaemonSetConfig{
 		Args: []string{
 			"-enableKubeArmorHostPolicy",
 		},
+		Envs: envVar,
 		VolumeMounts: []corev1.VolumeMount{
 			hostUsrVolMnt,
 			apparmorVolMnt,
@@ -409,6 +428,7 @@ var defaultConfigs = map[string]DaemonSetConfig{
 		Args: []string{
 			"-enableKubeArmorHostPolicy",
 		},
+		Envs: envVar,
 		VolumeMounts: []corev1.VolumeMount{
 			hostUsrVolMnt,
 			apparmorVolMnt,

--- a/deployments/get/objects.go
+++ b/deployments/get/objects.go
@@ -439,6 +439,7 @@ func GenerateDaemonSet(env, namespace string) *appsv1.DaemonSet {
 	}
 
 	args = append(args, defaultConfigs[env].Args...)
+	envs := defaultConfigs[env].Envs
 
 	volumeMounts = append(volumeMounts, defaultConfigs[env].VolumeMounts...)
 	volumes = append(volumes, defaultConfigs[env].Volumes...)
@@ -487,6 +488,7 @@ func GenerateDaemonSet(env, namespace string) *appsv1.DaemonSet {
 								Privileged: &privileged,
 							},
 							Args: args,
+							Env:  envs,
 							Ports: []corev1.ContainerPort{
 								{
 									ContainerPort: port,

--- a/deployments/k3s/kubearmor.yaml
+++ b/deployments/k3s/kubearmor.yaml
@@ -83,6 +83,11 @@ spec:
         - -gRPC=32767
         - -logPath=/tmp/kubearmor.log
         - -enableKubeArmorHostPolicy
+        env:
+        - name: KUBEARMOR_NODENAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
         image: kubearmor/kubearmor:stable
         imagePullPolicy: Always
         livenessProbe:

--- a/deployments/microk8s/kubearmor.yaml
+++ b/deployments/microk8s/kubearmor.yaml
@@ -83,6 +83,11 @@ spec:
         - -gRPC=32767
         - -logPath=/tmp/kubearmor.log
         - -enableKubeArmorHostPolicy
+        env:
+        - name: KUBEARMOR_NODENAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
         image: kubearmor/kubearmor:stable
         imagePullPolicy: Always
         livenessProbe:

--- a/deployments/minikube/kubearmor.yaml
+++ b/deployments/minikube/kubearmor.yaml
@@ -82,6 +82,11 @@ spec:
       - args:
         - -gRPC=32767
         - -logPath=/tmp/kubearmor.log
+        env:
+        - name: KUBEARMOR_NODENAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
         image: kubearmor/kubearmor:stable
         imagePullPolicy: Always
         livenessProbe:


### PR DESCRIPTION
Kubearmor goes into CrashLookBackOff if for some reason the k8s-nodeName
does not match with the node's hostname.
k8s-nodename is usually derived from the node's hostname, but if for
some reason the node's hostname is changed then the k8s-nodename is not
correspondingly changed. This causes the kubearmor to go in a crash
loop while printing the message "The node information is not available".

**Why does Kubearmor need to match nodename and hostname?**
Kubearmor needs to set annotation on the local node. For that it needs
to know the node's metadata from k8s and match it up with the hostname.

Signed-off-by: Rahul Jadhav <nyrahul@gmail.com>