### PR TITLE
Compile BPF code using vmlinux.h

### DIFF
--- a/.github/workflows/install-llvm.sh
+++ b/.github/workflows/install-llvm.sh
@@ -9,13 +9,13 @@ wget https://apt.llvm.org/llvm.sh -O /tmp/llvm.sh
 
 if [ "$VERSION_CODENAME" == "focal" ] || [ "$VERSION_CODENAME" == "bionic" ]; then
     sudo bash /tmp/llvm.sh 12
-    for tool in "clang" "llc" "llvm-strip"; do
+    for tool in "clang" "llc" "llvm-strip" "opt" "llvm-dis"; do
         sudo rm -f /usr/bin/$tool
         sudo ln -s /usr/bin/$tool-12 /usr/bin/$tool
     done
 else # VERSION_CODENAME == jammy
     sudo bash /tmp/llvm.sh 14
-    for tool in "clang" "llc" "llvm-strip"; do
+    for tool in "clang" "llc" "llvm-strip" "opt" "llvm-dis"; do
         sudo rm -f /usr/bin/$tool
         sudo ln -s /usr/bin/$tool-14 /usr/bin/$tool
     done

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,11 @@ RUN go build -o syscheck main.go
 FROM alpine:3.15 as kubearmor-init
 
 RUN apk --no-cache update
-RUN apk --no-cache add bash git clang llvm make gcc
+RUN echo "@edge http://dl-cdn.alpinelinux.org/alpine/edge/main" | tee -a /etc/apk/repositories
+RUN echo "@edge http://dl-cdn.alpinelinux.org/alpine/edge/community" | tee -a /etc/apk/repositories
+
+RUN apk --no-cache update
+RUN apk --no-cache add bash git clang llvm make gcc bpftool@edge
 
 COPY ./GKE /KubeArmor/GKE/
 COPY ./KubeArmor/BPF /KubeArmor/BPF/

--- a/KubeArmor/BPF/Makefile
+++ b/KubeArmor/BPF/Makefile
@@ -1,43 +1,58 @@
 include Makefile.vars
 
 .PHONY: all
-all: chkdir syscall_test system_monitor.bpf.o system_monitor.container.bpf.o system_monitor.host.bpf.o
+all: kernel_headers libbpf syscall_test system_monitor.bpf.o system_monitor.container.bpf.o system_monitor.host.bpf.o
 
-.PHONY: chkdir
-chkdir:
-ifeq (,$(wildcard $(KRNDIR)/Kconfig))
-	@echo "Your kernel path[$(RED)$(KRNDIR)$(NC)] is incorrect. Use 'make KRNDIR=[KERNEL-SRC-PATH]'."
-	Quitting 
+.PHONY: kernel_headers
+kernel_headers:
+ifeq ($(BTF_SUPPORTED),1)
+	@echo "$(GREEN)Kernel BTF information found$(NC)"
+	@echo "Generating vmlinux.h for kernel $(KRNV_X).$(KRNV_Y).$(KRNV_Z)"
+	$(Q)bpftool btf dump file $(KRBTF) format c > $(VMLINUX)/vmlinux.h
 else
-	@echo "Using kernel path[$(GREEN)$(KRNDIR)$(NC)]"
+	@echo "$(RED)Kernel BTF information not found$(NC)"
+	@echo "Trying to use kernel headers present in the host"
+ifeq (,$(wildcard $(KRNDIR)/Kconfig))
+	@echo "$(RED)Auto-detected kernel headers path [$(KRNDIR)] is incorrect.$(NC) Use 'make KRNDIR=[KERNEL-SRC-PATH]'."
+	Quitting
+else
+	@echo "$(GREEN)Using kernel headers at $(KRNDIR)$(NC)"
 endif
+endif
+
+.PHONY: libbpf
+libbpf:
 ifeq (,$(wildcard $(LIBBPF)/src/libbpf.c))
-	git submodule update --init --recursive
+	$(Q)git submodule update --init --recursive
 endif
 ifeq (,$(wildcard $(LIBBPF)/src/libbpf.a))
-	make -C $(LIBBPF)/src
+	$(Q)make -C $(LIBBPF)/src
 endif
 
 .PHONY: syscall_test
 syscall_test: tests/Makefile
-	@make -C tests KRNDIR="$(KRNDIR)"
+	$(Q)make -C tests KRNDIR="$(KRNDIR)"
 
