### PR TITLE
add in cluster tests + fix synk vuln SNYK-CC-K8S-8

### DIFF
--- a/.github/workflows/ci-test-incluster.yml
+++ b/.github/workflows/ci-test-incluster.yml
@@ -1,0 +1,79 @@
+name: run-in-cluster-test
+
+on:
+  push:
+    branches:
+    - "**"
+    paths:
+    - "deployments/annotations/**"
+    - "deployments/generic/**"
+    - "tests/test-scenarios-github.sh"
+    - ".github/workflows/ci-test-incluster.yml"
+  pull_request:
+    branches: ["*"]
+    paths: 
+    - "deployments/annotations/**"
+    - "deployments/generic/**"
+    - "tests/test-scenarios-github.sh"
+    - ".github/workflows/ci-test-incluster.yml"
+
+jobs:
+  manifest-test:
+    name: Run basic manifest tests / ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, ubuntu-18.04]
+    steps:
+      - name: Kernel version
+        run: uname -r
+      
+      - uses: actions/checkout@v2
+
+      - name: Setup Enviroment
+        run: |
+          ./contribution/k3s/install_k3s.sh
+
+      - name: Install cmctl
+        run: |
+          OS=$(go env GOOS); ARCH=$(go env GOARCH); curl -sSL -o cmctl.tar.gz https://github.com/cert-manager/cert-manager/releases/download/v1.7.2/cmctl-$OS-$ARCH.tar.gz
+          tar xzf cmctl.tar.gz
+          sudo mv cmctl /usr/local/bin
+
+      - name: Install annotation controller
+        run: |
+          kubectl apply -f deployments/annotations/cert-manager.yaml
+          kubectl wait pods --for=condition=ready -n cert-manager -l app.kubernetes.io/instance=cert-manager
+          cmctl check api  --wait 300s
+          kubectl apply -f deployments/annotations/kubearmor-annotation-manager.yaml
+          kubectl wait pods --for=condition=ready -n kube-system -l kubearmor-app=kubearmor-annotation-manager
+      
+      - name: Apply KubeArmor manifest
+        run: |
+            kubectl apply -f deployments/generic/kubearmor.yaml
+       
+      - name: Test manifests
+        run: |
+            ./tests/test-scenarios-github.sh
+
+      - name: Get pod informations
+        if: ${{ failure() }}
+        run: |
+          kubectl get po -n kube-system
+          kubectl describe po -n kube-system
+
+  
+      - name: Archive log artifacts
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: kubearmor.logs
+          path: |
+            /tmp/kubearmor.test
+            /tmp/kubearmor.log
+            /tmp/kubearmor.msg
+      
+      - name: Check Results
+        if: ${{ always() }}
+        run: cat /tmp/kubearmor.test

--- a/KubeArmor/build/kubearmor-test-containerd.yaml
+++ b/KubeArmor/build/kubearmor-test-containerd.yaml
@@ -79,6 +79,7 @@ spec:
         imagePullPolicy: Never
         securityContext:
           privileged: true
+          readOnlyRootFilesystem: true
         ports:
         - containerPort: 32767
         livenessProbe:
@@ -121,10 +122,14 @@ spec:
         - mountPath: /var/lib/docker
           name: docker-storage-path
           readOnly: true
+        - mountPath: /tmp
+          name: tmp-path
       terminationGracePeriodSeconds: 30
       volumes:
       - emptyDir: {}
         name: bpf
+      - emptyDir: {}
+        name: tmp-path
       - hostPath:
           path: /lib/modules
           type: Directory

--- a/KubeArmor/build/kubearmor-test-crio.yaml
+++ b/KubeArmor/build/kubearmor-test-crio.yaml
@@ -57,6 +57,7 @@ spec:
         - containerPort: 32767
         securityContext:
           privileged: true
+          readOnlyRootFilesystem: true
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:
@@ -83,6 +84,8 @@ spec:
         - mountPath: /run/crio
           name: crio-storage-path
           readOnly: true
+        - mountPath: /tmp
+          name: tmp-path
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
       hostPID: true
@@ -130,6 +133,8 @@ spec:
           path: /run/crio
           type: DirectoryOrCreate
         name: crio-storage-path
