### PR TITLE
added tag to hsp to make it cluster-scoped resource

### DIFF
--- a/pkg/KubeArmorHostPolicy/Makefile
+++ b/pkg/KubeArmorHostPolicy/Makefile
@@ -51,7 +51,6 @@ delete: manifests
 # Generate manifests e.g. CRD, RBAC etc.
 manifests: controller-gen
 	$(CONTROLLER_GEN) $(CRD_OPTIONS) rbac:roleName=manager-role webhook paths="./..." output:crd:artifacts:config=config/crd/bases
-	sed -i 's/scope: Namespaced/scope: Cluster/g' config/crd/bases/security.kubearmor.com_kubearmorhostpolicies.yaml
 	cp config/crd/bases/security.kubearmor.com_kubearmorhostpolicies.yaml ../../deployments/CRD/KubeArmorHostPolicy.yaml
 	cp config/crd/bases/security.kubearmor.com_kubearmorhostpolicies.yaml crd/KubeArmorHostPolicy.yaml
 

--- a/pkg/KubeArmorHostPolicy/api/security.kubearmor.com/v1/kubearmorhostpolicy_types.go
+++ b/pkg/KubeArmorHostPolicy/api/security.kubearmor.com/v1/kubearmorhostpolicy_types.go
@@ -266,6 +266,7 @@ type KubeArmorHostPolicyStatus struct {
 
 // KubeArmorHostPolicy is the Schema for the kubearmorhostpolicies API
 // +genclient
+// +genclient:nonNamespaced
 // +kubebuilder:resource:shortName=hsp
 // +kubebuilder:subresource:status
 type KubeArmorHostPolicy struct {

--- a/pkg/KubeArmorHostPolicy/client/clientset/versioned/typed/security.kubearmor.com/v1/fake/fake_kubearmorhostpolicy.go
+++ b/pkg/KubeArmorHostPolicy/client/clientset/versioned/typed/security.kubearmor.com/v1/fake/fake_kubearmorhostpolicy.go
@@ -20,7 +20,6 @@ import (
 // FakeKubeArmorHostPolicies implements KubeArmorHostPolicyInterface
 type FakeKubeArmorHostPolicies struct {
 	Fake *FakeSecurityV1
-	ns   string
 }
 
 var kubearmorhostpoliciesResource = schema.GroupVersionResource{Group: "security.kubearmor.com", Version: "v1", Resource: "kubearmorhostpolicies"}
@@ -30,8 +29,7 @@ var kubearmorhostpoliciesKind = schema.GroupVersionKind{Group: "security.kubearm
 // Get takes name of the kubeArmorHostPolicy, and returns the corresponding kubeArmorHostPolicy object, and an error if there is any.
 func (c *FakeKubeArmorHostPolicies) Get(ctx context.Context, name string, options v1.GetOptions) (result *securitykubearmorcomv1.KubeArmorHostPolicy, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewGetAction(kubearmorhostpoliciesResource, c.ns, name), &securitykubearmorcomv1.KubeArmorHostPolicy{})
-
+		Invokes(testing.NewRootGetAction(kubearmorhostpoliciesResource, name), &securitykubearmorcomv1.KubeArmorHostPolicy{})
 	if obj == nil {
 		return nil, err
 	}
@@ -41,8 +39,7 @@ func (c *FakeKubeArmorHostPolicies) Get(ctx context.Context, name string, option
 // List takes label and field selectors, and returns the list of KubeArmorHostPolicies that match those selectors.
 func (c *FakeKubeArmorHostPolicies) List(ctx context.Context, opts v1.ListOptions) (result *securitykubearmorcomv1.KubeArmorHostPolicyList, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewListAction(kubearmorhostpoliciesResource, kubearmorhostpoliciesKind, c.ns, opts), &securitykubearmorcomv1.KubeArmorHostPolicyList{})
-
+		Invokes(testing.NewRootListAction(kubearmorhostpoliciesResource, kubearmorhostpoliciesKind, opts), &securitykubearmorcomv1.KubeArmorHostPolicyList{})
 	if obj == nil {
 		return nil, err
 	}
@@ -63,15 +60,13 @@ func (c *FakeKubeArmorHostPolicies) List(ctx context.Context, opts v1.ListOption
 // Watch returns a watch.Interface that watches the requested kubeArmorHostPolicies.
 func (c *FakeKubeArmorHostPolicies) Watch(ctx context.Context, opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
-		InvokesWatch(testing.NewWatchAction(kubearmorhostpoliciesResource, c.ns, opts))
-
+		InvokesWatch(testing.NewRootWatchAction(kubearmorhostpoliciesResource, opts))
 }
 
 // Create takes the representation of a kubeArmorHostPolicy and creates it.  Returns the server's representation of the kubeArmorHostPolicy, and an error, if there is any.
 func (c *FakeKubeArmorHostPolicies) Create(ctx context.Context, kubeArmorHostPolicy *securitykubearmorcomv1.KubeArmorHostPolicy, opts v1.CreateOptions) (result *securitykubearmorcomv1.KubeArmorHostPolicy, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewCreateAction(kubearmorhostpoliciesResource, c.ns, kubeArmorHostPolicy), &securitykubearmorcomv1.KubeArmorHostPolicy{})
-
+		Invokes(testing.NewRootCreateAction(kubearmorhostpoliciesResource, kubeArmorHostPolicy), &securitykubearmorcomv1.KubeArmorHostPolicy{})
 	if obj == nil {
 		return nil, err
 	}
@@ -81,8 +76,7 @@ func (c *FakeKubeArmorHostPolicies) Create(ctx context.Context, kubeArmorHostPol
 // Update takes the representation of a kubeArmorHostPolicy and updates it. Returns the server's representation of the kubeArmorHostPolicy, and an error, if there is any.
 func (c *FakeKubeArmorHostPolicies) Update(ctx context.Context, kubeArmorHostPolicy *securitykubearmorcomv1.KubeArmorHostPolicy, opts v1.UpdateOptions) (result *securitykubearmorcomv1.KubeArmorHostPolicy, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewUpdateAction(kubearmorhostpoliciesResource, c.ns, kubeArmorHostPolicy), &securitykubearmorcomv1.KubeArmorHostPolicy{})
-
+		Invokes(testing.NewRootUpdateAction(kubearmorhostpoliciesResource, kubeArmorHostPolicy), &securitykubearmorcomv1.KubeArmorHostPolicy{})
 	if obj == nil {
 		return nil, err
 	}
@@ -93,8 +87,7 @@ func (c *FakeKubeArmorHostPolicies) Update(ctx context.Context, kubeArmorHostPol
 // Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 func (c *FakeKubeArmorHostPolicies) UpdateStatus(ctx context.Context, kubeArmorHostPolicy *securitykubearmorcomv1.KubeArmorHostPolicy, opts v1.UpdateOptions) (*securitykubearmorcomv1.KubeArmorHostPolicy, error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewUpdateSubresourceAction(kubearmorhostpoliciesResource, "status", c.ns, kubeArmorHostPolicy), &securitykubearmorcomv1.KubeArmorHostPolicy{})
-
+		Invokes(testing.NewRootUpdateSubresourceAction(kubearmorhostpoliciesResource, "status", kubeArmorHostPolicy), &securitykubearmorcomv1.KubeArmorHostPolicy{})
 	if obj == nil {
 		return nil, err
 	}
@@ -104,14 +97,13 @@ func (c *FakeKubeArmorHostPolicies) UpdateStatus(ctx context.Context, kubeArmorH
 // Delete takes name of the kubeArmorHostPolicy and deletes it. Returns an error if one occurs.
 func (c *FakeKubeArmorHostPolicies) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	_, err := c.Fake.
-		Invokes(testing.NewDeleteAction(kubearmorhostpoliciesResource, c.ns, name), &securitykubearmorcomv1.KubeArmorHostPolicy{})
-
+		Invokes(testing.NewRootDeleteAction(kubearmorhostpoliciesResource, name), &securitykubearmorcomv1.KubeArmorHostPolicy{})
 	return err
 }
 
 // DeleteCollection deletes a collection of objects.
 func (c *FakeKubeArmorHostPolicies) DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error {
-	action := testing.NewDeleteCollectionAction(kubearmorhostpoliciesResource, c.ns, listOpts)
+	action := testing.NewRootDeleteCollectionAction(kubearmorhostpoliciesResource, listOpts)
 
 	_, err := c.Fake.Invokes(action, &securitykubearmorcomv1.KubeArmorHostPolicyList{})
 	return err
@@ -120,8 +112,7 @@ func (c *FakeKubeArmorHostPolicies) DeleteCollection(ctx context.Context, opts v
 // Patch applies the patch and returns the patched kubeArmorHostPolicy.
 func (c *FakeKubeArmorHostPolicies) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *securitykubearmorcomv1.KubeArmorHostPolicy, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(kubearmorhostpoliciesResource, c.ns, name, pt, data, subresources...), &securitykubearmorcomv1.KubeArmorHostPolicy{})
-
+		Invokes(testing.NewRootPatchSubresourceAction(kubearmorhostpoliciesResource, name, pt, data, subresources...), &securitykubearmorcomv1.KubeArmorHostPolicy{})
 	if obj == nil {
 		return nil, err
 	}

--- a/pkg/KubeArmorHostPolicy/client/clientset/versioned/typed/security.kubearmor.com/v1/fake/fake_security.kubearmor.com_client.go
+++ b/pkg/KubeArmorHostPolicy/client/clientset/versioned/typed/security.kubearmor.com/v1/fake/fake_security.kubearmor.com_client.go
@@ -15,8 +15,8 @@ type FakeSecurityV1 struct {
 	*testing.Fake
 }
 
-func (c *FakeSecurityV1) KubeArmorHostPolicies(namespace string) v1.KubeArmorHostPolicyInterface {
-	return &FakeKubeArmorHostPolicies{c, namespace}
+func (c *FakeSecurityV1) KubeArmorHostPolicies() v1.KubeArmorHostPolicyInterface {
+	return &FakeKubeArmorHostPolicies{c}
 }
 
 // RESTClient returns a RESTClient that is used to communicate

--- a/pkg/KubeArmorHostPolicy/client/clientset/versioned/typed/security.kubearmor.com/v1/kubearmorhostpolicy.go
+++ b/pkg/KubeArmorHostPolicy/client/clientset/versioned/typed/security.kubearmor.com/v1/kubearmorhostpolicy.go
@@ -20,7 +20,7 @@ import (
 // KubeArmorHostPoliciesGetter has a method to return a KubeArmorHostPolicyInterface.
 // A group's client should implement this interface.
 type KubeArmorHostPoliciesGetter interface {
-	KubeArmorHostPolicies(namespace string) KubeArmorHostPolicyInterface
+	KubeArmorHostPolicies() KubeArmorHostPolicyInterface
 }
 
 // KubeArmorHostPolicyInterface has methods to work with KubeArmorHostPolicy resources.
@@ -40,14 +40,12 @@ type KubeArmorHostPolicyInterface interface {
 // kubeArmorHostPolicies implements KubeArmorHostPolicyInterface
 type kubeArmorHostPolicies struct {
 	client rest.Interface
-	ns     string
 }
 
 // newKubeArmorHostPolicies returns a KubeArmorHostPolicies
-func newKubeArmorHostPolicies(c *SecurityV1Client, namespace string) *kubeArmorHostPolicies {
+func newKubeArmorHostPolicies(c *SecurityV1Client) *kubeArmorHostPolicies {
 	return &kubeArmorHostPolicies{
 		client: c.RESTClient(),
-		ns:     namespace,
 	}
 }
 
@@ -55,7 +53,6 @@ func newKubeArmorHostPolicies(c *SecurityV1Client, namespace string) *kubeArmorH
 func (c *kubeArmorHostPolicies) Get(ctx context.Context, name string, options metav1.GetOptions) (result *v1.KubeArmorHostPolicy, err error) {
 	result = &v1.KubeArmorHostPolicy{}
 	err = c.client.Get().
-		Namespace(c.ns).
 		Resource("kubearmorhostpolicies").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -72,7 +69,6 @@ func (c *kubeArmorHostPolicies) List(ctx context.Context, opts metav1.ListOption
 	}
 	result = &v1.KubeArmorHostPolicyList{}
 	err = c.client.Get().
-		Namespace(c.ns).
 		Resource("kubearmorhostpolicies").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -89,7 +85,6 @@ func (c *kubeArmorHostPolicies) Watch(ctx context.Context, opts metav1.ListOptio
 	}
 	opts.Watch = true
 	return c.client.Get().
-		Namespace(c.ns).
 		Resource("kubearmorhostpolicies").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -100,7 +95,6 @@ func (c *kubeArmorHostPolicies) Watch(ctx context.Context, opts metav1.ListOptio
 func (c *kubeArmorHostPolicies) Create(ctx context.Context, kubeArmorHostPolicy *v1.KubeArmorHostPolicy, opts metav1.CreateOptions) (result *v1.KubeArmorHostPolicy, err error) {
 	result = &v1.KubeArmorHostPolicy{}
 	err = c.client.Post().
-		Namespace(c.ns).
 		Resource("kubearmorhostpolicies").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(kubeArmorHostPolicy).
@@ -113,7 +107,6 @@ func (c *kubeArmorHostPolicies) Create(ctx context.Context, kubeArmorHostPolicy 
 func (c *kubeArmorHostPolicies) Update(ctx context.Context, kubeArmorHostPolicy *v1.KubeArmorHostPolicy, opts metav1.UpdateOptions) (result *v1.KubeArmorHostPolicy, err error) {
 	result = &v1.KubeArmorHostPolicy{}
 	err = c.client.Put().
-		Namespace(c.ns).
 		Resource("kubearmorhostpolicies").
 		Name(kubeArmorHostPolicy.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -128,7 +121,6 @@ func (c *kubeArmorHostPolicies) Update(ctx context.Context, kubeArmorHostPolicy 
 func (c *kubeArmorHostPolicies) UpdateStatus(ctx context.Context, kubeArmorHostPolicy *v1.KubeArmorHostPolicy, opts metav1.UpdateOptions) (result *v1.KubeArmorHostPolicy, err error) {
 	result = &v1.KubeArmorHostPolicy{}
 	err = c.client.Put().
-		Namespace(c.ns).
 		Resource("kubearmorhostpolicies").
 		Name(kubeArmorHostPolicy.Name).
 		SubResource("status").
@@ -142,7 +134,6 @@ func (c *kubeArmorHostPolicies) UpdateStatus(ctx context.Context, kubeArmorHostP
 // Delete takes name of the kubeArmorHostPolicy and deletes it. Returns an error if one occurs.
 func (c *kubeArmorHostPolicies) Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error {
 	return c.client.Delete().
-		Namespace(c.ns).
 		Resource("kubearmorhostpolicies").
 		Name(name).
 		Body(&opts).
@@ -157,7 +148,6 @@ func (c *kubeArmorHostPolicies) DeleteCollection(ctx context.Context, opts metav
 		timeout = time.Duration(*listOpts.TimeoutSeconds) * time.Second
 	}
 	return c.client.Delete().
-		Namespace(c.ns).
 		Resource("kubearmorhostpolicies").
 		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -170,7 +160,6 @@ func (c *kubeArmorHostPolicies) DeleteCollection(ctx context.Context, opts metav
 func (c *kubeArmorHostPolicies) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions, subresources ...string) (result *v1.KubeArmorHostPolicy, err error) {
 	result = &v1.KubeArmorHostPolicy{}
 	err = c.client.Patch(pt).
-		Namespace(c.ns).
 		Resource("kubearmorhostpolicies").
 		Name(name).
 		SubResource(subresources...).

--- a/pkg/KubeArmorHostPolicy/client/clientset/versioned/typed/security.kubearmor.com/v1/security.kubearmor.com_client.go
+++ b/pkg/KubeArmorHostPolicy/client/clientset/versioned/typed/security.kubearmor.com/v1/security.kubearmor.com_client.go
@@ -21,8 +21,8 @@ type SecurityV1Client struct {
 	restClient rest.Interface
 }
 
-func (c *SecurityV1Client) KubeArmorHostPolicies(namespace string) KubeArmorHostPolicyInterface {
-	return newKubeArmorHostPolicies(c, namespace)
+func (c *SecurityV1Client) KubeArmorHostPolicies() KubeArmorHostPolicyInterface {
+	return newKubeArmorHostPolicies(c)
 }
 
 // NewForConfig creates a new SecurityV1Client for the given config.

--- a/pkg/KubeArmorHostPolicy/client/informers/externalversions/security.kubearmor.com/v1/interface.go
+++ b/pkg/KubeArmorHostPolicy/client/informers/externalversions/security.kubearmor.com/v1/interface.go
@@ -28,5 +28,5 @@ func New(f internalinterfaces.SharedInformerFactory, namespace string, tweakList
 
 // KubeArmorHostPolicies returns a KubeArmorHostPolicyInformer.
 func (v *version) KubeArmorHostPolicies() KubeArmorHostPolicyInformer {
-	return &kubeArmorHostPolicyInformer{factory: v.factory, namespace: v.namespace, tweakListOptions: v.tweakListOptions}
+	return &kubeArmorHostPolicyInformer{factory: v.factory, tweakListOptions: v.tweakListOptions}
 }

--- a/pkg/KubeArmorHostPolicy/client/informers/externalversions/security.kubearmor.com/v1/kubearmorhostpolicy.go
+++ b/pkg/KubeArmorHostPolicy/client/informers/externalversions/security.kubearmor.com/v1/kubearmorhostpolicy.go
@@ -29,33 +29,32 @@ type KubeArmorHostPolicyInformer interface {
 type kubeArmorHostPolicyInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
 	tweakListOptions internalinterfaces.TweakListOptionsFunc
-	namespace        string
 }
 
 // NewKubeArmorHostPolicyInformer constructs a new informer for KubeArmorHostPolicy type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewKubeArmorHostPolicyInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
-	return NewFilteredKubeArmorHostPolicyInformer(client, namespace, resyncPeriod, indexers, nil)
+func NewKubeArmorHostPolicyInformer(client versioned.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+	return NewFilteredKubeArmorHostPolicyInformer(client, resyncPeriod, indexers, nil)
 }
 
 // NewFilteredKubeArmorHostPolicyInformer constructs a new informer for KubeArmorHostPolicy type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewFilteredKubeArmorHostPolicyInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
+func NewFilteredKubeArmorHostPolicyInformer(client versioned.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
 	return cache.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.SecurityV1().KubeArmorHostPolicies(namespace).List(context.TODO(), options)
+				return client.SecurityV1().KubeArmorHostPolicies().List(context.TODO(), options)
 			},
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.SecurityV1().KubeArmorHostPolicies(namespace).Watch(context.TODO(), options)
+				return client.SecurityV1().KubeArmorHostPolicies().Watch(context.TODO(), options)
 			},
 		},
 		&securitykubearmorcomv1.KubeArmorHostPolicy{},
@@ -65,7 +64,7 @@ func NewFilteredKubeArmorHostPolicyInformer(client versioned.Interface, namespac
 }
 
 func (f *kubeArmorHostPolicyInformer) defaultInformer(client versioned.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFilteredKubeArmorHostPolicyInformer(client, f.namespace, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
+	return NewFilteredKubeArmorHostPolicyInformer(client, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
 }
 
 func (f *kubeArmorHostPolicyInformer) Informer() cache.SharedIndexInformer {

--- a/pkg/KubeArmorHostPolicy/client/listers/security.kubearmor.com/v1/expansion_generated.go
+++ b/pkg/KubeArmorHostPolicy/client/listers/security.kubearmor.com/v1/expansion_generated.go
@@ -8,7 +8,3 @@ package v1
 // KubeArmorHostPolicyListerExpansion allows custom methods to be added to
 // KubeArmorHostPolicyLister.
 type KubeArmorHostPolicyListerExpansion interface{}
-
-// KubeArmorHostPolicyNamespaceListerExpansion allows custom methods to be added to
-// KubeArmorHostPolicyNamespaceLister.
-type KubeArmorHostPolicyNamespaceListerExpansion interface{}

--- a/pkg/KubeArmorHostPolicy/client/listers/security.kubearmor.com/v1/kubearmorhostpolicy.go
+++ b/pkg/KubeArmorHostPolicy/client/listers/security.kubearmor.com/v1/kubearmorhostpolicy.go
@@ -18,8 +18,9 @@ type KubeArmorHostPolicyLister interface {
 	// List lists all KubeArmorHostPolicies in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1.KubeArmorHostPolicy, err error)
-	// KubeArmorHostPolicies returns an object that can list and get KubeArmorHostPolicies.
-	KubeArmorHostPolicies(namespace string) KubeArmorHostPolicyNamespaceLister
+	// Get retrieves the KubeArmorHostPolicy from the index for a given name.
+	// Objects returned here must be treated as read-only.
+	Get(name string) (*v1.KubeArmorHostPolicy, error)
 	KubeArmorHostPolicyListerExpansion
 }
 
@@ -41,41 +42,9 @@ func (s *kubeArmorHostPolicyLister) List(selector labels.Selector) (ret []*v1.Ku
 	return ret, err
 }
 
-// KubeArmorHostPolicies returns an object that can list and get KubeArmorHostPolicies.
-func (s *kubeArmorHostPolicyLister) KubeArmorHostPolicies(namespace string) KubeArmorHostPolicyNamespaceLister {
-	return kubeArmorHostPolicyNamespaceLister{indexer: s.indexer, namespace: namespace}
-}
-
-// KubeArmorHostPolicyNamespaceLister helps list and get KubeArmorHostPolicies.
-// All objects returned here must be treated as read-only.
-type KubeArmorHostPolicyNamespaceLister interface {
-	// List lists all KubeArmorHostPolicies in the indexer for a given namespace.
-	// Objects returned here must be treated as read-only.
-	List(selector labels.Selector) (ret []*v1.KubeArmorHostPolicy, err error)
-	// Get retrieves the KubeArmorHostPolicy from the indexer for a given namespace and name.
-	// Objects returned here must be treated as read-only.
-	Get(name string) (*v1.KubeArmorHostPolicy, error)
-	KubeArmorHostPolicyNamespaceListerExpansion
-}
-
-// kubeArmorHostPolicyNamespaceLister implements the KubeArmorHostPolicyNamespaceLister
-// interface.
-type kubeArmorHostPolicyNamespaceLister struct {
-	indexer   cache.Indexer
-	namespace string
-}
-
-// List lists all KubeArmorHostPolicies in the indexer for a given namespace.
-func (s kubeArmorHostPolicyNamespaceLister) List(selector labels.Selector) (ret []*v1.KubeArmorHostPolicy, err error) {
-	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
-		ret = append(ret, m.(*v1.KubeArmorHostPolicy))
-	})
-	return ret, err
-}
-
-// Get retrieves the KubeArmorHostPolicy from the indexer for a given namespace and name.
-func (s kubeArmorHostPolicyNamespaceLister) Get(name string) (*v1.KubeArmorHostPolicy, error) {
-	obj, exists, err := s.indexer.GetByKey(s.namespace + "/" + name)
+// Get retrieves the KubeArmorHostPolicy from the index for a given name.
+func (s *kubeArmorHostPolicyLister) Get(name string) (*v1.KubeArmorHostPolicy, error) {
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
`KubeArmorHostPolicy` is not a namespace scoped resource, therefore marked the type `KubeArmorHostPolicy` with tag `+genclient:nonNamespaced`.

Managing `hsp` with client-go API was an issue earlier. This PR fixes that issue.

Signed-off-by: rk <ramakant@accuknox.com>