### PR TITLE
get pid_ns of a process from the pids[PIDTYPE_PID] instead of nsproxy

### DIFF
--- a/KubeArmor/BPF/system_monitor.c
+++ b/KubeArmor/BPF/system_monitor.c
@@ -136,7 +136,15 @@ BPF_PERF_OUTPUT(sys_events);
 
 static __always_inline u32 get_task_pid_ns_id(struct task_struct *task)
 {
-    return task->nsproxy->pid_ns_for_children->ns.inum;
+    struct pid *pid = NULL;
+
+    #if (LINUX_VERSION_CODE < KERNEL_VERSION(4, 19, 0) && !defined(RHEL_RELEASE_GT_8_0))
+    pid = task->pids[PIDTYPE_PID].pid;
+    #else
+    pid = task->thread_pid;
+    #endif
+
+    return pid->numbers[pid->level].ns.inum;
 }
 
 struct mnt_namespace {


### PR DESCRIPTION
the code use `task->nsproxy` to get the pid_ns of a process, but it's not process's real pid_namespace 
```
static __always_inline u32 get_task_pid_ns_id(struct task_struct *task)
{
    return task->nsproxy->pid_ns_for_children->ns.inum;
}
```
just as [man pid_namespace](https://man7.org/linux/man-pages/man7/pid_namespaces.7.html) described:
`task->nsproxy->pid_ns_for_children` is a ns which the children of the process will be in

> Calls to [setns(2)](https://man7.org/linux/man-pages/man2/setns.2.html) that specify a PID namespace file descriptor
       and calls to [unshare(2)](https://man7.org/linux/man-pages/man2/unshare.2.html) with the CLONE_NEWPID flag cause children
       subsequently created by the caller to be placed in a different
       PID namespace from the caller.  (Since Linux 4.12, that PID
       namespace is shown via the /proc/[pid]/ns/pid_for_children file,
       as described in [namespaces(7)](https://man7.org/linux/man-pages/man7/namespaces.7.html).)  These calls do not, however,
       change the PID namespace of the calling process

because pid_ns can be nested, so the implementation is as follows:

```
static __always_inline u32 get_task_pid_ns_id(struct task_struct *task)
{
    unsigned int level = task->pids[PIDTYPE_PID].pid->level;
    return task->pids[PIDTYPE_PID].pid->numbers[level].ns.inum;
}
```