+      - emptyDir: {}
+        name: tmp-path
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition

--- a/KubeArmor/build/kubearmor-test-docker.yaml
+++ b/KubeArmor/build/kubearmor-test-docker.yaml
@@ -79,6 +79,7 @@ spec:
         imagePullPolicy: Never
         securityContext:
           privileged: true
+          readOnlyRootFilesystem: true
         ports:
         - containerPort: 32767
         livenessProbe:
@@ -118,10 +119,14 @@ spec:
         - mountPath: /var/lib/docker
           name: docker-storage-path
           readOnly: true
+        - mountPath: /tmp
+          name: tmp-path
       terminationGracePeriodSeconds: 30
       volumes:
       - emptyDir: {}
         name: bpf
+      - emptyDir: {}
+        name: tmp-path
       - hostPath:
           path: /lib/modules
           type: Directory

--- a/KubeArmor/build/kubearmor-test-k3s.yaml
+++ b/KubeArmor/build/kubearmor-test-k3s.yaml
@@ -79,6 +79,7 @@ spec:
         imagePullPolicy: Never
         securityContext:
           privileged: true
+          readOnlyRootFilesystem: true
         ports:
         - containerPort: 32767
         livenessProbe:
@@ -118,9 +119,13 @@ spec:
         - mountPath: /var/lib/docker
           name: docker-storage-path
           readOnly: true
+        - mountPath: /tmp
+          name: tmp-path
       volumes:
       - emptyDir: {}
         name: bpf
+      - emptyDir: {}
+        name: tmp-path
       - hostPath:
           path: /lib/modules
           type: Directory

--- a/deployments/AKS/kubearmor.yaml
+++ b/deployments/AKS/kubearmor.yaml
@@ -120,6 +120,8 @@ spec:
         - mountPath: /media/root/etc/os-release
           name: os-release-path
           readOnly: true
+        - mountPath: /tmp
+          name: tmp-path
         - mountPath: /usr/src
           name: usr-src-path
           readOnly: true
@@ -142,6 +144,7 @@ spec:
         name: init
         securityContext:
           privileged: true
+          readOnlyRootFilesystem: true
         volumeMounts:
         - mountPath: /opt/kubearmor/BPF
           name: bpf
@@ -157,6 +160,8 @@ spec:
         - mountPath: /media/root/etc/os-release
           name: os-release-path
           readOnly: true
+        - mountPath: /tmp
+          name: tmp-path
         - mountPath: /usr/src
           name: usr-src-path
           readOnly: true
@@ -170,6 +175,8 @@ spec:
       volumes:
       - emptyDir: {}
         name: bpf
+      - emptyDir: {}
+        name: tmp-path
       - hostPath:
           path: /lib/modules
           type: Directory
@@ -263,6 +270,8 @@ spec:
           requests:
             cpu: 100m
             memory: 20Mi
+        securityContext:
+          readOnlyRootFilesystem: true
       - args:
         - --metrics-addr=127.0.0.1:8080
         - --enable-leader-election
@@ -277,6 +286,8 @@ spec:
           requests:
             cpu: 100m
             memory: 20Mi
+        securityContext:
+          readOnlyRootFilesystem: true
       serviceAccountName: kubearmor
       terminationGracePeriodSeconds: 10
 ---
@@ -332,6 +343,8 @@ spec:
           requests:
             cpu: 100m
             memory: 20Mi
+        securityContext:
+          readOnlyRootFilesystem: true
       - args:
         - --metrics-addr=127.0.0.1:8080
         - --enable-leader-election
@@ -346,6 +359,8 @@ spec:
           requests:
             cpu: 100m
             memory: 20Mi
+        securityContext:
+          readOnlyRootFilesystem: true
       serviceAccountName: kubearmor
       terminationGracePeriodSeconds: 10
 ---

--- a/deployments/BottleRocket/kubearmor.yaml
+++ b/deployments/BottleRocket/kubearmor.yaml
@@ -121,6 +121,8 @@ spec:
         - mountPath: /media/root/etc/os-release
           name: os-release-path
           readOnly: true
