### PR TITLE
community meeting zoom link update

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ If you want to make a contribution, please refer to the following documents too.
 
 ### Biweekly Meetup
 
-* Where: [Zoom Link](https://us02web.zoom.us/j/5013008459?pwd=LzhGdk42T05QZEM5T2pmYzhYUEZuQT09)
+* Where: [Zoom Link](https://bit.ly/kubearmor-zoom)
 * Minutes: [Document](https://docs.google.com/document/d/1IqIIG9Vz-PYpbUwrH0u99KYEM1mtnYe6BHrson4NqEs/edit)
 * Calendar invite: [Google Calendar](https://calendar.google.com/event?action=TEMPLATE&tmeid=MWN0MTlzYWFoM2tkcXZidTk1cHZjNjNyOGtfMjAyMjAyMTBUMTUwMDAwWiBjXzJmMXRiYnNqNWdrNmdnbGpzMzA4NnAwamw4QGc&tmsrc=c_2f1tbbsj5gk6ggljs3086p0jl8%40group.calendar.google.com&scp=ALL)
 * ICS: [ICS file](getting-started/resources/KubeArmorMeetup.ics) for setting up meeting on your calendar

--- a/getting-started/resources/KubeArmorMeetup.ics
+++ b/getting-started/resources/KubeArmorMeetup.ics
@@ -25,11 +25,9 @@ CREATED:20211009T145900Z
 DESCRIPTION:Agenda:\n* Triage\, priorities\n* Community questions/feedback\
  n* Design discussions\, open sessions\n\nMinutes Document:\nhttps://docs.go
  ogle.com/document/d/1IqIIG9Vz-PYpbUwrH0u99KYEM1mtnYe6BHrson4NqEs/edit\n\nVe
- nue: https://us02web.zoom.us/j/5013008459?pwd=LzhGdk42T05QZEM5T2pmYzhYUEZuQ
- T09
+ nue: https://bit.ly/kubearmor-zoom
 LAST-MODIFIED:20211009T145900Z
-LOCATION:https://us02web.zoom.us/j/5013008459?pwd=LzhGdk42T05QZEM5T2pmYzhYU
- EZuQT09
+LOCATION:https://bit.ly/kubearmor-zoom
 SEQUENCE:0
 STATUS:CONFIRMED
 SUMMARY:KubeArmor Community Meetup


### PR DESCRIPTION
Previous zoom link is deprecated. Now we are using the bitly redirector
to specify the zoom link so as to handle future such changes smoothly.

Signed-off-by: Rahul Jadhav <r@accuknox.com>