-system_monitor.bpf.o: $(SYSMONITOR) syscall_test
+system_monitor.bpf.o: $(SYSMONITOR) $(VMLINUX_H) syscall_test
 	@echo "Compiling eBPF bytecode: $(GREEN)$@$(NC) ..."
 	@echo "Using Compiler flags: $(CFlags)"
 	$(Q)$(CL) $(KF) -DMONITOR_HOST_AND_CONTAINER $(CFlags) -c $< -o -| llc -march=bpf -mcpu=probe -filetype=obj -o $@
 
-system_monitor.container.bpf.o: $(SYSMONITOR) syscall_test
+system_monitor.container.bpf.o: $(SYSMONITOR) $(VMLINUX_H) syscall_test
 	@echo "Compiling eBPF bytecode: $(GREEN)$@$(NC) ..."
 	@echo "Using Compiler flags: $(CFlags)"
 	$(Q)$(CL) $(KF) -DMONITOR_CONTAINER $(CFlags) -c $< -o -| llc -march=bpf -mcpu=probe -filetype=obj -o $@
 
-system_monitor.host.bpf.o: $(SYSMONITOR) syscall_test
+system_monitor.host.bpf.o: $(SYSMONITOR) $(VMLINUX_H) syscall_test
 	@echo "Compiling eBPF bytecode: $(GREEN)$@$(NC) ..."
 	@echo "Using Compiler flags: $(CFlags)"
 	$(Q)$(CL) $(KF) -DMONITOR_HOST $(CFlags) -c $< -o -| llc -march=bpf -mcpu=probe -filetype=obj -o $@
 
-# clean up
+.PHONY: clean
 clean:
 	@make -C tests clean
-	$(Q)rm -rf *.o
+	$(Q)rm -rf *.o $(VMLINUX)/vmlinux.h
+
+.PHONY: clean-all
+clean-all: clean
+	$(Q)make clean -C $(LIBBPF)/src

--- a/KubeArmor/BPF/Makefile
+++ b/KubeArmor/BPF/Makefile
@@ -33,20 +33,27 @@ endif
 syscall_test: tests/Makefile
 	$(Q)make -C tests KRNDIR="$(KRNDIR)"
 
+# below we use long chain of commands, clang | opt | llvm-dis | llc,
+# to generate final object file. 'clang' compiles the source into IR
+# with native target, e.g., x64, arm64, etc. 'opt' does bpf CORE IR builtin
+# processing (llvm12) and IR optimizations. 'llvm-dis' converts
+# 'opt' output to IR, and finally 'llc' generates bpf byte code.
+# Ref https://elixir.bootlin.com/linux/v5.19.5/source/samples/bpf/Makefile#L439
+
 system_monitor.bpf.o: $(SYSMONITOR) $(VMLINUX_H) syscall_test
 	@echo "Compiling eBPF bytecode: $(GREEN)$@$(NC) ..."
 	@echo "Using Compiler flags: $(CFlags)"
-	$(Q)$(CL) $(KF) -DMONITOR_HOST_AND_CONTAINER $(CFlags) -c $< -o -| llc -march=bpf -mcpu=probe -filetype=obj -o $@
+	$(Q)$(CL) $(KF) -DMONITOR_HOST_AND_CONTAINER $(CFlags) -Xclang -disable-llvm-passes -c $< -o - | opt -O2 -mtriple=bpf-pc-linux | llvm-dis | llc -march=bpf -mcpu=probe -filetype=obj -o $@
 
 system_monitor.container.bpf.o: $(SYSMONITOR) $(VMLINUX_H) syscall_test
 	@echo "Compiling eBPF bytecode: $(GREEN)$@$(NC) ..."
 	@echo "Using Compiler flags: $(CFlags)"
-	$(Q)$(CL) $(KF) -DMONITOR_CONTAINER $(CFlags) -c $< -o -| llc -march=bpf -mcpu=probe -filetype=obj -o $@
+	$(Q)$(CL) $(KF) -DMONITOR_CONTAINER $(CFlags) -Xclang -disable-llvm-passes -c $< -o - | opt -O2 -mtriple=bpf-pc-linux | llvm-dis | llc -march=bpf -mcpu=probe -filetype=obj -o $@
 
 system_monitor.host.bpf.o: $(SYSMONITOR) $(VMLINUX_H) syscall_test
 	@echo "Compiling eBPF bytecode: $(GREEN)$@$(NC) ..."
 	@echo "Using Compiler flags: $(CFlags)"