+        - mountPath: /tmp
+          name: tmp-path
         - mountPath: /usr/src
           name: usr-src-path
           readOnly: true
@@ -143,6 +145,7 @@ spec:
         name: init
         securityContext:
           privileged: true
+          readOnlyRootFilesystem: true
         volumeMounts:
         - mountPath: /opt/kubearmor/BPF
           name: bpf
@@ -158,6 +161,8 @@ spec:
         - mountPath: /media/root/etc/os-release
           name: os-release-path
           readOnly: true
+        - mountPath: /tmp
+          name: tmp-path
         - mountPath: /usr/src
           name: usr-src-path
           readOnly: true
@@ -171,6 +176,8 @@ spec:
       volumes:
       - emptyDir: {}
         name: bpf
+      - emptyDir: {}
+        name: tmp-path
       - hostPath:
           path: /lib/modules
           type: Directory
@@ -264,6 +271,8 @@ spec:
           requests:
             cpu: 100m
             memory: 20Mi
+        securityContext:
+          readOnlyRootFilesystem: true
       - args:
         - --metrics-addr=127.0.0.1:8080
         - --enable-leader-election
@@ -278,6 +287,8 @@ spec:
           requests:
             cpu: 100m
             memory: 20Mi
+        securityContext:
+          readOnlyRootFilesystem: true
       serviceAccountName: kubearmor
       terminationGracePeriodSeconds: 10
 ---
@@ -333,6 +344,8 @@ spec:
           requests:
             cpu: 100m
             memory: 20Mi
+        securityContext:
+          readOnlyRootFilesystem: true
       - args:
         - --metrics-addr=127.0.0.1:8080
         - --enable-leader-election
@@ -347,6 +360,8 @@ spec:
           requests:
             cpu: 100m
             memory: 20Mi
+        securityContext:
+          readOnlyRootFilesystem: true
       serviceAccountName: kubearmor
       terminationGracePeriodSeconds: 10
 ---

--- a/deployments/EKS/kubearmor.yaml
+++ b/deployments/EKS/kubearmor.yaml
@@ -120,6 +120,8 @@ spec:
         - mountPath: /media/root/etc/os-release
           name: os-release-path
           readOnly: true
+        - mountPath: /tmp
+          name: tmp-path
         - mountPath: /usr/src
           name: usr-src-path
           readOnly: true
@@ -142,6 +144,7 @@ spec:
         name: init
         securityContext:
           privileged: true
+          readOnlyRootFilesystem: true
         volumeMounts:
         - mountPath: /opt/kubearmor/BPF
           name: bpf
@@ -157,6 +160,8 @@ spec:
         - mountPath: /media/root/etc/os-release
           name: os-release-path
           readOnly: true
+        - mountPath: /tmp
+          name: tmp-path
         - mountPath: /usr/src
           name: usr-src-path
           readOnly: true
@@ -170,6 +175,8 @@ spec:
       volumes:
       - emptyDir: {}
         name: bpf
+      - emptyDir: {}
+        name: tmp-path
       - hostPath:
           path: /lib/modules
           type: Directory
@@ -263,6 +270,8 @@ spec:
           requests:
             cpu: 100m
             memory: 20Mi
+        securityContext:
+          readOnlyRootFilesystem: true
       - args:
         - --metrics-addr=127.0.0.1:8080
         - --enable-leader-election
@@ -277,6 +286,8 @@ spec:
           requests:
             cpu: 100m
             memory: 20Mi
+        securityContext:
+          readOnlyRootFilesystem: true
       serviceAccountName: kubearmor
       terminationGracePeriodSeconds: 10
 ---
@@ -332,6 +343,8 @@ spec:
           requests:
             cpu: 100m
             memory: 20Mi
+        securityContext:
+          readOnlyRootFilesystem: true
       - args:
         - --metrics-addr=127.0.0.1:8080
         - --enable-leader-election
@@ -346,6 +359,8 @@ spec:
           requests:
             cpu: 100m
             memory: 20Mi
+        securityContext:
+          readOnlyRootFilesystem: true
       serviceAccountName: kubearmor
       terminationGracePeriodSeconds: 10
 ---

