### PR TITLE
Refactor Apparmor Profile generation

### DIFF
--- a/KubeArmor/enforcer/appArmorEnforcer.go
+++ b/KubeArmor/enforcer/appArmorEnforcer.go
@@ -489,6 +489,8 @@ func (ae *AppArmorEnforcer) UpdateAppArmorProfile(endPoint tp.EndPoint, appArmor
 		}
 
 		ae.Logger.Printf("Updated %d security rule(s) to %s/%s/%s", policyCount, endPoint.NamespaceName, endPoint.EndPointName, appArmorProfile)
+	} else if newProfile != "" {
+		ae.Logger.Errf("Error Generating %s AppArmor profile: %s", appArmorProfile, newProfile)
 	}
 }
 

--- a/KubeArmor/enforcer/appArmorProfile.go
+++ b/KubeArmor/enforcer/appArmorProfile.go
@@ -5,307 +5,237 @@ package enforcer
 
 import (
 	"bufio"
-	"fmt"
-	"io/ioutil"
+	"bytes"
 	"os"
 	"path/filepath"
 	"strings"
+	"text/template"
 
-	kl "github.com/kubearmor/KubeArmor/KubeArmor/common"
 	tp "github.com/kubearmor/KubeArmor/KubeArmor/types"
 )
 
 // == //
 
 // ResolvedProcessWhiteListConflicts Function
