### PR TITLE
hotfix: deprecate docker in CI

### DIFF
--- a/.github/workflows/ci-new-test.yml
+++ b/.github/workflows/ci-new-test.yml
@@ -26,7 +26,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, ubuntu-18.04]
-        runtime: ["docker", "containerd", "crio"]
+        runtime: ["containerd", "crio"]
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/ci-test-runtime.yml
+++ b/.github/workflows/ci-test-runtime.yml
@@ -7,19 +7,21 @@ on:
       - "KubeArmor/**"
       - "tests/**"
       - "protobuf/**"
-      - ".github/workflows/ci-test.yml"
+      - ".github/workflows/ci-test-runtime.yml"
   pull_request:
     branches: [main]
     paths:
       - "KubeArmor/**"
       - "tests/**"
       - "protobuf/**"
-      - ".github/workflows/ci-test.yml"
+      - ".github/workflows/ci-test-runtime.yml"
 
 jobs:
   build:
     name: Auto-testing Framework Runtime
     runs-on: ubuntu-latest
+    env:
+      RUNTIME: "containerd"
     steps:
       - name: Kernel version
         run: uname -r
@@ -46,6 +48,7 @@ jobs:
         run: |
           echo ::set-output name=tag::latest
 
+          echo "RUNTIME="$RUNTIME
           ./contribution/k3s/install_k3s.sh
 
           cd KubeArmor/BPF/
@@ -53,22 +56,28 @@ jobs:
 
       - name: Generate KubeArmor artifacts
         run: |
-            GITHUB_SHA=$GITHUB_SHA ./KubeArmor/build/build_kubearmor.sh ${{ steps.vars.outputs.tag }}
+          echo "TAG="${{ steps.vars.outputs.tag }}
+          GITHUB_SHA=$GITHUB_SHA ./KubeArmor/build/build_kubearmor.sh ${{ steps.vars.outputs.tag }}
+          docker save kubearmor/kubearmor:${{ steps.vars.outputs.tag }} | sudo k3s ctr images import -
+          docker save kubearmor/kubearmor-init:${{ steps.vars.outputs.tag }} | sudo k3s ctr images import -
 
       - name: Run KubeArmor
         run: |
-            kubectl apply -f KubeArmor/build/kubearmor-test-k3s.yaml && kubectl wait --for=condition=ready --timeout=5m -n kube-system pod -l kubearmor-app=kubearmor
-            kubectl get pods -A
+          kubectl apply -f KubeArmor/build/kubearmor-test-k3s.yaml && kubectl wait --for=condition=ready --timeout=5m -n kube-system pod -l kubearmor-app=kubearmor
+          kubectl get pods -A
 
       - name: Test KubeArmor
         run: |
-            ./tests/test-scenarios-github.sh ${{ steps.vars.outputs.tag }}
+          ./tests/test-scenarios-github.sh ${{ steps.vars.outputs.tag }}
 
       - name: Capture KubeArmor logs
         if: ${{ failure() }}
         run: kubectl exec -n kube-system daemonset/kubearmor -- cat /tmp/kubearmor.log > /tmp/kubearmor.log
-            
-      
+
+      - name: Capture KubeArmor Pod Events
+        if: ${{ failure() }}
+        run: kubectl describe pod -n kube-system kubearmor
+
       - name: Archive log artifacts
         if: ${{ failure() }}
         uses: actions/upload-artifact@v2

--- a/.github/workflows/ci-test-systemd.yml
+++ b/.github/workflows/ci-test-systemd.yml
@@ -7,14 +7,14 @@ on:
       - "KubeArmor/**"
       - "tests/**"
       - "protobuf/**"
-      - ".github/workflows/ci-test.yml"
+      - ".github/workflows/ci-test-systemd.yml"
   pull_request:
     branches: [main]
     paths:
       - "KubeArmor/**"
       - "tests/**"
       - "protobuf/**"
-      - ".github/workflows/ci-test.yml"
+      - ".github/workflows/ci-test-systemd.yml"
 
 jobs:
   build:
@@ -26,7 +26,7 @@ jobs:
         os: [ubuntu-latest, ubuntu-18.04]
     steps:
       - name: Kernel version
-        run: uname -r
+        run: uname -a
 
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -26,7 +26,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, ubuntu-18.04]
-        runtime: ["docker", "containerd", "crio"]
+        runtime: ["containerd", "crio"]
     steps:
       - name: Kernel version
         run: uname -r

--- a/.github/workflows/latest-release.yml
+++ b/.github/workflows/latest-release.yml
@@ -21,6 +21,8 @@ jobs:
     name: Create KubeArmor latest release - 18.04
     if: github.repository == 'kubearmor/kubearmor'
     runs-on: ubuntu-18.04
+    env:
+      RUNTIME: "containerd"
     timeout-minutes: 20
     steps:
       - name: Checkout KubeArmor code
@@ -34,6 +36,7 @@ jobs:
           else
             echo ::set-output name=tag::${GITHUB_REF#refs/*/}
           fi
+          echo "RUNTIME="$RUNTIME
           ./contribution/k3s/install_k3s.sh
 
       - name: Install cmctl
@@ -53,6 +56,8 @@ jobs:
       - name: Generate KubeArmor artifacts
         run: |
             GITHUB_SHA=$GITHUB_SHA ./KubeArmor/build/build_kubearmor.sh ${{ steps.vars.outputs.tag }}
+            echo "TAG="${{ steps.vars.outputs.tag }}
+            docker save kubearmor/kubearmor:${{ steps.vars.outputs.tag }} | sudo k3s ctr images import -
 
       - name: Run KubeArmor
         run: |

--- a/KubeArmor/build/kubearmor-test-k3s.yaml
+++ b/KubeArmor/build/kubearmor-test-k3s.yaml
@@ -112,11 +112,11 @@ spec:
           readOnly: true
         - mountPath: /etc/apparmor.d
           name: etc-apparmor-d-path
-        - mountPath: /var/run/docker.sock
-          name: docker-sock-path
+        - mountPath: /var/run/containerd/containerd.sock
+          name: containerd-sock-path
           readOnly: true
-        - mountPath: /var/lib/docker
-          name: docker-storage-path
+        - mountPath: /run/containerd
+          name: containerd-storage-path
           readOnly: true
       volumes:
       - emptyDir: {}
@@ -150,13 +150,13 @@ spec:
           type: DirectoryOrCreate
         name: etc-apparmor-d-path
       - hostPath:
-          path: /var/run/docker.sock
+          path: /run/k3s/containerd/containerd.sock
           type: Socket
-        name: docker-sock-path
+        name: containerd-sock-path
       - hostPath:
-          path: /var/lib/docker
+          path: /run/k3s/containerd
           type: DirectoryOrCreate
-        name: docker-storage-path
+        name: containerd-storage-path
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition


### PR DESCRIPTION
Recent updates to k3s and k8s where dockershim was deprecated has caused a broken CI. Removing docker from the CI workflows till we have full analysis and proper fix.