--- a/deployments/GKE/kubearmor.yaml
+++ b/deployments/GKE/kubearmor.yaml
@@ -120,6 +120,8 @@ spec:
         - mountPath: /media/root/etc/os-release
           name: os-release-path
           readOnly: true
+        - mountPath: /tmp
+          name: tmp-path
         - mountPath: /media/root/usr
           name: usr-src-path
           readOnly: true
@@ -142,6 +144,7 @@ spec:
         name: init
         securityContext:
           privileged: true
+          readOnlyRootFilesystem: true
         volumeMounts:
         - mountPath: /opt/kubearmor/BPF
           name: bpf
@@ -157,6 +160,8 @@ spec:
         - mountPath: /media/root/etc/os-release
           name: os-release-path
           readOnly: true
+        - mountPath: /tmp
+          name: tmp-path
         - mountPath: /media/root/usr
           name: usr-src-path
           readOnly: true
@@ -170,6 +175,8 @@ spec:
       volumes:
       - emptyDir: {}
         name: bpf
+      - emptyDir: {}
+        name: tmp-path
       - hostPath:
           path: /lib/modules
           type: Directory
@@ -263,6 +270,8 @@ spec:
           requests:
             cpu: 100m
             memory: 20Mi
+        securityContext:
+          readOnlyRootFilesystem: true
       - args:
         - --metrics-addr=127.0.0.1:8080
         - --enable-leader-election
@@ -277,6 +286,8 @@ spec:
           requests:
             cpu: 100m
             memory: 20Mi
+        securityContext:
+          readOnlyRootFilesystem: true
       serviceAccountName: kubearmor
       terminationGracePeriodSeconds: 10
 ---
@@ -332,6 +343,8 @@ spec:
           requests:
             cpu: 100m
             memory: 20Mi
+        securityContext:
+          readOnlyRootFilesystem: true
       - args:
         - --metrics-addr=127.0.0.1:8080
         - --enable-leader-election
@@ -346,6 +359,8 @@ spec:
           requests:
             cpu: 100m
             memory: 20Mi
+        securityContext:
+          readOnlyRootFilesystem: true
       serviceAccountName: kubearmor
       terminationGracePeriodSeconds: 10
 ---

--- a/deployments/OKE/kubearmor.yaml
+++ b/deployments/OKE/kubearmor.yaml
@@ -120,6 +120,8 @@ spec:
         - mountPath: /media/root/etc/os-release
           name: os-release-path
           readOnly: true
+        - mountPath: /tmp
+          name: tmp-path
         - mountPath: /usr/src
           name: usr-src-path
           readOnly: true
@@ -139,6 +141,7 @@ spec:
         name: init
         securityContext:
           privileged: true
+          readOnlyRootFilesystem: true
         volumeMounts:
         - mountPath: /opt/kubearmor/BPF
           name: bpf
@@ -154,6 +157,8 @@ spec:
         - mountPath: /media/root/etc/os-release
           name: os-release-path
           readOnly: true
+        - mountPath: /tmp
+          name: tmp-path
         - mountPath: /usr/src
           name: usr-src-path
           readOnly: true
@@ -167,6 +172,8 @@ spec:
       volumes:
       - emptyDir: {}
         name: bpf
+      - emptyDir: {}
+        name: tmp-path
       - hostPath:
           path: /lib/modules
           type: Directory
@@ -256,6 +263,8 @@ spec:
           requests:
             cpu: 100m
             memory: 20Mi
+        securityContext:
+          readOnlyRootFilesystem: true
       - args:
         - --metrics-addr=127.0.0.1:8080
         - --enable-leader-election
@@ -270,6 +279,8 @@ spec:
           requests:
             cpu: 100m
             memory: 20Mi
+        securityContext:
+          readOnlyRootFilesystem: true
       serviceAccountName: kubearmor
       terminationGracePeriodSeconds: 10
 ---
@@ -325,6 +336,8 @@ spec:
           requests:
             cpu: 100m
             memory: 20Mi
+        securityContext:
+          readOnlyRootFilesystem: true
       - args:
         - --metrics-addr=127.0.0.1:8080
         - --enable-leader-election