-func (ae *AppArmorEnforcer) ResolvedProcessWhiteListConflicts(processWhiteList *[]string, fromSources map[string][]string, fusionProcessWhiteList *[]string) {
-	prunedProcessWhiteList := make([]string, len(*processWhiteList))
-	copy(prunedProcessWhiteList, *processWhiteList)
-
-	for source := range fromSources {
-		for _, line := range *processWhiteList {
-			if source == strings.Split(strings.TrimSpace(line), " ")[0] {
-				if !kl.ContainsElement(*fusionProcessWhiteList, source) {
-					*fusionProcessWhiteList = append(*fusionProcessWhiteList, source)
-
-					for idx, line := range prunedProcessWhiteList {
-						if source == strings.Split(strings.TrimSpace(line), " ")[0] {
-							prunedProcessWhiteList = append(prunedProcessWhiteList[:idx], prunedProcessWhiteList[idx+1:]...)
-							break
-						}
-					}
-				}
-			}
+func (ae *AppArmorEnforcer) ResolvedProcessWhiteListConflicts(prof *Profile) {
+	for source, val := range prof.FromSource {
+		if _, ok := prof.ProcessPaths[source]; ok {
+			val.Fusion = true
+			prof.FromSource[source] = val
+			delete(prof.ProcessPaths, source)
 		}
 	}
-
-	*processWhiteList = prunedProcessWhiteList
 }
 
-// AllowedProcessMatchPaths Function
-func (ae *AppArmorEnforcer) AllowedProcessMatchPaths(path tp.ProcessPathType, processWhiteList *[]string, fromSources map[string][]string) {
+// SetProcessMatchPaths Function
+func (ae *AppArmorEnforcer) SetProcessMatchPaths(path tp.ProcessPathType, prof *Profile, deny bool) {
+	if deny == false {
+		prof.File = false
+	}
+	rule := RuleConfig{}
+	rule.Deny = deny
+	rule.OwnerOnly = path.OwnerOnly
+
 	if len(path.FromSource) == 0 {
-		line := ""
-
-		if path.OwnerOnly {
-			line = fmt.Sprintf("  owner %s ix,\n", path.Path)
-		} else { // !path.OwnerOnly
-			line = fmt.Sprintf("  %s ix,\n", path.Path)
-		}
-
-		if !kl.ContainsElement(*processWhiteList, line) {
-			*processWhiteList = append(*processWhiteList, line)
+		if _, ok := prof.ProcessPaths[path.Path]; !ok {
+			prof.ProcessPaths[path.Path] = rule
 		}
 
 		return
 	}
 
 	for _, src := range path.FromSource {
-		line := ""
-
 		if len(src.Path) == 0 {
 			continue
 		}
 
 		source := src.Path
-		if _, ok := fromSources[source]; !ok {
-			fromSources[source] = []string{}
+		if _, ok := prof.FromSource[source]; !ok {
+			var fromsource FromSourceConfig
+			fromsource.ProfileHeader.Init()
+			fromsource.Rules.Init()
+			prof.FromSource[source] = fromsource
 		}
-
-		if path.OwnerOnly {
-			line = fmt.Sprintf("  owner %s ix,\n", path.Path)
-		} else { // !path.OwnerOnly
-			line = fmt.Sprintf("  %s ix,\n", path.Path)
+		if deny == false {
+			if val, ok := prof.FromSource[source]; ok {
+				val.File = false
+				prof.FromSource[source] = val
+			}
 		}
-
-		if !kl.ContainsElement(fromSources[source], line) {
-			fromSources[source] = append(fromSources[source], line)
+		if _, ok := prof.FromSource[source].ProcessPaths[path.Path]; !ok {
+			prof.ProcessPaths[path.Path] = rule
 		}
 	}
 }
 
-// AllowedProcessMatchDirectories Function
-func (ae *AppArmorEnforcer) AllowedProcessMatchDirectories(dir tp.ProcessDirectoryType, processWhiteList *[]string, fromSources map[string][]string) {
+// SetProcessMatchDirectories Function
+func (ae *AppArmorEnforcer) SetProcessMatchDirectories(dir tp.ProcessDirectoryType, prof *Profile, deny bool) {
+	if deny == false {
+		prof.File = false
+	}
+	rule := RuleConfig{}
+	rule.Deny = deny
+	rule.Dir = true
+	rule.Recursive = dir.Recursive
+	rule.OwnerOnly = dir.OwnerOnly
+
 	if len(dir.FromSource) == 0 {
-		line := ""
-
-		if dir.Recursive && dir.OwnerOnly {
-			line = fmt.Sprintf("  owner %s{*,**} ix,\n", dir.Directory)
-		} else if dir.Recursive && !dir.OwnerOnly {
-			line = fmt.Sprintf("  %s{*,**} ix,\n", dir.Directory)
-		} else if !dir.Recursive && dir.OwnerOnly {
-			line = fmt.Sprintf("  owner %s* ix,\n", dir.Directory)
-		} else { // !dir.Recursive && !dir.OwnerOnly
-			line = fmt.Sprintf("  %s* ix,\n", dir.Directory)
-		}
-
-		if !kl.ContainsElement(*processWhiteList, line) {
-			*processWhiteList = append(*processWhiteList, line)
+		if _, ok := prof.ProcessPaths[dir.Directory]; !ok {
+			prof.ProcessPaths[dir.Directory] = rule
 		}
 
 		return
 	}
 
 	for _, src := range dir.FromSource {
-		line := ""
-
 		if len(src.Path) == 0 {
 			continue
 		}
 
 		source := src.Path
-		if _, ok := fromSources[source]; !ok {
-			fromSources[source] = []string{}
+		if _, ok := prof.FromSource[source]; !ok {
+			var fromsource FromSourceConfig
+			fromsource.ProfileHeader.Init()
+			fromsource.Rules.Init()
+			prof.FromSource[source] = fromsource
 		}
-
-		if dir.Recursive && dir.OwnerOnly {
-			line = fmt.Sprintf("  owner %s{*,**} ix,\n", dir.Directory)
-		} else if dir.Recursive && !dir.OwnerOnly {
-			line = fmt.Sprintf("  %s{*,**} ix,\n", dir.Directory)
-		} else if !dir.Recursive && dir.OwnerOnly {
-			line = fmt.Sprintf("  owner %s* ix,\n", dir.Directory)
-		} else { // !dir.Recursive && !dir.OwnerOnly
-			line = fmt.Sprintf("  %s* ix,\n", dir.Directory)
+		if deny == false {
+			if val, ok := prof.FromSource[source]; ok {
+				val.File = false
+				prof.FromSource[source] = val
+			}
 		}
-
-		if !kl.ContainsElement(fromSources[source], line) {
-			fromSources[source] = append(fromSources[source], line)
+		if _, ok := prof.FromSource[source].ProcessPaths[dir.Directory]; !ok {
+			prof.FromSource[source].ProcessPaths[dir.Directory] = rule
 		}
 	}
 }
 
-// AllowedProcessMatchPatterns Function
-func (ae *AppArmorEnforcer) AllowedProcessMatchPatterns(pat tp.ProcessPatternType, processWhiteList *[]string) {
-	line := ""
-
-	if pat.OwnerOnly {
-		line = fmt.Sprintf("  owner %s ix,\n", pat.Pattern)
-	} else { // !pat.OwnerOnly
-		line = fmt.Sprintf("  %s* ix,\n", pat.Pattern)
+// SetProcessMatchPatterns Function
+func (ae *AppArmorEnforcer) SetProcessMatchPatterns(pat tp.ProcessPatternType, prof *Profile, deny bool) {
+	if deny == false {
+		prof.File = false
 	}
+	rule := RuleConfig{}
+	rule.Deny = deny
+	rule.OwnerOnly = pat.OwnerOnly
 
-	if !kl.ContainsElement(*processWhiteList, line) {
-		*processWhiteList = append(*processWhiteList, line)
+	if _, ok := prof.ProcessPaths[pat.Pattern]; !ok {
+		prof.ProcessPaths[pat.Pattern] = rule
 	}
 }
 
-// AllowedFileMatchPaths Function
-func (ae *AppArmorEnforcer) AllowedFileMatchPaths(path tp.FilePathType, fileWhiteList *[]string, fromSources map[string][]string) {
+// SetFileMatchPaths Function
+func (ae *AppArmorEnforcer) SetFileMatchPaths(path tp.FilePathType, prof *Profile, deny bool) {
+	if deny == false {
+		prof.File = false
+	}
+	rule := RuleConfig{}
+	rule.Deny = deny
+	rule.OwnerOnly = path.OwnerOnly
+	rule.ReadOnly = path.ReadOnly
+
 	if len(path.FromSource) == 0 {
-		line := ""
-
-		if path.ReadOnly && path.OwnerOnly {
-			line = fmt.Sprintf("  owner %s r,\n", path.Path)
-		} else if path.ReadOnly && !path.OwnerOnly {
-			line = fmt.Sprintf("  %s r,\n", path.Path)
-		} else if !path.ReadOnly && path.OwnerOnly {
-			line = fmt.Sprintf("  owner %s rw,\n", path.Path)
-		} else { // !path.ReadOnly && !path.OwnerOnly
-			line = fmt.Sprintf("  %s rw,\n", path.Path)
-		}
-
-		if !kl.ContainsElement(*fileWhiteList, line) {
-			*fileWhiteList = append(*fileWhiteList, line)
+		if _, ok := prof.FilePaths[path.Path]; !ok {
+			prof.FilePaths[path.Path] = rule
 		}
 
 		return
 	}
 
 	for _, src := range path.FromSource {
-		line := ""
-
 		if len(src.Path) == 0 {
 			continue
 		}
 
 		source := src.Path
-		if _, ok := fromSources[source]; !ok {
-			fromSources[source] = []string{}
+		if _, ok := prof.FromSource[source]; !ok {
+			var fromsource FromSourceConfig
+			fromsource.ProfileHeader.Init()
+			fromsource.Rules.Init()
+			prof.FromSource[source] = fromsource
 		}
-
-		if path.ReadOnly && path.OwnerOnly {
-			line = fmt.Sprintf("  owner %s r,\n", path.Path)
-		} else if path.ReadOnly && !path.OwnerOnly {
-			line = fmt.Sprintf("  %s r,\n", path.Path)
-		} else if !path.ReadOnly && path.OwnerOnly {
-			line = fmt.Sprintf("  owner %s rw,\n", path.Path)
-		} else { // !path.ReadOnly && !path.OwnerOnly
-			line = fmt.Sprintf("  %s rw,\n", path.Path)
+		if deny == false {
+			if val, ok := prof.FromSource[source]; ok {
+				val.File = false
+				prof.FromSource[source] = val
+			}
 		}
-
-		if !kl.ContainsElement(fromSources[source], line) {
-			fromSources[source] = append(fromSources[source], line)
+		if _, ok := prof.FromSource[source].FilePaths[path.Path]; !ok {
+			prof.FromSource[source].FilePaths[path.Path] = rule
 		}
 	}
 }
 
-// AllowedFileMatchDirectories Function
-func (ae *AppArmorEnforcer) AllowedFileMatchDirectories(dir tp.FileDirectoryType, fileWhiteList *[]string, fromSources map[string][]string) {
+// SetFileMatchDirectories Function
+func (ae *AppArmorEnforcer) SetFileMatchDirectories(dir tp.FileDirectoryType, prof *Profile, deny bool) {
+	if deny == false {
+		prof.File = false
+	}
+	rule := RuleConfig{}
+	rule.Deny = deny
+	rule.OwnerOnly = dir.OwnerOnly
+	rule.ReadOnly = dir.ReadOnly
+	rule.Dir = true
+	rule.Recursive = dir.Recursive
+
 	if len(dir.FromSource) == 0 {
-		line := ""
-
-		if dir.ReadOnly && dir.OwnerOnly {
-			if dir.Recursive {
-				line = fmt.Sprintf("  owner %s{*,**} r,\n", dir.Directory)
-			} else {
-				line = fmt.Sprintf("  owner %s* r,\n", dir.Directory)
-			}
-		} else if dir.ReadOnly && !dir.OwnerOnly {
-			if dir.Recursive {
-				line = fmt.Sprintf("  %s{*,**} r,\n", dir.Directory)
-			} else {
-				line = fmt.Sprintf("  %s* r,\n", dir.Directory)
-			}
-		} else if !dir.ReadOnly && dir.OwnerOnly {
-			if dir.Recursive {
-				line = fmt.Sprintf("  owner %s{*,**} rw,\n", dir.Directory)
-			} else {
-				line = fmt.Sprintf("  owner %s* rw,\n", dir.Directory)
-			}
-		} else { // !dir.ReadOnly && !dir.OwnerOnly
-			if dir.Recursive {
-				line = fmt.Sprintf("  %s{*,**} rw,\n", dir.Directory)
-			} else {
-				line = fmt.Sprintf("  %s* rw,\n", dir.Directory)
-			}
-		}
-
-		if !kl.ContainsElement(*fileWhiteList, line) {
-			*fileWhiteList = append(*fileWhiteList, line)
+		if _, ok := prof.FilePaths[dir.Directory]; !ok {
+			prof.FilePaths[dir.Directory] = rule
 		}
 
 		return
 	}
 
 	for _, src := range dir.FromSource {
-		line := ""
-
 		if len(src.Path) == 0 {
 			continue
 		}
 
 		source := src.Path
-		if _, ok := fromSources[source]; !ok {
-			fromSources[source] = []string{}
+		if _, ok := prof.FromSource[source]; !ok {
+			var fromsource FromSourceConfig
+			fromsource.ProfileHeader.Init()
+			fromsource.Rules.Init()
+			prof.FromSource[source] = fromsource
 		}
-
-		if dir.ReadOnly && dir.OwnerOnly {
-			if dir.Recursive {
-				line = fmt.Sprintf("  owner %s{*,**} r,\n", dir.Directory)
-			} else {
-				line = fmt.Sprintf("  owner %s* r,\n", dir.Directory)
-			}
-		} else if dir.ReadOnly && !dir.OwnerOnly {
-			if dir.Recursive {
-				line = fmt.Sprintf("  %s{*,**} r,\n", dir.Directory)
-			} else {
-				line = fmt.Sprintf("  %s* r,\n", dir.Directory)
-			}
-		} else if !dir.ReadOnly && dir.OwnerOnly {
-			if dir.Recursive {
-				line = fmt.Sprintf("  owner %s{*,**} rw,\n", dir.Directory)
-			} else {
-				line = fmt.Sprintf("  owner %s* rw,\n", dir.Directory)
-			}
-		} else { // !dir.ReadOnly && !dir.OwnerOnly
-			if dir.Recursive {
-				line = fmt.Sprintf("  %s{*,**} rw,\n", dir.Directory)
-			} else {
-				line = fmt.Sprintf("  %s* rw,\n", dir.Directory)
+		if deny == false {
+			if val, ok := prof.FromSource[source]; ok {
+				val.File = false
+				prof.FromSource[source] = val
 			}
 		}
-
-		if !kl.ContainsElement(fromSources[source], line) {
-			fromSources[source] = append(fromSources[source], line)
+		if _, ok := prof.FromSource[source].FilePaths[dir.Directory]; !ok {
+			prof.FromSource[source].FilePaths[dir.Directory] = rule
 		}
 	}
 }
 
-// AllowedFileMatchPatterns Function
-func (ae *AppArmorEnforcer) AllowedFileMatchPatterns(pat tp.FilePatternType, fileWhiteList *[]string) {
-	line := ""
-
-	if pat.ReadOnly && pat.OwnerOnly {
-		line = fmt.Sprintf("  owner %s r,\n", pat.Pattern)
-	} else if pat.ReadOnly && !pat.OwnerOnly {
-		line = fmt.Sprintf("  %s r,\n", pat.Pattern)
-	} else if !pat.ReadOnly && pat.OwnerOnly {
-		line = fmt.Sprintf("  owner %s rw,\n", pat.Pattern)
-	} else { // !pat.ReadOnly && !pat.OwnerOnly
-		line = fmt.Sprintf("  %s rw,\n", pat.Pattern)
+// SetFileMatchPatterns Function
+func (ae *AppArmorEnforcer) SetFileMatchPatterns(pat tp.FilePatternType, prof *Profile, deny bool) {
+	if deny == false {
+		prof.File = false
 	}
+	rule := RuleConfig{}
+	rule.Deny = deny
+	rule.OwnerOnly = pat.OwnerOnly
+	rule.ReadOnly = pat.ReadOnly
 
-	if !kl.ContainsElement(*fileWhiteList, line) {
-		*fileWhiteList = append(*fileWhiteList, line)
+	if _, ok := prof.FilePaths[pat.Pattern]; !ok {
+		prof.FilePaths[pat.Pattern] = rule
 	}
 }
 
-// AllowedNetworkMatchProtocols Function
-func (ae *AppArmorEnforcer) AllowedNetworkMatchProtocols(proto tp.NetworkProtocolType, networkWhiteList *[]string, fromSources map[string][]string) {
+// SetNetworkMatchProtocols Function
+func (ae *AppArmorEnforcer) SetNetworkMatchProtocols(proto tp.NetworkProtocolType, prof *Profile, deny bool) {
+	if deny == false {
+		prof.Network = false
+	}
+	rule := RuleConfig{}
+	rule.Deny = deny
 	if len(proto.FromSource) == 0 {
-		line := fmt.Sprintf("  network %s,\n", proto.Protocol)
-		if !kl.ContainsElement(*networkWhiteList, line) {
-			*networkWhiteList = append(*networkWhiteList, line)
+		if _, ok := prof.NetworkRules[proto.Protocol]; !ok {
+			prof.NetworkRules[proto.Protocol] = rule
 		}
 		return
 	}
@@ -316,23 +246,34 @@ func (ae *AppArmorEnforcer) AllowedNetworkMatchProtocols(proto tp.NetworkProtoco
 		}
 
 		source := src.Path
-		if _, ok := fromSources[source]; !ok {
-			fromSources[source] = []string{}
+		if _, ok := prof.FromSource[source]; !ok {
+			var fromsource FromSourceConfig
+			fromsource.ProfileHeader.Init()
+			fromsource.Rules.Init()
+			prof.FromSource[source] = fromsource
 		}
-
-		line := fmt.Sprintf("  network %s,\n", proto.Protocol)
-		if !kl.ContainsElement(fromSources[source], line) {
-			fromSources[source] = append(fromSources[source], line)
+		if deny == false {
+			if val, ok := prof.FromSource[source]; ok {
+				val.Network = false
+				prof.FromSource[source] = val
+			}
+		}
+		if _, ok := prof.FromSource[source].NetworkRules[proto.Protocol]; !ok {
+			prof.FromSource[source].NetworkRules[proto.Protocol] = rule
 		}
 	}
 }
 
-// AllowedCapabilitiesMatchCapabilities Function
-func (ae *AppArmorEnforcer) AllowedCapabilitiesMatchCapabilities(cap tp.CapabilitiesCapabilityType, capabilityWhiteList *[]string, fromSources map[string][]string) {
+// SetCapabilitiesMatchCapabilities Function
+func (ae *AppArmorEnforcer) SetCapabilitiesMatchCapabilities(cap tp.CapabilitiesCapabilityType, prof *Profile, deny bool) {
+	if deny == false {
+		prof.Network = false
+	}
+	rule := RuleConfig{}
+	rule.Deny = deny
 	if len(cap.FromSource) == 0 {
-		line := fmt.Sprintf("  capability %s,\n", cap.Capability)
-		if !kl.ContainsElement(*capabilityWhiteList, line) {
-			*capabilityWhiteList = append(*capabilityWhiteList, line)
+		if _, ok := prof.CapabilitiesRules[cap.Capability]; !ok {
+			prof.CapabilitiesRules[cap.Capability] = rule
 		}
 		return
 	}
@@ -343,451 +284,68 @@ func (ae *AppArmorEnforcer) AllowedCapabilitiesMatchCapabilities(cap tp.Capabili
 		}
 
 		source := src.Path
-		if _, ok := fromSources[source]; !ok {
-			fromSources[source] = []string{}
+		if _, ok := prof.FromSource[source]; !ok {
+			var fromsource FromSourceConfig
+			fromsource.ProfileHeader.Init()
+			fromsource.Rules.Init()
+			prof.FromSource[source] = fromsource
 		}
-
-		line := fmt.Sprintf("  capability %s,\n", cap.Capability)
-		if !kl.ContainsElement(fromSources[source], line) {
-			fromSources[source] = append(fromSources[source], line)
-		}
-	}
-}
-
-//
-
-// BlockedProcessMatchPaths Function
-func (ae *AppArmorEnforcer) BlockedProcessMatchPaths(path tp.ProcessPathType, processBlackList *[]string, fromSources map[string][]string) {
-	if len(path.FromSource) == 0 {
-		line := ""
-
-		if path.OwnerOnly {
-			line = fmt.Sprintf("  owner %s ix,\n  deny other %s x,\n", path.Path, path.Path)
-		} else { // !path.OwnerOnly
-			line = fmt.Sprintf("  deny %s x,\n", path.Path)
-		}
-
-		if !kl.ContainsElement(*processBlackList, line) {
-			*processBlackList = append(*processBlackList, line)
-		}
-
-		return
-	}
-
-	for _, src := range path.FromSource {
-		line := ""
-
-		if len(src.Path) == 0 {
-			continue
-		}
-
-		source := src.Path
-		if _, ok := fromSources[source]; !ok {
-			fromSources[source] = []string{}
-		}
-
-		if path.OwnerOnly {
-			line = fmt.Sprintf("  owner %s ix,\n  deny other %s x,\n", path.Path, path.Path)
-		} else { // !path.OwnerOnly
-			line = fmt.Sprintf("  deny %s x,\n", path.Path)
-		}
-
-		if !kl.ContainsElement(fromSources[source], line) {
-			fromSources[source] = append(fromSources[source], line)
-		}
-	}
-}
-
-// BlockedProcessMatchDirectories Function
-func (ae *AppArmorEnforcer) BlockedProcessMatchDirectories(dir tp.ProcessDirectoryType, processBlackList *[]string, fromSources map[string][]string) {
-	if len(dir.FromSource) == 0 {
-		line := ""
-
-		if dir.Recursive && dir.OwnerOnly {
-			line = fmt.Sprintf("  owner %s{*,**} ix,\n  deny other %s{*,**} x,\n", dir.Directory, dir.Directory)
-		} else if dir.Recursive && !dir.OwnerOnly {
-			line = fmt.Sprintf("  deny %s{*,**} x,\n", dir.Directory)
-		} else if !dir.Recursive && dir.OwnerOnly {
-			line = fmt.Sprintf("  owner %s* ix,\n  deny other %s* x,\n", dir.Directory, dir.Directory)
-		} else { // !dir.Recursive && !dir.OwnerOnly
-			line = fmt.Sprintf("  deny %s* x,\n", dir.Directory)
-		}
-
-		if !kl.ContainsElement(*processBlackList, line) {
-			*processBlackList = append(*processBlackList, line)
-		}
-
-		return
-	}
-
-	for _, src := range dir.FromSource {
-		line := ""
-
-		if len(src.Path) == 0 {
-			continue
-		}
-
-		source := src.Path
-		if _, ok := fromSources[source]; !ok {
-			fromSources[source] = []string{}
-		}
-
-		if dir.Recursive && dir.OwnerOnly {
-			line = fmt.Sprintf("  owner %s{*,**} ix,\n  deny other %s{*,**} x,\n", dir.Directory, dir.Directory)
-		} else if dir.Recursive && !dir.OwnerOnly {
-			line = fmt.Sprintf("  deny %s{*,**} x,\n", dir.Directory)
-		} else if !dir.Recursive && dir.OwnerOnly {
-			line = fmt.Sprintf("  owner %s* ix,\n  deny other %s* x,\n", dir.Directory, dir.Directory)
-		} else { // !dir.Recursive && !dir.OwnerOnly
-			line = fmt.Sprintf("  deny %s* x,\n", dir.Directory)
-		}
-
-		if !kl.ContainsElement(fromSources[source], line) {
-			fromSources[source] = append(fromSources[source], line)
-		}
-	}
-}
-
-// BlockedProcessMatchPatterns Function
-func (ae *AppArmorEnforcer) BlockedProcessMatchPatterns(pat tp.ProcessPatternType, processBlackList *[]string) {
-	line := ""
-
-	if pat.OwnerOnly {
-		line = fmt.Sprintf("  owner %s ix,\n  deny other %s x,\n", pat.Pattern, pat.Pattern)
-	} else { // !path.OwnerOnly
-		line = fmt.Sprintf("  deny %s x,\n", pat.Pattern)
-	}
-
-	if !kl.ContainsElement(*processBlackList, line) {
-		*processBlackList = append(*processBlackList, line)
-	}
-}
-
-// BlockedFileMatchPaths Function
-func (ae *AppArmorEnforcer) BlockedFileMatchPaths(path tp.FilePathType, fileBlackList *[]string, fromSources map[string][]string) {
-	if len(path.FromSource) == 0 {
-		line := ""
-
-		if path.ReadOnly && path.OwnerOnly {
-			line = fmt.Sprintf("  deny owner %s w,\n  deny other %s rw,\n", path.Path, path.Path)
-		} else if path.ReadOnly && !path.OwnerOnly {
-			line = fmt.Sprintf("  deny %s w,\n", path.Path)
-		} else if !path.ReadOnly && path.OwnerOnly {
-			line = fmt.Sprintf("  owner %s rw,\n  deny other %s rw,\n", path.Path, path.Path)
-		} else { // !path.ReadOnly && !path.OwnerOnly
-			line = fmt.Sprintf("  deny %s rw,\n", path.Path)
-		}
-
-		if !kl.ContainsElement(*fileBlackList, line) {
-			*fileBlackList = append(*fileBlackList, line)
-		}
-
-		return
-	}
-
-	for _, src := range path.FromSource {
-		line := ""
-
-		if len(src.Path) == 0 {
-			continue
-		}
-
-		source := src.Path
-		if _, ok := fromSources[source]; !ok {
-			fromSources[source] = []string{}
-		}
-
-		if path.ReadOnly && path.OwnerOnly {
-			line = fmt.Sprintf("  deny owner %s w,\n  deny other %s rw,\n", path.Path, path.Path)
-		} else if path.ReadOnly && !path.OwnerOnly {
-			line = fmt.Sprintf("  deny %s w,\n", path.Path)
-		} else if !path.ReadOnly && path.OwnerOnly {
-			line = fmt.Sprintf("  owner %s rw,\n  deny other %s rw,\n", path.Path, path.Path)
-		} else { // !path.ReadOnly && !path.OwnerOnly
-			line = fmt.Sprintf("  deny %s rw,\n", path.Path)
-		}
-
-		if !kl.ContainsElement(fromSources[source], line) {
-			fromSources[source] = append(fromSources[source], line)
-		}
-	}
-}
-
-// BlockedFileMatchDirectories Function
-func (ae *AppArmorEnforcer) BlockedFileMatchDirectories(dir tp.FileDirectoryType, fileBlackList *[]string, fromSources map[string][]string) {
-	if len(dir.FromSource) == 0 {
-		line := ""
-
-		if dir.ReadOnly && dir.OwnerOnly {
-			if dir.Recursive {
-				line = fmt.Sprintf("  deny owner %s{*,**} w,\n  deny other %s{*,**} rw,\n", dir.Directory, dir.Directory)
-			} else {
-				line = fmt.Sprintf("  deny owner %s* w,\n  deny other %s* rw,\n", dir.Directory, dir.Directory)
-			}
-		} else if dir.ReadOnly && !dir.OwnerOnly {
-			if dir.Recursive {
-				line = fmt.Sprintf("  deny %s{*,**} w,\n", dir.Directory)
-			} else {
-				line = fmt.Sprintf("  deny %s* w,\n", dir.Directory)
-			}
-		} else if !dir.ReadOnly && dir.OwnerOnly {
-			if dir.Recursive {
-				line = fmt.Sprintf("  owner %s{*,**} rw,\n  deny other %s{*,**} rw,\n", dir.Directory, dir.Directory)
-			} else {
-				line = fmt.Sprintf("  owner %s* rw,\n  deny other %s* w,\n", dir.Directory, dir.Directory)
-			}
-		} else { // !dir.ReadOnly && !dir.OwnerOnly
-			if dir.Recursive {
-				line = fmt.Sprintf("  deny %s{*,**} rw,\n", dir.Directory)
-			} else {
-				line = fmt.Sprintf("  deny %s* rw,\n", dir.Directory)
+		if deny == false {
+			if val, ok := prof.FromSource[source]; ok {
+				val.Capabilities = false
+				prof.FromSource[source] = val
 			}
 		}
-
-		if !kl.ContainsElement(*fileBlackList, line) {
-			*fileBlackList = append(*fileBlackList, line)
-		}
-
-		return
-	}
-
-	for _, src := range dir.FromSource {
-		line := ""
-
-		if len(src.Path) == 0 {
-			continue
-		}
-
-		source := src.Path
-		if _, ok := fromSources[source]; !ok {
-			fromSources[source] = []string{}
-		}
-
-		if dir.ReadOnly && dir.OwnerOnly {
-			if dir.Recursive {
-				line = fmt.Sprintf("  deny owner %s{*,**} w,\n  deny other %s{*,**} rw,\n", dir.Directory, dir.Directory)
-			} else {
-				line = fmt.Sprintf("  deny owner %s* w,\n  deny other %s* rw,\n", dir.Directory, dir.Directory)
-			}
-		} else if dir.ReadOnly && !dir.OwnerOnly {
-			if dir.Recursive {
-				line = fmt.Sprintf("  deny %s{*,**} w,\n", dir.Directory)
-			} else {
-				line = fmt.Sprintf("  deny %s* w,\n", dir.Directory)
-			}
-		} else if !dir.ReadOnly && dir.OwnerOnly {
-			if dir.Recursive {
-				line = fmt.Sprintf("  owner %s{*,**} rw,\n  deny other %s{*,**} rw,\n", dir.Directory, dir.Directory)
-			} else {
-				line = fmt.Sprintf("  owner %s* rw,\n  deny other %s* w,\n", dir.Directory, dir.Directory)
-			}
-		} else { // !dir.ReadOnly && !dir.OwnerOnly
-			if dir.Recursive {
-				line = fmt.Sprintf("  deny %s{*,**} rw,\n", dir.Directory)
-			} else {
-				line = fmt.Sprintf("  deny %s* rw,\n", dir.Directory)
-			}
-		}
-
-		if !kl.ContainsElement(fromSources[source], line) {
-			fromSources[source] = append(fromSources[source], line)
+		if _, ok := prof.FromSource[source].CapabilitiesRules[cap.Capability]; !ok {
+			prof.FromSource[source].CapabilitiesRules[cap.Capability] = rule
 		}
 	}
-}
-
-// BlockedFileMatchPatterns Function
-func (ae *AppArmorEnforcer) BlockedFileMatchPatterns(pat tp.FilePatternType, fileBlackList *[]string) {
-	line := ""
-
-	if pat.ReadOnly && pat.OwnerOnly {
-		line = fmt.Sprintf("  deny owner %s w,\n  deny other %s rw,\n", pat.Pattern, pat.Pattern)
-	} else if pat.ReadOnly && !pat.OwnerOnly {
-		line = fmt.Sprintf("  deny %s w,\n", pat.Pattern)
-	} else if !pat.ReadOnly && pat.OwnerOnly {
-		line = fmt.Sprintf("  owner %s rw,\n  deny other %s rw,\n", pat.Pattern, pat.Pattern)
-	} else { // !pat.ReadOnly && !pat.OwnerOnly
-		line = fmt.Sprintf("  deny %s rw,\n", pat.Pattern)
-	}
-
-	if !kl.ContainsElement(*fileBlackList, line) {
-		*fileBlackList = append(*fileBlackList, line)
-	}
-}
-
-// BlockedNetworkMatchProtocols Function
-func (ae *AppArmorEnforcer) BlockedNetworkMatchProtocols(proto tp.NetworkProtocolType, networkBlackList *[]string, fromSources map[string][]string) {
-	if len(proto.FromSource) == 0 {
-		line := fmt.Sprintf("  deny network %s,\n", proto.Protocol)
-		if !kl.ContainsElement(*networkBlackList, line) {
-			*networkBlackList = append(*networkBlackList, line)
-		}
-		return
-	}
-
-	for _, src := range proto.FromSource {
-		if len(src.Path) == 0 {
-			continue
-		}
-
-		source := src.Path
-		if _, ok := fromSources[source]; !ok {
-			fromSources[source] = []string{}
-		}
-
-		line := fmt.Sprintf("  deny network %s,\n", proto.Protocol)
-		if !kl.ContainsElement(fromSources[source], line) {
-			fromSources[source] = append(fromSources[source], line)
-		}
-	}
-}
-
-// BlockedCapabilitiesMatchCapabilities Function
-func (ae *AppArmorEnforcer) BlockedCapabilitiesMatchCapabilities(cap tp.CapabilitiesCapabilityType, capabilityBlackList *[]string, fromSources map[string][]string) {
-	if len(cap.FromSource) == 0 {
-		line := fmt.Sprintf("  deny capability %s,\n", cap.Capability)
-		if !kl.ContainsElement(*capabilityBlackList, line) {
-			*capabilityBlackList = append(*capabilityBlackList, line)
-		}
-		return
-	}
-
-	for _, src := range cap.FromSource {
-		if len(src.Path) <= 0 {
-			continue
-		}
-
-		source := src.Path
-		if _, ok := fromSources[source]; !ok {
-			fromSources[source] = []string{}
-		}
-
-		line := fmt.Sprintf("  deny capability %s,\n", cap.Capability)
-		if !kl.ContainsElement(fromSources[source], line) {
-			fromSources[source] = append(fromSources[source], line)
-		}
-	}
-}
-
-// == //
-
-// GenerateProfileHead Function
-func (ae *AppArmorEnforcer) GenerateProfileHead(numProcessWhiteList, numFileWhiteList, numNetworkWhiteList, numCapabilityWhiteList int, fromSourceFile, fromSourceNetwork, fromSourceCapability bool, defaultPosture tp.DefaultPosture) string {
-	profileHead := "  #include <abstractions/base>\n"
-	profileHead = profileHead + "  umount,\n"
-
-	if defaultPosture.FileAction == "block" && (numProcessWhiteList+numFileWhiteList == 0 && fromSourceFile) {
-		// if defaultPosture == block and there is at least one (fromSource-based) allow policy, block others
-		// hoever, if defaultPosture == block and there is no (fromSource-based) allow policy, allow others as usual
-		profileHead = profileHead + "  file,\n"
-	} else if defaultPosture.FileAction != "block" {
-		// if defaultPosture == audit, audit others (= allow others)
-		// if defaultPosture == allow, skip (ignore) allow policies while still enforcing block policies
-		profileHead = profileHead + "  file,\n"
-	}
-
-	if defaultPosture.NetworkAction == "block" && (numNetworkWhiteList == 0 && fromSourceNetwork) {
-		profileHead = profileHead + "  network,\n"
-	} else if defaultPosture.NetworkAction != "block" {
-		profileHead = profileHead + "  network,\n"
-	}
-
-	if defaultPosture.CapabilitiesAction == "block" && (numCapabilityWhiteList == 0 && fromSourceCapability) {
-		profileHead = profileHead + "  capability,\n"
-	} else if defaultPosture.CapabilitiesAction != "block" {
-		profileHead = profileHead + "  capability,\n"
-	}
-
-	return profileHead
-}
-
-// GenerateProfileFoot Function
-func (ae *AppArmorEnforcer) GenerateProfileFoot() string {
-	profileFoot := "  /lib/x86_64-linux-gnu/{*,**} rm,\n"
-	profileFoot = profileFoot + "\n"
-	profileFoot = profileFoot + "  deny @{PROC}/{*,**^[0-9*],sys/kernel/shm*} wkx,\n"
-	profileFoot = profileFoot + "  deny @{PROC}/sysrq-trigger rwklx,\n"
-	profileFoot = profileFoot + "  deny @{PROC}/mem rwklx,\n"
-	profileFoot = profileFoot + "  deny @{PROC}/kmem rwklx,\n"
-	profileFoot = profileFoot + "  deny @{PROC}/kcore rwklx,\n"
-	profileFoot = profileFoot + "\n"
-	profileFoot = profileFoot + "  deny mount,\n"
-	profileFoot = profileFoot + "\n"
-	profileFoot = profileFoot + "  deny /sys/[^f]*/** wklx,\n"
-	profileFoot = profileFoot + "  deny /sys/f[^s]*/** wklx,\n"
-	profileFoot = profileFoot + "  deny /sys/fs/[^c]*/** wklx,\n"
-	profileFoot = profileFoot + "  deny /sys/fs/c[^g]*/** wklx,\n"
-	profileFoot = profileFoot + "  deny /sys/fs/cg[^r]*/** wklx,\n"
-	profileFoot = profileFoot + "  deny /sys/firmware/efi/efivars/** rwklx,\n"
-	profileFoot = profileFoot + "  deny /sys/kernel/security/** rwklx,\n"
-
-	return profileFoot
 }
 
 // == //
 
 // GenerateProfileBody Function
-func (ae *AppArmorEnforcer) GenerateProfileBody(securityPolicies []tp.SecurityPolicy, defaultPosture tp.DefaultPosture) (int, string) {
+func (ae *AppArmorEnforcer) GenerateProfileBody(securityPolicies []tp.SecurityPolicy, defaultPosture tp.DefaultPosture) (int, Profile) {
 	// preparation
 
 	count := 0
 
-	processWhiteList := []string{}
-	processBlackList := []string{}
-
-	fileWhiteList := []string{}
-	fileBlackList := []string{}
-
-	networkWhiteList := []string{}
-	networkBlackList := []string{}
-
-	capabilityWhiteList := []string{}
-	capabilityBlackList := []string{}
-
-	fromSources := map[string][]string{}
-
-	nativeAppArmorRules := []string{}
-
-	fusionProcessWhiteList := []string{}
-
-	fromSourceFile := true
-	fromSourceNetwork := true
-	fromSourceCapability := true
-
-	// preparation
+	var profile Profile
+	profile.Init()
 
 	for _, secPolicy := range securityPolicies {
 		if len(secPolicy.Spec.AppArmor) > 0 {
 			scanner := bufio.NewScanner(strings.NewReader(secPolicy.Spec.AppArmor))
 			for scanner.Scan() {
-				line := "  " + strings.TrimSpace(scanner.Text()) + "\n"
-				nativeAppArmorRules = append(nativeAppArmorRules, line)
+				line := strings.TrimSpace(scanner.Text())
+				profile.NativeRules = append(profile.NativeRules, line)
 			}
 		}
 
 		if len(secPolicy.Spec.Process.MatchPaths) > 0 {
 			for _, path := range secPolicy.Spec.Process.MatchPaths {
 				if path.Action == "Allow" && defaultPosture.FileAction == "block" {
-					ae.AllowedProcessMatchPaths(path, &processWhiteList, fromSources)
+					ae.SetProcessMatchPaths(path, &profile, false)
 				} else if path.Action == "Block" {
-					ae.BlockedProcessMatchPaths(path, &processBlackList, fromSources)
+					ae.SetProcessMatchPaths(path, &profile, true)
 				}
 			}
 		}
 		if len(secPolicy.Spec.Process.MatchDirectories) > 0 {
 			for _, dir := range secPolicy.Spec.Process.MatchDirectories {
 				if dir.Action == "Allow" && defaultPosture.FileAction == "block" {
-					ae.AllowedProcessMatchDirectories(dir, &processWhiteList, fromSources)
+					ae.SetProcessMatchDirectories(dir, &profile, false)
 				} else if dir.Action == "Block" {
-					ae.BlockedProcessMatchDirectories(dir, &processBlackList, fromSources)
+					ae.SetProcessMatchDirectories(dir, &profile, true)
 				}
 			}
 		}
 		if len(secPolicy.Spec.Process.MatchPatterns) > 0 {
 			for _, pat := range secPolicy.Spec.Process.MatchPatterns {
 				if pat.Action == "Allow" && defaultPosture.FileAction == "block" {
-					ae.AllowedProcessMatchPatterns(pat, &processWhiteList)
+					ae.SetProcessMatchPatterns(pat, &profile, false)
 				} else if pat.Action == "Block" {
-					ae.BlockedProcessMatchPatterns(pat, &processBlackList)
+					ae.SetProcessMatchPatterns(pat, &profile, true)
 				}
 			}
 		}
@@ -795,27 +353,27 @@ func (ae *AppArmorEnforcer) GenerateProfileBody(securityPolicies []tp.SecurityPo
 		if len(secPolicy.Spec.File.MatchPaths) > 0 {
 			for _, path := range secPolicy.Spec.File.MatchPaths {
 				if path.Action == "Allow" && defaultPosture.FileAction == "block" {
-					ae.AllowedFileMatchPaths(path, &fileWhiteList, fromSources)
+					ae.SetFileMatchPaths(path, &profile, false)
 				} else if path.Action == "Block" {
-					ae.BlockedFileMatchPaths(path, &fileBlackList, fromSources)
+					ae.SetFileMatchPaths(path, &profile, true)
 				}
 			}
 		}
 		if len(secPolicy.Spec.File.MatchDirectories) > 0 {
 			for _, dir := range secPolicy.Spec.File.MatchDirectories {
 				if dir.Action == "Allow" && defaultPosture.FileAction == "block" {
-					ae.AllowedFileMatchDirectories(dir, &fileWhiteList, fromSources)
+					ae.SetFileMatchDirectories(dir, &profile, false)
 				} else if dir.Action == "Block" {
-					ae.BlockedFileMatchDirectories(dir, &fileBlackList, fromSources)
+					ae.SetFileMatchDirectories(dir, &profile, true)
 				}
 			}
 		}
 		if len(secPolicy.Spec.File.MatchPatterns) > 0 {
 			for _, pat := range secPolicy.Spec.File.MatchPatterns {
 				if pat.Action == "Allow" && defaultPosture.FileAction == "block" {
-					ae.AllowedFileMatchPatterns(pat, &fileWhiteList)
+					ae.SetFileMatchPatterns(pat, &profile, false)
 				} else if pat.Action == "Block" {
-					ae.BlockedFileMatchPatterns(pat, &fileBlackList)
+					ae.SetFileMatchPatterns(pat, &profile, true)
 				}
 			}
 		}
@@ -823,9 +381,9 @@ func (ae *AppArmorEnforcer) GenerateProfileBody(securityPolicies []tp.SecurityPo
 		if len(secPolicy.Spec.Network.MatchProtocols) > 0 {
 			for _, proto := range secPolicy.Spec.Network.MatchProtocols {
 				if proto.Action == "Allow" && defaultPosture.NetworkAction == "block" {
-					ae.AllowedNetworkMatchProtocols(proto, &networkWhiteList, fromSources)
+					ae.SetNetworkMatchProtocols(proto, &profile, false)
 				} else if proto.Action == "Block" {
-					ae.BlockedNetworkMatchProtocols(proto, &networkBlackList, fromSources)
+					ae.SetNetworkMatchProtocols(proto, &profile, true)
 				}
 			}
 		}
@@ -833,194 +391,47 @@ func (ae *AppArmorEnforcer) GenerateProfileBody(securityPolicies []tp.SecurityPo
 		if len(secPolicy.Spec.Capabilities.MatchCapabilities) > 0 {
 			for _, cap := range secPolicy.Spec.Capabilities.MatchCapabilities {
 				if cap.Action == "Allow" && defaultPosture.CapabilitiesAction == "block" {
-					ae.AllowedCapabilitiesMatchCapabilities(cap, &capabilityWhiteList, fromSources)
+					ae.SetCapabilitiesMatchCapabilities(cap, &profile, false)
 				} else if cap.Action == "Block" {
-					ae.BlockedCapabilitiesMatchCapabilities(cap, &capabilityBlackList, fromSources)
+					ae.SetCapabilitiesMatchCapabilities(cap, &profile, true)
 				}
 			}
 		}
 	}
 
 	// Count the number of global security rules
-
-	numProcessWhiteList := len(processWhiteList)
-	numFileWhiteList := len(fileWhiteList)
-	numNetworkWhiteList := len(networkWhiteList)
-	numCapabilityWhiteList := len(capabilityWhiteList)
-
-	count = count + numProcessWhiteList + numFileWhiteList + numNetworkWhiteList + numCapabilityWhiteList
-	count = count + len(processBlackList) + len(fileBlackList) + len(networkBlackList) + len(capabilityBlackList)
+	count = len(profile.ProcessPaths) + len(profile.FilePaths) + len(profile.NetworkRules) + len(profile.CapabilitiesRules)
 
 	// Resolve conflicts
-	ae.ResolvedProcessWhiteListConflicts(&processWhiteList, fromSources, &fusionProcessWhiteList)
+	ae.ResolvedProcessWhiteListConflicts(&profile)
 
-	// body
-
-	profileBody := ""
-
-	// body - white list
-
-	for _, line := range processWhiteList {
-		profileBody = profileBody + line
-	}
-
-	for _, line := range fileWhiteList {
-		profileBody = profileBody + line
-	}
-
-	for _, line := range networkWhiteList {
-		profileBody = profileBody + line
-	}
-
-	for _, line := range capabilityWhiteList {
-		profileBody = profileBody + line
-	}
-
-	// body - black list
-
-	for _, line := range processBlackList {
-		profileBody = profileBody + line
-	}
-
-	for _, line := range fileBlackList {
-		profileBody = profileBody + line
-	}
-
-	for _, line := range networkBlackList {
-		profileBody = profileBody + line
-	}
-
-	for _, line := range capabilityBlackList {
-		profileBody = profileBody + line
-	}
-
-	// body - from source
-
-	bodyFromSource := ""
-
-	for source, lines := range fromSources {
-		if kl.ContainsElement(fusionProcessWhiteList, source) {
-			bodyFromSource = bodyFromSource + fmt.Sprintf("  %s cix,\n", source)
-		} else {
-			bodyFromSource = bodyFromSource + fmt.Sprintf("  %s cx,\n", source)
-		}
-
-		bodyFromSource = bodyFromSource + fmt.Sprintf("  profile %s {\n", source)
-		bodyFromSource = bodyFromSource + fmt.Sprintf("    %s rix,\n", source)
-
-		// head
-
-		bodyFromSource = bodyFromSource + fmt.Sprintf("    ## == PRE START (%s) == ##\n", source)
-
-		bodyFromSource = bodyFromSource + "    #include <abstractions/base>\n"
-		bodyFromSource = bodyFromSource + "    umount,\n"
-
-		file := true
-		network := true
-		capability := true
-
-		for _, line := range lines {
-			if strings.Contains(line, "  network") { // matchProtocols + allow
-				network = false
-				fromSourceNetwork = false
-				continue
+	for source, val := range profile.FromSource {
+		for proc, config := range profile.ProcessPaths {
+			if _, ok := val.ProcessPaths[proc]; !ok {
+				val.ProcessPaths[proc] = config
 			}
-
-			if strings.Contains(line, "  capability") { // matchCapabilities + allow
-				capability = false
-				fromSourceCapability = false
-				continue
+		}
+		for file, config := range profile.FilePaths {
+			if _, ok := val.FilePaths[file]; !ok {
+				val.FilePaths[file] = config
 			}
-
-			if strings.Contains(line, "  owner") && strings.Contains(line, "deny") { // ownerOnly + block
-				continue
+		}
+		for net, config := range profile.NetworkRules {
+			if _, ok := val.NetworkRules[net]; !ok {
+				val.NetworkRules[net] = config
 			}
-
-			if strings.Contains(line, "  deny") { // block
-				continue
+		}
+		for cap, config := range profile.CapabilitiesRules {
+			if _, ok := val.CapabilitiesRules[cap]; !ok {
+				val.CapabilitiesRules[cap] = config
 			}
-
-			file = false // matchPaths or matchDirectories + allow
-			fromSourceFile = false
 		}
 
-		if defaultPosture.FileAction == "block" && (numProcessWhiteList == 0 && numFileWhiteList == 0 && file) {
-			// if defaultPosture == block and there is at least one (fromSource-based) allow policy, block others
-			// hoever, if defaultPosture == block and there is no (fromSource-based) allow policy, allow others as usual
-			bodyFromSource = bodyFromSource + "    file,\n"
-		} else if defaultPosture.FileAction != "block" {
-			// if defaultPosture == audit, audit others (= allow others)
-			// if defaultPosture == allow, skip (ignore) allow policies while still enforcing block policies
-			bodyFromSource = bodyFromSource + "    file,\n"
-		}
-
-		if defaultPosture.NetworkAction == "block" && (numNetworkWhiteList == 0 && network) {
-			bodyFromSource = bodyFromSource + "    network,\n"
-		} else if defaultPosture.NetworkAction != "block" {
-			bodyFromSource = bodyFromSource + "    network,\n"
-		}
-
-		if defaultPosture.CapabilitiesAction == "block" && (numCapabilityWhiteList == 0 && capability) {
-			bodyFromSource = bodyFromSource + "    capability,\n"
-		} else if defaultPosture.CapabilitiesAction != "block" {
-			bodyFromSource = bodyFromSource + "    capability,\n"
-		}
-
-		bodyFromSource = bodyFromSource + fmt.Sprintf("    ## == PRE END (%s) == ##\n\n", source)
-
-		// body
-
-		bodyFromSource = bodyFromSource + fmt.Sprintf("    ## == POLICY START (%s) == ##\n", source)
-
-		bodyFromSource = bodyFromSource + strings.Replace(profileBody, "  ", "    ", -1)
-
-		for _, line := range lines {
-			bodyFromSource = bodyFromSource + "  " + line
-		}
-
-		bodyFromSource = bodyFromSource + fmt.Sprintf("    ## == POLICY END (%s) == ##\n\n", source)
-
-		// foot
-
-		bodyFromSource = bodyFromSource + fmt.Sprintf("    ## == POST START (%s) == ##\n", source)
-
-		bodyFromSource = bodyFromSource + strings.Replace(ae.GenerateProfileFoot(), "  ", "    ", -1)
-
-		bodyFromSource = bodyFromSource + fmt.Sprintf("    ## == POST END (%s) == ##\n", source)
-		bodyFromSource = bodyFromSource + "  }\n"
+		profile.FromSource[source] = val
+		count = count + len(profile.FromSource[source].ProcessPaths) + len(profile.FromSource[source].FilePaths) + len(profile.FromSource[source].NetworkRules) + len(profile.FromSource[source].CapabilitiesRules)
 	}
 
-	for _, source := range fromSources {
-		count = count + len(source)
-	}
-
-	// head
-
-	profileHead := "  ## == PRE START == ##\n" + ae.GenerateProfileHead(numProcessWhiteList, numFileWhiteList, numNetworkWhiteList, numCapabilityWhiteList, fromSourceFile, fromSourceNetwork, fromSourceCapability, defaultPosture) + "  ## == PRE END == ##\n\n"
-
-	// body - together
-
-	profileBody = "  ## == POLICY START == ##\n" + profileBody + bodyFromSource + "  ## == POLICY END == ##\n\n"
-
-	// body - native apparmor
-
-	if len(nativeAppArmorRules) > 0 {
-		profileBody = profileBody + "\n  ## == NATIVE POLICY START == ##\n"
-		for _, nativeRule := range nativeAppArmorRules {
-			profileBody = profileBody + nativeRule
-		}
-		profileBody = profileBody + "  ## == NATIVE POLICY END == ##\n\n"
-	}
-
-	count = count + len(nativeAppArmorRules)
-
-	// foot
-
-	profileFoot := "  ## == POST START == ##\n" + ae.GenerateProfileFoot() + "  ## == POST END == ##\n"
-
-	// finalization
-
-	return count, profileHead + profileBody + profileFoot
+	return count, profile
 }
 
 // == //
@@ -1035,7 +446,7 @@ func (ae *AppArmorEnforcer) GenerateAppArmorProfile(appArmorProfile string, secu
 
 	// get the old profile
 
-	profile, err := ioutil.ReadFile(filepath.Clean("/etc/apparmor.d/" + appArmorProfile))
+	profile, err := os.ReadFile(filepath.Clean("/etc/apparmor.d/" + appArmorProfile))
 	if err != nil {
 		return 0, err.Error(), false
 	}
@@ -1043,20 +454,25 @@ func (ae *AppArmorEnforcer) GenerateAppArmorProfile(appArmorProfile string, secu
 
 	// generate a profile body
 
-	count, newProfileBody := ae.GenerateProfileBody(securityPolicies, defaultPosture)
+	count, newProfile := ae.GenerateProfileBody(securityPolicies, defaultPosture)
 
-	newProfile := "## == Managed by KubeArmor == ##\n" +
-		"\n" +
-		"#include <tunables/global>\n" +
-		"\n" +
-		"profile " + appArmorProfile + " flags=(attach_disconnected,mediate_deleted) {\n" +
-		newProfileBody +
-		"}\n"
+	newProfile.Name = appArmorProfile
+
+	// Create a new template and parse the letter into it.
+	t, err := template.New("apparmor").Parse(BaseTemplate)
+	if err != nil {
+		return 0, err.Error(), false
+	}
+
+	var np bytes.Buffer
+	if err := t.Execute(&np, newProfile); err != nil {
+		return 0, err.Error(), false
+	}
 
 	// check the new profile with the old profile
 
-	if newProfile != oldProfile {
-		return count, newProfile, true
+	if np.String() != oldProfile {
+		return count, np.String(), true
 	}
 
 	return 0, "", false

--- a/KubeArmor/enforcer/appArmorProfile.go
+++ b/KubeArmor/enforcer/appArmorProfile.go
@@ -35,12 +35,11 @@ func (ae *AppArmorEnforcer) SetProcessMatchPaths(path tp.ProcessPathType, prof *
 	}
 	rule := RuleConfig{}
 	rule.Deny = deny
+	rule.Allow = !deny
 	rule.OwnerOnly = path.OwnerOnly
 
 	if len(path.FromSource) == 0 {
-		if _, ok := prof.ProcessPaths[path.Path]; !ok {
-			prof.ProcessPaths[path.Path] = rule
-		}
+		addRuletoMap(rule, path.Path, prof.ProcessPaths)
 
 		return
 	}
@@ -63,9 +62,7 @@ func (ae *AppArmorEnforcer) SetProcessMatchPaths(path tp.ProcessPathType, prof *
 				prof.FromSource[source] = val
 			}
 		}
-		if _, ok := prof.FromSource[source].ProcessPaths[path.Path]; !ok {
-			prof.ProcessPaths[path.Path] = rule
-		}
+		addRuletoMap(rule, path.Path, prof.FromSource[source].ProcessPaths)
 	}
 }
 
@@ -76,14 +73,13 @@ func (ae *AppArmorEnforcer) SetProcessMatchDirectories(dir tp.ProcessDirectoryTy
 	}
 	rule := RuleConfig{}
 	rule.Deny = deny
+	rule.Allow = !deny
 	rule.Dir = true
 	rule.Recursive = dir.Recursive
 	rule.OwnerOnly = dir.OwnerOnly
 
 	if len(dir.FromSource) == 0 {
-		if _, ok := prof.ProcessPaths[dir.Directory]; !ok {
-			prof.ProcessPaths[dir.Directory] = rule
-		}
+		addRuletoMap(rule, dir.Directory, prof.ProcessPaths)
 
 		return
 	}
@@ -106,9 +102,7 @@ func (ae *AppArmorEnforcer) SetProcessMatchDirectories(dir tp.ProcessDirectoryTy
 				prof.FromSource[source] = val
 			}
 		}
-		if _, ok := prof.FromSource[source].ProcessPaths[dir.Directory]; !ok {
-			prof.FromSource[source].ProcessPaths[dir.Directory] = rule
-		}
+		addRuletoMap(rule, dir.Directory, prof.FromSource[source].ProcessPaths)
 	}
 }
 
@@ -119,6 +113,7 @@ func (ae *AppArmorEnforcer) SetProcessMatchPatterns(pat tp.ProcessPatternType, p
 	}
 	rule := RuleConfig{}
 	rule.Deny = deny
+	rule.Allow = !deny
 	rule.OwnerOnly = pat.OwnerOnly
 
 	if _, ok := prof.ProcessPaths[pat.Pattern]; !ok {
@@ -133,13 +128,12 @@ func (ae *AppArmorEnforcer) SetFileMatchPaths(path tp.FilePathType, prof *Profil
 	}
 	rule := RuleConfig{}
 	rule.Deny = deny
+	rule.Allow = !deny
 	rule.OwnerOnly = path.OwnerOnly
 	rule.ReadOnly = path.ReadOnly
 
 	if len(path.FromSource) == 0 {
-		if _, ok := prof.FilePaths[path.Path]; !ok {
-			prof.FilePaths[path.Path] = rule
-		}
+		addRuletoMap(rule, path.Path, prof.FilePaths)
 
 		return
 	}
@@ -162,9 +156,7 @@ func (ae *AppArmorEnforcer) SetFileMatchPaths(path tp.FilePathType, prof *Profil
 				prof.FromSource[source] = val
 			}
 		}
-		if _, ok := prof.FromSource[source].FilePaths[path.Path]; !ok {
-			prof.FromSource[source].FilePaths[path.Path] = rule
-		}
+		addRuletoMap(rule, path.Path, prof.FromSource[source].FilePaths)
 	}
 }
 
@@ -175,15 +167,14 @@ func (ae *AppArmorEnforcer) SetFileMatchDirectories(dir tp.FileDirectoryType, pr
 	}
 	rule := RuleConfig{}
 	rule.Deny = deny
+	rule.Allow = !deny
 	rule.OwnerOnly = dir.OwnerOnly
 	rule.ReadOnly = dir.ReadOnly
 	rule.Dir = true
 	rule.Recursive = dir.Recursive
 
 	if len(dir.FromSource) == 0 {
-		if _, ok := prof.FilePaths[dir.Directory]; !ok {
-			prof.FilePaths[dir.Directory] = rule
-		}
+		addRuletoMap(rule, dir.Directory, prof.FilePaths)
 
 		return
 	}
@@ -206,9 +197,7 @@ func (ae *AppArmorEnforcer) SetFileMatchDirectories(dir tp.FileDirectoryType, pr
 				prof.FromSource[source] = val
 			}
 		}
-		if _, ok := prof.FromSource[source].FilePaths[dir.Directory]; !ok {
-			prof.FromSource[source].FilePaths[dir.Directory] = rule
-		}
+		addRuletoMap(rule, dir.Directory, prof.FromSource[source].FilePaths)
 	}
 }
 
@@ -219,6 +208,7 @@ func (ae *AppArmorEnforcer) SetFileMatchPatterns(pat tp.FilePatternType, prof *P
 	}
 	rule := RuleConfig{}
 	rule.Deny = deny
+	rule.Allow = !deny
 	rule.OwnerOnly = pat.OwnerOnly
 	rule.ReadOnly = pat.ReadOnly
 
@@ -234,10 +224,9 @@ func (ae *AppArmorEnforcer) SetNetworkMatchProtocols(proto tp.NetworkProtocolTyp
 	}
 	rule := RuleConfig{}
 	rule.Deny = deny
+	rule.Allow = !deny
 	if len(proto.FromSource) == 0 {
-		if _, ok := prof.NetworkRules[proto.Protocol]; !ok {
-			prof.NetworkRules[proto.Protocol] = rule
-		}
+		addRuletoMap(rule, proto.Protocol, prof.NetworkRules)
 		return
 	}
 
@@ -259,9 +248,7 @@ func (ae *AppArmorEnforcer) SetNetworkMatchProtocols(proto tp.NetworkProtocolTyp
 				prof.FromSource[source] = val
 			}
 		}
-		if _, ok := prof.FromSource[source].NetworkRules[proto.Protocol]; !ok {
-			prof.FromSource[source].NetworkRules[proto.Protocol] = rule
-		}
+		addRuletoMap(rule, proto.Protocol, prof.FromSource[source].NetworkRules)
 	}
 }
 
@@ -272,10 +259,9 @@ func (ae *AppArmorEnforcer) SetCapabilitiesMatchCapabilities(cap tp.Capabilities
 	}
 	rule := RuleConfig{}
 	rule.Deny = deny
+	rule.Allow = !deny
 	if len(cap.FromSource) == 0 {
-		if _, ok := prof.CapabilitiesRules[cap.Capability]; !ok {
-			prof.CapabilitiesRules[cap.Capability] = rule
-		}
+		addRuletoMap(rule, cap.Capability, prof.CapabilitiesRules)
 		return
 	}
 
@@ -297,9 +283,7 @@ func (ae *AppArmorEnforcer) SetCapabilitiesMatchCapabilities(cap tp.Capabilities
 				prof.FromSource[source] = val
 			}
 		}
-		if _, ok := prof.FromSource[source].CapabilitiesRules[cap.Capability]; !ok {
-			prof.FromSource[source].CapabilitiesRules[cap.Capability] = rule
-		}
+		addRuletoMap(rule, cap.Capability, prof.FromSource[source].CapabilitiesRules)
 	}
 }
 
@@ -428,7 +412,11 @@ func (ae *AppArmorEnforcer) GenerateProfileBody(securityPolicies []tp.SecurityPo
 
 	for source, val := range profile.FromSource {
 		var newval FromSourceConfig
-		kl.Clone(val, &newval)
+		err := kl.Clone(val, &newval)
+		if err != nil {
+			ae.Logger.Errf("Error while copying global rules to local profile for %s: %s", source, err.Error())
+			continue
+		}
 		for proc, config := range profile.ProcessPaths {
 			add := checkIfGlobalRuleToBeAdded(proc, val.ProcessPaths)
 			if add {
@@ -501,6 +489,18 @@ func (ae *AppArmorEnforcer) GenerateAppArmorProfile(appArmorProfile string, secu
 	}
 
 	return 0, "", false
+}
+
+func addRuletoMap(rule RuleConfig, entity string, m map[string]RuleConfig) {
+	if val, ok := m[entity]; ok {
+		if val.Deny != rule.Deny {
+			rule.Deny = true
+			rule.Allow = true
+		} else {
+			return
+		}
+	}
+	m[entity] = rule
 }
 
 func checkIfGlobalRuleToBeAdded(p string, val map[string]RuleConfig) bool {

--- a/KubeArmor/enforcer/appArmorTemplate.go
+++ b/KubeArmor/enforcer/appArmorTemplate.go
@@ -1,0 +1,202 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2022 Authors of KubeArmor
+
+package enforcer
+
+// ProfileHeader contain sAppArmor Profile/SubProfile header config
+type ProfileHeader struct {
+	File, Network, Capabilities bool
+}
+
+// Init sets the presence of Entity headers to true by default
+func (h *ProfileHeader) Init() {
+	h.File = true
+	h.Network = true
+	h.Capabilities = true
+}
+
+// RuleConfig contains details for individual apparmor rules
+type RuleConfig struct {
+	Dir, Recursive, Deny, ReadOnly, OwnerOnly bool
+}
+
+// Rules contains configuration for the AppArmor Profile/SubProfile Body
+type Rules struct {
+	FilePaths         map[string]RuleConfig
+	ProcessPaths      map[string]RuleConfig
+	NetworkRules      map[string]RuleConfig
+	CapabilitiesRules map[string]RuleConfig
+}
+
+// Init initialises elements Rule Structure
+func (r *Rules) Init() {
+	r.FilePaths = make(map[string]RuleConfig)
+	r.ProcessPaths = make(map[string]RuleConfig)
+	r.NetworkRules = make(map[string]RuleConfig)
+	r.CapabilitiesRules = make(map[string]RuleConfig)
+}
+
+// FromSourceConfig has details for individual from source subprofiles
+type FromSourceConfig struct {
+	Fusion bool
+	ProfileHeader
+	Rules
+}
+
+// Profile header has all the details for a new AppArmor profile
+type Profile struct {
+	Name string
+	ProfileHeader
+	Rules
+	FromSource  map[string]FromSourceConfig
+	NativeRules []string
+}
+
+// Init initialises elements Profike Structure
+func (p *Profile) Init() {
+	p.ProfileHeader.Init()
+	p.Rules.Init()
+	p.FromSource = make(map[string]FromSourceConfig)
+}
+
+// Inspired from https://github.com/genuinetools/bane/blob/master/apparmor/template.go
+
+//BaseTemplate for AppArmor profiles
+const BaseTemplate = `
+## == Managed by KubeArmor == ##
+
+#include <tunables/global>
+
+profile {{.Name}} flags=(attach_disconnected,mediate_deleted) {
+
+	## == PRE START == ##
+
+	#include <abstractions/base>
+
+{{if .File}}	file,
+{{end}}{{if .Network}}	network,
+{{end}}{{if .Capabilities}}	capability,
+{{end}}
+	## == PRE END == ##
+
+	## == POLICY START == ##
+{{range $value, $data := .FilePaths}}{{$suffix := ""}}{{if and $data.Dir $data.Recursive}}{{$suffix = "**"}}{{else if $data.Dir}}{{$suffix = "*"}}{{end}}{{if $data.Deny}}{{if and $data.ReadOnly $data.OwnerOnly}}
+	deny owner {{$value}}{{$suffix}} w,
+	deny other {{$value}}{{$suffix}} rw,
+{{else if $data.OwnerOnly}}	owner {{$value}}{{$suffix}} rw,
+	deny other {{$value}}{{$suffix}} rw,
+{{else if $data.ReadOnly}}	deny {{$value}}{{$suffix}} w,
+{{else}}	deny {{$value}}{{$suffix}} rw,{{end}}
+{{else}}{{if and $data.ReadOnly $data.OwnerOnly}}	owner {{$value}}{{$suffix}} r,
+{{else if $data.OwnerOnly}}	owner {{$value}}{{$suffix}} rw,
+{{else if $data.ReadOnly}}	{{$value}}{{$suffix}} r,
+{{else}}	{{$value}}{{$suffix}} rw,
+{{end}}{{end}}{{end}}
+{{range $value, $data := .ProcessPaths}}{{$suffix := ""}}{{if and $data.Dir $data.Recursive}}{{$suffix = "**"}}{{else if $data.Dir}}{{$suffix = "*"}}{{end}}{{if $data.Deny}}{{if $data.OwnerOnly}}
+	owner {{$value}}{{$suffix}} ix,
+	deny other {{$value}}{{$suffix}} x,{{else}}
+	deny {{$value}}{{$suffix}} x,{{end}}{{else}}{{if $data.OwnerOnly}}
+	owner {{$value}}{{$suffix}} ix,{{else}}	{{$value}}{{$suffix}} ix,
+{{end}}{{end}}{{end}}
+{{range $value, $data := .NetworkRules}}{{if $data.Deny}}	deny network {{$value}},{{else}}
+	network {{$value}},
+{{end}}{{end}}
+{{range $value, $data := .CapabilitiesRules}}{{if $data.Deny}}	deny capability {{$value}},{{else}}
+	capability {{$value}},
+{{end}}{{end}}
+{{ range $source, $value := $.FromSource }}{{if $value.Fusion}}
+	{{$source}} cix,{{else}}
+	{{$source}} cx,{{end}}
+	profile {{$source}} {
+
+		{{$source}} rix,
+		## == PRE START == ##
+
+		#include <abstractions/base>
+	
+	{{if .File}}	file,
+	{{end}}{{if .Network}}	network,
+	{{end}}{{if .Capabilities}}	capability,
+	{{end}}
+		## == PRE END == ##
+	
+		## == POLICY START == ##
+	{{range $value, $data := .FilePaths}}{{$suffix := ""}}{{if and $data.Dir $data.Recursive}}{{$suffix = "**"}}{{else if $data.Dir}}{{$suffix = "*"}}{{end}}{{if $data.Deny}}{{if and $data.ReadOnly $data.OwnerOnly}}
+		deny owner {{$value}}{{$suffix}} w,
+		deny other {{$value}}{{$suffix}} rw,
+	{{else if $data.OwnerOnly}}	owner {{$value}}{{$suffix}} rw,
+		deny other {{$value}}{{$suffix}} rw,
+	{{else if $data.ReadOnly}}	deny {{$value}}{{$suffix}} w,
+	{{else}}	deny {{$value}}{{$suffix}} rw,{{end}}
+	{{else}}{{if and $data.ReadOnly $data.OwnerOnly}}	owner {{$value}}{{$suffix}} r,
+	{{else if $data.OwnerOnly}}	owner {{$value}}{{$suffix}} rw,
+	{{else if $data.ReadOnly}}	{{$value}}{{$suffix}} r,
+	{{else}}	{{$value}}{{$suffix}} rw,
+	{{end}}{{end}}{{end}}
+	{{range $value, $data := .ProcessPaths}}{{$suffix := ""}}{{if and $data.Dir $data.Recursive}}{{$suffix = "**"}}{{else if $data.Dir}}{{$suffix = "*"}}{{end}}{{if $data.Deny}}{{if $data.OwnerOnly}}
+		owner {{$value}}{{$suffix}} ix,
+		deny other {{$value}}{{$suffix}} x,{{else}}
+		deny {{$value}}{{$suffix}} x,{{end}}{{else}}{{if $data.OwnerOnly}}
+		owner {{$value}}{{$suffix}} ix,{{else}}	{{$value}}{{$suffix}} ix,
+	{{end}}{{end}}{{end}}
+	{{range $value, $data := .NetworkRules}}{{if $data.Deny}}	deny network {{$value}},{{else}}
+		network {{$value}},
+	{{end}}{{end}}
+	{{range $value, $data := .CapabilitiesRules}}{{if $data.Deny}}	deny capability {{$value}},{{else}}
+		capability {{$value}},
+	{{end}}{{end}}
+		## == POLICY END == ##
+	
+		## == POST START == ##
+	
+		/lib/x86_64-linux-gnu/{*,**} rm,
+		
+		deny @{PROC}/{*,**^[0-9*],sys/kernel/shm*} wkx,
+		deny @{PROC}/sysrq-trigger rwklx,
+		deny @{PROC}/mem rwklx,
+		deny @{PROC}/kmem rwklx,
+		deny @{PROC}/kcore rwklx,
+		
+		deny mount,
+		
+		deny /sys/[^f]*/** wklx,
+		deny /sys/f[^s]*/** wklx,
+		deny /sys/fs/[^c]*/** wklx,
+		deny /sys/fs/c[^g]*/** wklx,
+		deny /sys/fs/cg[^r]*/** wklx,
+		deny /sys/firmware/efi/efivars/** rwklx,
+		deny /sys/kernel/security/** rwklx,
+	
+		## == POST END == ##
+
+	}
+{{end}}
+	## == POLICY END == ##
+{{ if gt (len .NativeRules) 0 }}	## == NATIVE POLICY START == ##
+{{range $value := .NativeRules}}	{{$value}}
+{{end}}	## == NATIVE POLICY END == ##
+{{end}}
+	## == POST START == ##
+
+	/lib/x86_64-linux-gnu/{*,**} rm,
+	
+	deny @{PROC}/{*,**^[0-9*],sys/kernel/shm*} wkx,
+	deny @{PROC}/sysrq-trigger rwklx,
+	deny @{PROC}/mem rwklx,
+	deny @{PROC}/kmem rwklx,
+	deny @{PROC}/kcore rwklx,
+	
+	deny mount,
+	
+	deny /sys/[^f]*/** wklx,
+	deny /sys/f[^s]*/** wklx,
+	deny /sys/fs/[^c]*/** wklx,
+	deny /sys/fs/c[^g]*/** wklx,
+	deny /sys/fs/cg[^r]*/** wklx,
+	deny /sys/firmware/efi/efivars/** rwklx,
+	deny /sys/kernel/security/** rwklx,
+
+	## == POST END == ##
+
+}
+`

--- a/KubeArmor/enforcer/appArmorTemplate.go
+++ b/KubeArmor/enforcer/appArmorTemplate.go
@@ -17,7 +17,7 @@ func (h *ProfileHeader) Init() {
 
 // RuleConfig contains details for individual apparmor rules
 type RuleConfig struct {
-	Dir, Recursive, Deny, ReadOnly, OwnerOnly bool
+	Dir, Recursive, ReadOnly, OwnerOnly, Deny, Allow bool
 }
 
 // Rules contains configuration for the AppArmor Profile/SubProfile Body
@@ -87,7 +87,7 @@ profile {{.Name}} flags=(attach_disconnected,mediate_deleted) {
 	deny other {{$value}}{{$suffix}} rw,
 {{else if $data.ReadOnly}}	deny {{$value}}{{$suffix}} w,
 {{else}}	deny {{$value}}{{$suffix}} rw,{{end}}
-{{else}}{{if and $data.ReadOnly $data.OwnerOnly}}	owner {{$value}}{{$suffix}} r,
+{{end}}{{if $data.Allow}}{{if and $data.ReadOnly $data.OwnerOnly}}	owner {{$value}}{{$suffix}} r,
 {{else if $data.OwnerOnly}}	owner {{$value}}{{$suffix}} rw,
 {{else if $data.ReadOnly}}	{{$value}}{{$suffix}} r,
 {{else}}	{{$value}}{{$suffix}} rw,
@@ -95,14 +95,14 @@ profile {{.Name}} flags=(attach_disconnected,mediate_deleted) {
 {{range $value, $data := .ProcessPaths}}{{$suffix := ""}}{{if and $data.Dir $data.Recursive}}{{$suffix = "**"}}{{else if $data.Dir}}{{$suffix = "*"}}{{end}}{{if $data.Deny}}{{if $data.OwnerOnly}}
 	owner {{$value}}{{$suffix}} ix,
 	deny other {{$value}}{{$suffix}} x,{{else}}
-	deny {{$value}}{{$suffix}} x,{{end}}{{else}}{{if $data.OwnerOnly}}
+	deny {{$value}}{{$suffix}} x,{{end}}{{end}}{{if $data.Allow}}{{if $data.OwnerOnly}}
 	owner {{$value}}{{$suffix}} ix,{{else}}	{{$value}}{{$suffix}} ix,
 {{end}}{{end}}{{end}}
-{{range $value, $data := .NetworkRules}}{{if $data.Deny}}	deny network {{$value}},{{else}}
-	network {{$value}},
+{{range $value, $data := .NetworkRules}}{{if $data.Deny}}	deny network {{$value}},
+{{end}}{{if $data.Allow}}	network {{$value}},
 {{end}}{{end}}
-{{range $value, $data := .CapabilitiesRules}}{{if $data.Deny}}	deny capability {{$value}},{{else}}
-	capability {{$value}},
+{{range $value, $data := .CapabilitiesRules}}{{if $data.Deny}}	deny capability {{$value}},
+{{end}}{{if $data.Allow}}	capability {{$value}},
 {{end}}{{end}}
 {{ range $source, $value := $.FromSource }}{{if $value.Fusion}}
 	{{$source}} cix,{{else}}
@@ -128,7 +128,7 @@ profile {{.Name}} flags=(attach_disconnected,mediate_deleted) {
 		deny other {{$value}}{{$suffix}} rw,
 	{{else if $data.ReadOnly}}	deny {{$value}}{{$suffix}} w,
 	{{else}}	deny {{$value}}{{$suffix}} rw,{{end}}
-	{{else}}{{if and $data.ReadOnly $data.OwnerOnly}}	owner {{$value}}{{$suffix}} r,
+	{{end}}{{if $data.Allow}}{{if and $data.ReadOnly $data.OwnerOnly}}	owner {{$value}}{{$suffix}} r,
 	{{else if $data.OwnerOnly}}	owner {{$value}}{{$suffix}} rw,
 	{{else if $data.ReadOnly}}	{{$value}}{{$suffix}} r,
 	{{else}}	{{$value}}{{$suffix}} rw,
@@ -136,14 +136,14 @@ profile {{.Name}} flags=(attach_disconnected,mediate_deleted) {
 	{{range $value, $data := .ProcessPaths}}{{$suffix := ""}}{{if and $data.Dir $data.Recursive}}{{$suffix = "**"}}{{else if $data.Dir}}{{$suffix = "*"}}{{end}}{{if $data.Deny}}{{if $data.OwnerOnly}}
 		owner {{$value}}{{$suffix}} ix,
 		deny other {{$value}}{{$suffix}} x,{{else}}
-		deny {{$value}}{{$suffix}} x,{{end}}{{else}}{{if $data.OwnerOnly}}
+		deny {{$value}}{{$suffix}} x,{{end}}{{end}}{{if $data.Allow}}{{if $data.OwnerOnly}}
 		owner {{$value}}{{$suffix}} ix,{{else}}	{{$value}}{{$suffix}} ix,
 	{{end}}{{end}}{{end}}
-	{{range $value, $data := .NetworkRules}}{{if $data.Deny}}	deny network {{$value}},{{else}}
-		network {{$value}},
+	{{range $value, $data := .NetworkRules}}{{if $data.Deny}}	deny network {{$value}},
+	{{end}}{{if $data.Allow}}	network {{$value}},
 	{{end}}{{end}}
-	{{range $value, $data := .CapabilitiesRules}}{{if $data.Deny}}	deny capability {{$value}},{{else}}
-		capability {{$value}},
+	{{range $value, $data := .CapabilitiesRules}}{{if $data.Deny}}	deny capability {{$value}},
+	{{end}}{{if $data.Allow}}	capability {{$value}},
 	{{end}}{{end}}
 		## == POLICY END == ##
 	

--- a/KubeArmor/feeder/policyMatcher.go
+++ b/KubeArmor/feeder/policyMatcher.go
@@ -893,6 +893,11 @@ func (fd *Feeder) UpdateMatchedPolicy(log tp.Log) tp.Log {
 
 							continue
 						}
+
+						if matchedFlags && secPolicy.Action == "Allow" && log.Result != "Passed" {
+							// It's possible there are additional rules in the Security Policy resulting in the block else we deem it as default posture anyway
+							continue
+						}
 					}
 
 					if secPolicy.Action == "Allow" && log.Result != "Passed" {

--- a/tests/smoke/res/ksp-wordpress-lenient-allow-sa.yaml
+++ b/tests/smoke/res/ksp-wordpress-lenient-allow-sa.yaml
@@ -1,0 +1,32 @@
+apiVersion: security.kubearmor.com/v1
+kind: KubeArmorPolicy
+metadata:
+  name: ksp-wordpress-lenient-allow-sa
+  namespace: wordpress-mysql
+spec:
+  severity: 7
+  selector:
+    matchLabels:
+      app: wordpress
+  file:
+    matchDirectories:
+      - dir: /run/secrets/kubernetes.io/serviceaccount/
+        recursive: true
+        action: Block
+      - dir: /
+        recursive: true
+      - dir: /run/secrets/kubernetes.io/serviceaccount/
+        recursive: true
+        fromSource:
+          - path: /bin/cat
+  process:
+    matchDirectories:
+      - dir: /
+        recursive: true
+
+        # cat /run/secrets/kubernetes.io/serviceaccount/token
+        # cat /etc/passwd
+        # head /run/secrets/kubernetes.io/serviceaccount/token
+        # head /etc/passwd
+
+  action: Allow


### PR DESCRIPTION
We now have a way to resolve conflicts between local and global profile allowing us to set a priority order in the code for what to expect when conflicting rules exist between a global policy and fromSource.

This conflict deemed a complex resolution logic so I ended up refactoring the profile generation logic to more freely analyse and manipulate the profiles.

Will handle in BPF LSM in separate PR

Ref #787 