### PR TITLE
backport: gracefully terminate kubearmor container

### DIFF
--- a/KubeArmor/build/entrypoint.sh
+++ b/KubeArmor/build/entrypoint.sh
@@ -3,7 +3,6 @@
 # Copyright 2021 Authors of KubeArmor
 
 terminate_kubearmor() {
-    pid=$(ps -e | grep kubearmor | awk '{print $1}')
     if [ "$pid" != "" ]; then
         kill -SIGTERM $pid
     fi
@@ -25,7 +24,9 @@ esac
 
 for ((i=0;i<5;i++))
 do
-    /KubeArmor/kubearmor ${ARMOR_OPTIONS[@]}
+    /KubeArmor/kubearmor ${ARMOR_OPTIONS[@]} &
+    pid=$!
+    wait $pid
     ERROR_CODE=$?
 
     if [ $ERROR_CODE != 0 ]; then


### PR DESCRIPTION
We passed control to KubeArmor binary, so trapping the signals didn't help, now we take control back in the script after executing

Thanks a lot @rexagod for helping me figure this out 😸 

Ref
- https://github.com/kubearmor/KubeArmor/pull/861
- https://github.com/kubearmor/KubeArmor/issues/851