@@ -339,6 +352,8 @@ spec:
           requests:
             cpu: 100m
             memory: 20Mi
+        securityContext:
+          readOnlyRootFilesystem: true
       serviceAccountName: kubearmor
       terminationGracePeriodSeconds: 10
 ---

--- a/deployments/docker/kubearmor.yaml
+++ b/deployments/docker/kubearmor.yaml
@@ -120,6 +120,8 @@ spec:
         - mountPath: /media/root/etc/os-release
           name: os-release-path
           readOnly: true
+        - mountPath: /tmp
+          name: tmp-path
         - mountPath: /usr/src
           name: usr-src-path
           readOnly: true
@@ -139,6 +141,7 @@ spec:
         name: init
         securityContext:
           privileged: true
+          readOnlyRootFilesystem: true
         volumeMounts:
         - mountPath: /opt/kubearmor/BPF
           name: bpf
@@ -154,6 +157,8 @@ spec:
         - mountPath: /media/root/etc/os-release
           name: os-release-path
           readOnly: true
+        - mountPath: /tmp
+          name: tmp-path
         - mountPath: /usr/src
           name: usr-src-path
           readOnly: true
@@ -167,6 +172,8 @@ spec:
       volumes:
       - emptyDir: {}
         name: bpf
+      - emptyDir: {}
+        name: tmp-path
       - hostPath:
           path: /lib/modules
           type: Directory
@@ -256,6 +263,8 @@ spec:
           requests:
             cpu: 100m
             memory: 20Mi
+        securityContext:
+          readOnlyRootFilesystem: true
       - args:
         - --metrics-addr=127.0.0.1:8080
         - --enable-leader-election
@@ -270,6 +279,8 @@ spec:
           requests:
             cpu: 100m
             memory: 20Mi
+        securityContext:
+          readOnlyRootFilesystem: true
       serviceAccountName: kubearmor
       terminationGracePeriodSeconds: 10
 ---
@@ -325,6 +336,8 @@ spec:
           requests:
             cpu: 100m
             memory: 20Mi
+        securityContext:
+          readOnlyRootFilesystem: true
       - args:
         - --metrics-addr=127.0.0.1:8080
         - --enable-leader-election
@@ -339,6 +352,8 @@ spec:
           requests:
             cpu: 100m
             memory: 20Mi
+        securityContext:
+          readOnlyRootFilesystem: true
       serviceAccountName: kubearmor
       terminationGracePeriodSeconds: 10
 ---

--- a/deployments/generic/kubearmor.yaml
+++ b/deployments/generic/kubearmor.yaml
@@ -120,9 +120,8 @@ spec:
         - mountPath: /media/root/etc/os-release
           name: os-release-path
           readOnly: true
-        - mountPath: /usr/src
-          name: usr-src-path
-          readOnly: true
+        - mountPath: /tmp
+          name: tmp-path
         - mountPath: /usr/src
           name: usr-src-path
           readOnly: true
@@ -145,6 +144,7 @@ spec:
         name: init
         securityContext:
           privileged: true
+          readOnlyRootFilesystem: true
         volumeMounts:
         - mountPath: /opt/kubearmor/BPF
           name: bpf
@@ -160,6 +160,8 @@ spec:
         - mountPath: /media/root/etc/os-release
           name: os-release-path
           readOnly: true
+        - mountPath: /tmp
+          name: tmp-path
         - mountPath: /usr/src
           name: usr-src-path
           readOnly: true
@@ -173,6 +175,8 @@ spec:
       volumes:
       - emptyDir: {}
         name: bpf
+      - emptyDir: {}
+        name: tmp-path
       - hostPath:
           path: /lib/modules
           type: Directory
@@ -266,6 +270,8 @@ spec:
           requests:
             cpu: 100m
             memory: 20Mi
+        securityContext:
+          readOnlyRootFilesystem: true
       - args:
         - --metrics-addr=127.0.0.1:8080
         - --enable-leader-election
@@ -280,6 +286,8 @@ spec:
           requests:
             cpu: 100m
             memory: 20Mi