-	$(Q)$(CL) $(KF) -DMONITOR_HOST $(CFlags) -c $< -o -| llc -march=bpf -mcpu=probe -filetype=obj -o $@
+	$(Q)$(CL) $(KF) -DMONITOR_HOST $(CFlags) -Xclang -disable-llvm-passes -c $< -o - | opt -O2 -mtriple=bpf-pc-linux | llvm-dis | llc -march=bpf -mcpu=probe -filetype=obj -o $@
 
 .PHONY: clean
 clean:

--- a/KubeArmor/BPF/Makefile.vars
+++ b/KubeArmor/BPF/Makefile.vars
@@ -1,8 +1,22 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2022 Authors of KubeArmor
 
+KRBTF = /sys/kernel/btf/vmlinux
+
+KRNVER = $(shell uname -r)
+# split kernel version string
+		 # extract upstream version | x.y.z-rc-arch --> x.y.z
+KRNV_U = $(shell echo $(KRNVER) | sed -nr 's/([0-9.]+).*/\1/p')
+		 # split version | x.y.z --> x y z
+KRNV_S = $(subst ., ,$(KRNV_U))
+		 # major version
+KRNV_X = $(word 1,$(KRNV_S))
+		 # patch level version
+KRNV_Y = $(word 2,$(KRNV_S))
+		 # sublevel version
+KRNV_Z = $(word 3,$(KRNV_S))
+
 ifeq (,$(KRNDIR))
-	KRNVER = $(shell uname -r)
 ifneq (,$(wildcard /lib/modules/$(KRNVER)/build/Kconfig))
 	KRNDIR = /lib/modules/$(KRNVER)/build
 else ifneq (,$(wildcard /lib/modules/$(KRNVER)/source/Kconfig))
@@ -16,6 +30,9 @@ endif
 
 LIBBPF = $(CURDIR)/libbpf
 
+VMLINUX = $(CURDIR)
+VMLINUX_H = $(wildcard $(VMLINUX)/vmlinux*.h)
+
 CL  = clang
 CC  = gcc
 Q   = @
@@ -24,19 +41,35 @@ ifeq ($(V),1)
   Q =
 endif
 
-# shamelessly copied from kernel's samples/bpf/Makefile
-KF = -I$(KRNDIR)/arch/x86/include -I$(KRNDIR)/arch/x86/include/generated  \
-	 -I$(KRNDIR)/include -I$(KRNDIR)/arch/x86/include/uapi \
-	 -I$(KRNDIR)/arch/x86/include/generated/uapi -I$(KRNDIR)/include/uapi \
-	 -I$(KRNDIR)/include/generated/uapi \
-	 -I$(LIBBPF)/src \
-	 -include $(KRNDIR)/include/linux/kconfig.h \
+BTF_SUPPORTED = 0
+ifneq (,$(wildcard $(KRBTF)))
+	BTF_SUPPORTED = 1
+endif
+
+ifeq ($(BTF_SUPPORTED),1)
+	INC_F = -I $(VMLINUX) \
+			-DBTF_SUPPORTED \
+			-DBPF_NO_PRESERVE_ACCESS_INDEX
+else
+	# copied from kernel's samples/bpf/Makefile
+	INC_F = -I$(KRNDIR)/arch/x86/include -I$(KRNDIR)/arch/x86/include/generated  \
+	 	 	-I$(KRNDIR)/include -I$(KRNDIR)/arch/x86/include/uapi \
+	 	 	-I$(KRNDIR)/arch/x86/include/generated/uapi -I$(KRNDIR)/include/uapi \
+	 	 	-I$(KRNDIR)/include/generated/uapi \
+	 	 	-include $(KRNDIR)/include/linux/kconfig.h
+endif
+
+KF = $(INC_F) -I$(LIBBPF)/src \
+	 -DLINUX_VERSION_MAJOR=$(KRNV_X) \
+	 -DLINUX_VERSION_PATCHLEVEL=$(KRNV_Y) \
+	 -DLINUX_VERSION_SUBLEVEL=$(KRNV_Z) \
 	 -D__KERNEL__ \
 	 -D__BPF_TRACING__ \
 	 -D__TARGET_ARCH_x86 \
 	 -Wunused \
 	 -Wno-frame-address \
 	 -Wno-unused-value \
+	 -Wno-unused-function \
 	 -Wno-unknown-warning-option \
 	 -Wno-pragma-once-outside-header \
 	 -Wno-pointer-sign \
