### PR TITLE
cri: handle bugs and edge cases

### DIFF
--- a/KubeArmor/core/dockerHandler.go
+++ b/KubeArmor/core/dockerHandler.go
@@ -172,9 +172,9 @@ func (dh *DockerHandler) GetEventChannel() <-chan events.Message {
 
 // GetAlreadyDeployedDockerContainers Function
 func (dm *KubeArmorDaemon) GetAlreadyDeployedDockerContainers() {
-	// check if Docker exists
+	// check if Docker exists else instantiate
 	if Docker == nil {
-		return
+		Docker = NewDockerHandler()
 	}
 
 	if containerList, err := Docker.DockerClient.ContainerList(context.Background(), types.ContainerListOptions{}); err == nil {
@@ -376,11 +376,9 @@ func (dm *KubeArmorDaemon) MonitorDockerEvents() {
 	dm.WgDaemon.Add(1)
 	defer dm.WgDaemon.Done()
 
-	Docker = NewDockerHandler()
-
-	// check if Docker exists
+	// check if Docker exists else instantiate
 	if Docker == nil {
-		return
+		Docker = NewDockerHandler()
 	}
 
 	dm.Logger.Print("Started to monitor Docker events")

--- a/KubeArmor/core/kubeArmor.go
+++ b/KubeArmor/core/kubeArmor.go
@@ -461,15 +461,15 @@ func KubeArmor() {
 			}
 
 			// monitor containers
-			if strings.Contains(cfg.GlobalCfg.CRISocket, "docker") {
+			if strings.Contains(dm.Node.ContainerRuntimeVersion, "docker") {
 				// update already deployed containers
 				dm.GetAlreadyDeployedDockerContainers()
 				// monitor docker events
 				go dm.MonitorDockerEvents()
-			} else if strings.Contains(cfg.GlobalCfg.CRISocket, "containerd") {
+			} else if strings.Contains(dm.Node.ContainerRuntimeVersion, "containerd") {
 				// monitor containerd events
 				go dm.MonitorContainerdEvents()
-			} else if strings.Contains(cfg.GlobalCfg.CRISocket, "crio") {
+			} else if strings.Contains(dm.Node.ContainerRuntimeVersion, "crio") {
 				// monitor crio events
 				go dm.MonitorCrioEvents()
 			} else {


### PR DESCRIPTION
- It is possible that cri socket be named something different and cri runtime be different like EKS uses dockershim as socket but the runtime is containerd. So we decide based on the runtime and not configured socket

- Recent changes introduced docker getting instantiated later at runtime and not init time due to which we were not fetching already deployed containers, so added a check to instantiate docker handler if nil