+        securityContext:
+          readOnlyRootFilesystem: true
       serviceAccountName: kubearmor
       terminationGracePeriodSeconds: 10
 ---
@@ -335,6 +343,8 @@ spec:
           requests:
             cpu: 100m
             memory: 20Mi
+        securityContext:
+          readOnlyRootFilesystem: true
       - args:
         - --metrics-addr=127.0.0.1:8080
         - --enable-leader-election
@@ -349,6 +359,8 @@ spec:
           requests:
             cpu: 100m
             memory: 20Mi
+        securityContext:
+          readOnlyRootFilesystem: true
       serviceAccountName: kubearmor
       terminationGracePeriodSeconds: 10
 ---

--- a/deployments/get/defaults.go
+++ b/deployments/get/defaults.go
@@ -104,7 +104,6 @@ var defaultConfigs = map[string]DaemonSetConfig{
 		},
 		Envs: envVar,
 		VolumeMounts: []corev1.VolumeMount{
-			hostUsrVolMnt,
 			apparmorVolMnt,
 			{
 				Name:      "containerd-sock-path", // containerd

--- a/deployments/k3s/kubearmor.yaml
+++ b/deployments/k3s/kubearmor.yaml
@@ -120,6 +120,8 @@ spec:
         - mountPath: /media/root/etc/os-release
           name: os-release-path
           readOnly: true
+        - mountPath: /tmp
+          name: tmp-path
         - mountPath: /usr/src
           name: usr-src-path
           readOnly: true
@@ -139,6 +141,7 @@ spec:
         name: init
         securityContext:
           privileged: true
+          readOnlyRootFilesystem: true
         volumeMounts:
         - mountPath: /opt/kubearmor/BPF
           name: bpf
@@ -154,6 +157,8 @@ spec:
         - mountPath: /media/root/etc/os-release
           name: os-release-path
           readOnly: true
+        - mountPath: /tmp
+          name: tmp-path
         - mountPath: /usr/src
           name: usr-src-path
           readOnly: true
@@ -167,6 +172,8 @@ spec:
       volumes:
       - emptyDir: {}
         name: bpf
+      - emptyDir: {}
+        name: tmp-path
       - hostPath:
           path: /lib/modules
           type: Directory
@@ -256,6 +263,8 @@ spec:
           requests:
             cpu: 100m
             memory: 20Mi
+        securityContext:
+          readOnlyRootFilesystem: true
       - args:
         - --metrics-addr=127.0.0.1:8080
         - --enable-leader-election
@@ -270,6 +279,8 @@ spec:
           requests:
             cpu: 100m
             memory: 20Mi
+        securityContext:
+          readOnlyRootFilesystem: true
       serviceAccountName: kubearmor
       terminationGracePeriodSeconds: 10
 ---
@@ -325,6 +336,8 @@ spec:
           requests:
             cpu: 100m
             memory: 20Mi
+        securityContext:
+          readOnlyRootFilesystem: true
       - args:
         - --metrics-addr=127.0.0.1:8080
         - --enable-leader-election
@@ -339,6 +352,8 @@ spec:
           requests:
             cpu: 100m
             memory: 20Mi
+        securityContext:
+          readOnlyRootFilesystem: true
       serviceAccountName: kubearmor
       terminationGracePeriodSeconds: 10
 ---

--- a/deployments/microk8s/kubearmor.yaml
+++ b/deployments/microk8s/kubearmor.yaml
@@ -120,6 +120,8 @@ spec:
         - mountPath: /media/root/etc/os-release
           name: os-release-path
           readOnly: true
+        - mountPath: /tmp
+          name: tmp-path
         - mountPath: /usr/src
           name: usr-src-path
           readOnly: true
@@ -139,6 +141,7 @@ spec:
         name: init
         securityContext:
           privileged: true
+          readOnlyRootFilesystem: true
         volumeMounts:
         - mountPath: /opt/kubearmor/BPF
           name: bpf
@@ -154,6 +157,8 @@ spec:
         - mountPath: /media/root/etc/os-release
           name: os-release-path
           readOnly: true
+        - mountPath: /tmp
+          name: tmp-path
         - mountPath: /usr/src
           name: usr-src-path
           readOnly: true
@@ -167,6 +172,8 @@ spec:
       volumes:
       - emptyDir: {}
         name: bpf
+      - emptyDir: {}
+        name: tmp-path
       - hostPath:
           path: /lib/modules
           type: Directory
@@ -256,6 +263,8 @@ spec:
           requests:
             cpu: 100m
             memory: 20Mi
+        securityContext:
+          readOnlyRootFilesystem: true
       - args:
         - --metrics-addr=127.0.0.1:8080
         - --enable-leader-election
@@ -270,6 +279,8 @@ spec:
           requests:
             cpu: 100m
             memory: 20Mi
+        securityContext:
+          readOnlyRootFilesystem: true
       serviceAccountName: kubearmor
       terminationGracePeriodSeconds: 10
 ---
@@ -325,6 +336,8 @@ spec:
           requests:
             cpu: 100m
             memory: 20Mi
+        securityContext:
+          readOnlyRootFilesystem: true
       - args:
         - --metrics-addr=127.0.0.1:8080
         - --enable-leader-election
@@ -339,6 +352,8 @@ spec:
           requests:
             cpu: 100m
             memory: 20Mi
+        securityContext:
+          readOnlyRootFilesystem: true
       serviceAccountName: kubearmor
       terminationGracePeriodSeconds: 10
 ---

--- a/deployments/minikube/kubearmor.yaml
+++ b/deployments/minikube/kubearmor.yaml
@@ -119,6 +119,8 @@ spec:
         - mountPath: /media/root/etc/os-release
           name: os-release-path
           readOnly: true
+        - mountPath: /tmp
+          name: tmp-path
         - mountPath: /usr/src
           name: usr-src-path
           readOnly: true
@@ -138,6 +140,7 @@ spec:
         name: init
         securityContext:
           privileged: true
+          readOnlyRootFilesystem: true
         volumeMounts:
         - mountPath: /opt/kubearmor/BPF
           name: bpf
@@ -153,6 +156,8 @@ spec:
         - mountPath: /media/root/etc/os-release
           name: os-release-path
           readOnly: true
+        - mountPath: /tmp
+          name: tmp-path
         - mountPath: /usr/src
           name: usr-src-path
           readOnly: true
@@ -166,6 +171,8 @@ spec:
       volumes:
       - emptyDir: {}
         name: bpf
+      - emptyDir: {}
+        name: tmp-path
       - hostPath:
           path: /lib/modules
           type: Directory
@@ -255,6 +262,8 @@ spec:
           requests:
             cpu: 100m
             memory: 20Mi
+        securityContext:
+          readOnlyRootFilesystem: true
       - args:
         - --metrics-addr=127.0.0.1:8080
         - --enable-leader-election
@@ -269,6 +278,8 @@ spec:
           requests:
             cpu: 100m
             memory: 20Mi
+        securityContext:
+          readOnlyRootFilesystem: true
       serviceAccountName: kubearmor
       terminationGracePeriodSeconds: 10
 ---
@@ -324,6 +335,8 @@ spec:
           requests:
             cpu: 100m
             memory: 20Mi
+        securityContext:
+          readOnlyRootFilesystem: true
       - args:
         - --metrics-addr=127.0.0.1:8080
         - --enable-leader-election
@@ -338,6 +351,8 @@ spec:
           requests:
             cpu: 100m
             memory: 20Mi
+        securityContext:
+          readOnlyRootFilesystem: true
       serviceAccountName: kubearmor
       terminationGracePeriodSeconds: 10
 ---


### PR DESCRIPTION
## What does this PR do: 
- fixes synk vuln SNYK-CC-K8S-8 (enable readonly file system) mentioned here #733 point 11
- Impliments new ci tests inside a kubernetes cluster
- updates ci to include cmctl to avoid random ci cashe due to delayed cert manager CA cert injection

## Why the new in cluster tests:
already existant tests test kubearmor functionalities but not its related yaml files. In order for us to properly determine that our hardening actions wont impact kubearmor inside kubernetes environment we need to run tests in kubernetes cluster rather than as binary at the host level.

Signed-off-by: Achref ben saad <achref9612@gmail.com>