@@ -50,10 +83,6 @@ KF = -I$(KRNDIR)/arch/x86/include -I$(KRNDIR)/arch/x86/include/generated  \
 	 -fno-asynchronous-unwind-tables \
 	 -xc -O2 -g -emit-llvm
 
-SRCDIR=$(CURDIR)
-
-SRCS_KERN:=$(wildcard $(SRCDIR)/*.c)
-SRCN:=$(notdir $(SRCS_KERN))
 SYSMONITOR = $(CURDIR)/system_monitor.c
 
 RED=\033[0;31m

--- a/KubeArmor/BPF/enforcer.bpf.c
+++ b/KubeArmor/BPF/enforcer.bpf.c
@@ -1,6 +1,7 @@
 // +build ignore
 
 #include "vmlinux.h"
+#include "vmlinux_macro.h"
 #include <bpf/bpf_core_read.h>
 #include <bpf/bpf_helpers.h>
 #include <bpf/bpf_tracing.h>

--- a/KubeArmor/BPF/system_monitor.c
+++ b/KubeArmor/BPF/system_monitor.c
@@ -32,9 +32,12 @@
 #include <linux/proc_ns.h>
 #include <linux/mount.h>
 #include <linux/binfmts.h>
-#include <linux/bpf.h>
+
 #include <linux/un.h>
 #include <net/inet_sock.h>
+
+#include <linux/bpf.h>
+#include <linux/version.h>
 #endif
 
 #include <bpf_helpers.h>

--- a/KubeArmor/BPF/tests/Makefile
+++ b/KubeArmor/BPF/tests/Makefile
@@ -5,6 +5,7 @@
 include ../Makefile.vars
 
 LIBBPF = $(CURDIR)/../libbpf
+VMLINUX = $(CURDIR)/../
 
 Cfiles =  $(wildcard checks/*.c)
 files = $(Cfiles:.c=)

--- a/KubeArmor/BPF/tests/checks/security_path_unlink.c
+++ b/KubeArmor/BPF/tests/checks/security_path_unlink.c
@@ -5,7 +5,12 @@
 #define KBUILD_MODNAME "kubearmor_syscall_check"
 #endif
 
+#ifdef BTF_SUPPORTED
+#include "vmlinux.h"
+#else
 #include <linux/bpf.h>
+#endif
+
 #include <bpf_helpers.h>
 
 // CFlag=-DSECURITY_PATH

--- a/KubeArmor/BPF/vmlinux_macro.h
+++ b/KubeArmor/BPF/vmlinux_macro.h
@@ -1,0 +1,65 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+/* Copyright 2022 Authors of KubeArmor */
+
+#ifndef __VMLINUX_MACRO_H__
+#define __VMLINUX_MACRO_H__
+
+/* --------------------------------------------------------------
+ * ## Missing macro/enum in vmlinux BTF (/sys/kernel/btf/vmlinux)
+ * --------------------------------------------------------------
+ * ### DWARF
+ * ---------
+ * 1) Macros in C will not part of DWARF section in an ELF file.
+ * 2) When it comes to struct & enum of a C program, the decision to
+ *    include them in the DWARF section of ELF file depends on whether
+ *    the compiler thinks they will be useful during debugging.
+ *    For example, due to compiler optimization or because of to the way
+ *    the code is written, certain lines of code, struct and enums will
+ *    become unreachable when the ELF file is executed and debugged. The
+ *    compiler deems them as unnecessary debug_info and (by default) do
+ *    not add such struct and enum in the DWARF section of the ELF file
+ *    (unless `-fno-eliminate-unused-debug-types` flag is used).
+ *
+ * ### vmlinux BTF
+ * ---------------
+ * 1) `/sys/kernel/btf/vmlinux` file is usually generated from the DWARF
+ *    section of the kernel image (vmlinux). So whatever apply to DWARF
+ *    in general applies to vmlinux BTF as well.
+ * 2) Macros in the kernel source will not part of vmlinux BTF [Ref 1]
+ * 3) Kernel struct & enum may or may not be present in the vmlinux BTF
+ *    unless the `BTF_TYPE_EMIT*` macros are explicity used on those
+ *    struct and enum in the kernel source [Ref 2 and 3].
+ * 
+ * ### Reference
+ * -------------
+ * 1) https://lore.kernel.org/all/CAO658oV9AAcMMbVhjkoq5PtpvbVf41Cd_TBLCORTcf3trtwHfw@mail.gmail.com/T/
+ * 2) https://lore.kernel.org/bpf/20210317174132.589276-1-yhs@fb.com/
+ * 3) https://elixir.bootlin.com/linux/v5.19.4/source/include/linux/btf.h#L12
+ *
+ * -------------------------------------------------------------- */
+
+#ifndef KERNEL_VERSION
+#define KERNEL_VERSION(a, b, c) (((a) << 16) + ((b) << 8) + ((c) > 255 ? 255 : (c)))
+#endif
+
+#define LINUX_VERSION_CODE KERNEL_VERSION(LINUX_VERSION_MAJOR,      \
+                                          LINUX_VERSION_PATCHLEVEL, \
+                                          LINUX_VERSION_SUBLEVEL)
+
+/*
+ * In some kernels (example - Debian 11 w/ kernel 5.10.0-17-amd64),
+ * the BTF information for the below enum value is not present
+ * in /sys/kernel/btf/vmlinux.
+ */
+#define PROC_PID_INIT_INO   0xEFFFFFFCU
+
+/*
+ * The following values are define as macro in the kernel until v5.6.19.
+ * From 5.7, they are defined as enum values. 
+ */
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 7, 0)
+#define BPF_ANY             0
+#define BPF_F_CURRENT_CPU   0xffffffffULL
+#endif
+
+#endif

