### PR TITLE
fix get ns pid/tgid of process

### DIFF
--- a/KubeArmor/BPF/system_monitor.c
+++ b/KubeArmor/BPF/system_monitor.c
@@ -223,48 +223,35 @@ static __always_inline u32 get_task_mnt_ns_id(struct task_struct *task)
     return get_mnt_ns_id(READ_KERN(task->nsproxy));
 }
 
-static __always_inline u32 get_task_ns_ppid(struct task_struct *task)
+static __always_inline u32 get_task_pid_vnr(struct task_struct *task)
 {
-    struct task_struct *real_parent = READ_KERN(task->real_parent);
-    struct nsproxy *namespaceproxy = READ_KERN(real_parent->nsproxy);
-    struct pid_namespace *pid_ns_children = READ_KERN(namespaceproxy->pid_ns_for_children);
-    unsigned int level = READ_KERN(pid_ns_children->level);
+    struct pid *pid = NULL;
 
-#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 19, 0) && !defined(RHEL_RELEASE_GT_8_0)
-    struct pid *tpid = READ_KERN(real_parent->pids[PIDTYPE_PID].pid);
-#else
-    struct pid *tpid = READ_KERN(real_parent->thread_pid);
-#endif
-    return READ_KERN(tpid->numbers[level].nr);
+    #if (LINUX_VERSION_CODE < KERNEL_VERSION(4, 19, 0) && !defined(RHEL_RELEASE_GT_8_0))
+    pid = READ_KERN(task->pids[PIDTYPE_PID].pid);
+    #else
+    pid = READ_KERN(task->thread_pid);
+    #endif
+
+    unsigned int level = READ_KERN(pid->level);
+    return READ_KERN(pid->numbers[level].nr);
 }
 
 static __always_inline u32 get_task_ns_tgid(struct task_struct *task)
 {
-    struct nsproxy *namespaceproxy = READ_KERN(task->nsproxy);
-    struct pid_namespace *pid_ns_children = READ_KERN(namespaceproxy->pid_ns_for_children);
-    unsigned int level = READ_KERN(pid_ns_children->level);
     struct task_struct *group_leader = READ_KERN(task->group_leader);
-
-#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 19, 0) && !defined(RHEL_RELEASE_GT_8_0)
-    struct pid *tpid = READ_KERN(group_leader->pids[PIDTYPE_PID].pid);
-#else
-    struct pid *tpid = READ_KERN(group_leader->thread_pid);
-#endif
-    return READ_KERN(tpid->numbers[level].nr);
+    return get_task_pid_vnr(group_leader);
 }
 
 static __always_inline u32 get_task_ns_pid(struct task_struct *task)
 {
-    struct nsproxy *namespaceproxy = READ_KERN(task->nsproxy);
-    struct pid_namespace *pid_ns_children = READ_KERN(namespaceproxy->pid_ns_for_children);
-    unsigned int level = READ_KERN(pid_ns_children->level);
+    return get_task_pid_vnr(task);
+}
 
-#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 19, 0) && !defined(RHEL_RELEASE_GT_8_0)
-    struct pid *tpid = READ_KERN(task->pids[PIDTYPE_PID].pid);
-#else
-    struct pid *tpid = READ_KERN(task->thread_pid);
-#endif
-    return READ_KERN(tpid->numbers[level].nr);
+static __always_inline u32 get_task_ns_ppid(struct task_struct *task)
+{
+    struct task_struct *real_parent = READ_KERN(task->real_parent);
+    return get_task_pid_vnr(real_parent);
 }
 
 static __always_inline u32 get_task_ppid(struct task_struct *task)


### PR DESCRIPTION
the problem is task->nsproxy can't show the real ns pid/tgid of a namespaced process.

I have a issue to explain this :https://github.com/aquasecurity/tracee/issues/1950#issue-1299924163

the fix is from the relevant PR.