### PR TITLE
[tests] add multi runtime CI tests

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -18,18 +18,18 @@ on:
 
 jobs:
   build:
-    name: Auto-testing Framework / ${{ matrix.os }}
+    name: Auto-testing Framework / ${{ matrix.os }} / ${{ matrix.runtime }}
     runs-on: ${{ matrix.os }}
+    env:
+      RUNTIME: ${{ matrix.runtime }}
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, ubuntu-18.04]
+        runtime: ["containerd", "docker", "crio"]
     steps:
       - name: Kernel version
         run: uname -r
-
-      - name: Check Docker Version
-        run: docker --version
 
       - uses: actions/checkout@v2
 
@@ -54,7 +54,11 @@ jobs:
 
       - name: Setup Enviroment
         run: |
-          RUNTIME=docker ./contribution/k3s/install_k3s.sh
+          if [ "$RUNTIME" == "crio" ]; then
+            ./contribution/self-managed-k8s/crio/install-crio.sh
+            crio --version
+          fi
+          RUNTIME=$RUNTIME ./contribution/k3s/install_k3s.sh
 
       - name: Install annotation controller
         run: |
@@ -67,7 +71,7 @@ jobs:
         run: kubectl proxy &
 
       - name: Test KubeArmor
-        run: ./tests/test-scenarios-github.sh
+        run: RUNTIME=$RUNTIME ./tests/test-scenarios-github.sh
         timeout-minutes: 15
 
       - name: Archive log artifacts

--- a/.github/workflows/latest-release.yml
+++ b/.github/workflows/latest-release.yml
@@ -34,7 +34,8 @@ jobs:
           else
             echo ::set-output name=tag::${GITHUB_REF#refs/*/}
           fi
-          ./contribution/k3s/install_k3s.sh
+          # use docker because image build script uses docker
+          RUNTIME="docker" ./contribution/k3s/install_k3s.sh
 
       - name: Install annotation controller
         run: |

--- a/KubeArmor/config/config.go
+++ b/KubeArmor/config/config.go
@@ -4,7 +4,6 @@
 package config
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -230,7 +229,7 @@ func LoadConfig() error {
 	}
 
 	if GlobalCfg.CRISocket != "" && !strings.HasPrefix(GlobalCfg.CRISocket, "unix://") {
-		return errors.New(fmt.Sprintf("%s is invalid. CRI socket must start with unix://", GlobalCfg.CRISocket))
+		return fmt.Errorf("%s is invalid. CRI socket must start with unix://", GlobalCfg.CRISocket)
 	}
 
 	kg.Printf("Configuration [%+v]", GlobalCfg)

--- a/KubeArmor/core/crioHandler.go
+++ b/KubeArmor/core/crioHandler.go
@@ -205,7 +205,6 @@ func (dm *KubeArmorDaemon) UpdateCrioContainer(ctx context.Context, containerID,
 		// get container info from client
 		container, err := Crio.GetContainerInfo(ctx, containerID)
 		if err != nil {
-			kg.Warnf(err.Error())
 			return false
 		}
 


### PR DESCRIPTION
Signed-off-by: Rudraksh Pareek <rudraksh@accuknox.com>

PR description:
* Adds workflow for testing CRI-O in GH actions
* Adds a matrix job for parallelly testing all runtimes in GH actions
* Fixes the currently failing `Create KubeArmor release after testing the image` workflow on main
* Lint

~~Needs #697 to be merged first.~~