--- a/KubeArmor/build/compile.sh
+++ b/KubeArmor/build/compile.sh
@@ -2,19 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2021 Authors of KubeArmor
 
-KRNDIR=""
-
-FILE=/media/root/etc/os-release
-if [ -f "$FILE" ]; then
-    . $FILE
-    if [ "$ID" == "cos" ]; then
-        echo "* COS detected (build ${BUILD_ID}), downloading COS kernel headers"
-        . /KubeArmor/GKE/download_cos_kernel_headers.sh
-        KRNDIR=/KubeArmor/GKE/kernel/usr/src/linux-headers-$(uname -r)
-        echo $KRNDIR
-    fi
-fi
-
 cd /KubeArmor/BPF
 make clean
 

--- a/contribution/self-managed-k8s/setup.sh
+++ b/contribution/self-managed-k8s/setup.sh
@@ -21,7 +21,7 @@ export DEBIAN_FRONTEND=noninteractive
 echo 'debconf debconf/frontend select Noninteractive' | sudo debconf-set-selections
 
 # install dependencies and llvm--toolchain
-sudo apt-get -y install build-essential libelf-dev pkg-config net-tools linux-headers-generic
+sudo apt-get -y install build-essential libelf-dev pkg-config net-tools linux-headers-$(uname -r) linux-tools-$(uname -r)
 wget https://apt.llvm.org/llvm.sh
 chmod +x llvm.sh
 if [ "$VERSION_CODENAME" == "focal" ] || [ "$VERSION_CODENAME" == "bionic" ]; then

--- a/contribution/self-managed-k8s/setup.sh
+++ b/contribution/self-managed-k8s/setup.sh
@@ -26,13 +26,13 @@ wget https://apt.llvm.org/llvm.sh
 chmod +x llvm.sh
 if [ "$VERSION_CODENAME" == "focal" ] || [ "$VERSION_CODENAME" == "bionic" ]; then
     sudo ./llvm.sh 12
-    for tool in "clang" "llc" "llvm-strip"; do
+    for tool in "clang" "llc" "llvm-strip" "opt" "llvm-dis"; do
         sudo rm -f /usr/bin/$tool
         sudo ln -s /usr/bin/$tool-12 /usr/bin/$tool
     done
 else # VERSION_CODENAME == jammy
     sudo ./llvm.sh 14
-    for tool in "clang" "llc" "llvm-strip"; do
+    for tool in "clang" "llc" "llvm-strip" "opt" "llvm-dis"; do
         sudo rm -f /usr/bin/$tool
         sudo ln -s /usr/bin/$tool-14 /usr/bin/$tool
     done


### PR DESCRIPTION
If the host has kernel BTF information (`/sys/kernel/btf/vmlinux`),
then generate `vmlinux.h` using `bpftool` and compile the BPF code
using `vmlinux.h`.

This removes dependency on kernel headers to be present in the host
system if it uses a kernel > v5.4.

Fixes #803 

Signed-off-by: Wazir Ahmed <wazir@accuknox.com>