### PR TITLE
[bugfix] fix security profile clash 

### DIFF
--- a/KubeArmor/common/common.go
+++ b/KubeArmor/common/common.go
@@ -18,6 +18,7 @@ import (
 
 	kc "github.com/kubearmor/KubeArmor/KubeArmor/config"
 	kg "github.com/kubearmor/KubeArmor/KubeArmor/log"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // ============ //
@@ -388,6 +389,16 @@ func GetCRISocket(ContainerRuntime string) string {
 		}
 	}
 	return ""
+}
+
+// GetControllingPodOwner Function returns the pod's Controlling OnwerReference
+func GetControllingPodOwner(ownerRefs []metav1.OwnerReference) *metav1.OwnerReference {
+	for _, ownerRef := range ownerRefs {
+		if *ownerRef.Controller {
+			return &ownerRef
+		}
+	}
+	return nil
 }
 
 // ==================== //

--- a/contribution/self-managed-k8s/k8s/initialize_kubernetes.sh
+++ b/contribution/self-managed-k8s/k8s/initialize_kubernetes.sh
@@ -9,8 +9,9 @@ fi
 
 # use docker as default CRI
 if [ "$CRI_SOCKET" == "" ]; then
+    # if docker, let kubeadm figure it out
     if [ -S /var/run/docker.sock ]; then
-        CRI_SOCKET=unix:///var/run/docker.sock
+        CRI_SOCKET=""
     elif [ -S /var/run/containerd/containerd.sock ]; then
         CRI_SOCKET=unix:///var/run/containerd/containerd.sock
     elif [ -S /var/run/crio/crio.sock ]; then


### PR DESCRIPTION
Signed-off-by: Rudraksh Pareek <rudraksh@accuknox.com>

Scenarios:
- [x] Deploy kubearmor then deploy pods
- [x] Deploy workloads then deploy kubearmor
- [x] The profile name has deployment's name and is unaffected by changing template hash of pods
- [x]  Workloads annotated by older version of kubearmor comply with these changes. (Handling update)

TODO:
- [x] Update annontations controller to use similar naming convention

This PR fixes #700 