### PR TITLE
Add code generation for Capabilties

### DIFF
--- a/KubeArmor/build/kubearmor-test-containerd.yaml
+++ b/KubeArmor/build/kubearmor-test-containerd.yaml
@@ -51,7 +51,21 @@ spec:
         image: kubearmor/kubearmor-init:latest
         imagePullPolicy: Never
         securityContext:
-          privileged: true
+          privileged: false
+          capabilities:
+            drop: 
+              - ALL
+            add: 
+              - SETUID 
+              - SETGID
+              - SETPCAP
+              - SYS_ADMIN
+              - SYS_PTRACE 
+              - MAC_ADMIN
+              - SYS_RESOURCE 
+              - IPC_LOCK
+              - CAP_DAC_OVERRIDE
+              - CAP_DAC_READ_SEARCH
         volumeMounts:
           - mountPath: /opt/kubearmor/BPF
             name: bpf
@@ -78,7 +92,21 @@ spec:
         image: kubearmor/kubearmor:latest
         imagePullPolicy: Never
         securityContext:
-          privileged: true
+          privileged: false
+          capabilities:
+            drop: 
+              - ALL
+            add: 
+              - SETUID 
+              - SETGID
+              - SETPCAP
+              - SYS_ADMIN
+              - SYS_PTRACE 
+              - MAC_ADMIN
+              - SYS_RESOURCE 
+              - IPC_LOCK
+              - CAP_DAC_OVERRIDE
+              - CAP_DAC_READ_SEARCH
         ports:
         - containerPort: 32767
         livenessProbe:

--- a/KubeArmor/build/kubearmor-test-crio.yaml
+++ b/KubeArmor/build/kubearmor-test-crio.yaml
@@ -51,7 +51,21 @@ spec:
         image: kubearmor/kubearmor-init:latest
         imagePullPolicy: Never
         securityContext:
-          privileged: true
+          privileged: false
+          capabilities:
+            drop: 
+              - ALL
+            add: 
+              - SETUID 
+              - SETGID
+              - SETPCAP
+              - SYS_ADMIN
+              - SYS_PTRACE 
+              - MAC_ADMIN
+              - SYS_RESOURCE 
+              - IPC_LOCK
+              - CAP_DAC_OVERRIDE
+              - CAP_DAC_READ_SEARCH
         volumeMounts:
           - mountPath: /opt/kubearmor/BPF
             name: bpf
@@ -89,7 +103,21 @@ spec:
         ports:
         - containerPort: 32767
         securityContext:
-          privileged: true
+          privileged: false
+          capabilities:
+            drop: 
+              - ALL
+            add: 
+              - SETUID 
+              - SETGID
+              - SETPCAP
+              - SYS_ADMIN
+              - SYS_PTRACE 
+              - MAC_ADMIN
+              - SYS_RESOURCE 
+              - IPC_LOCK
+              - CAP_DAC_OVERRIDE
+              - CAP_DAC_READ_SEARCH
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:

--- a/KubeArmor/build/kubearmor-test-docker.yaml
+++ b/KubeArmor/build/kubearmor-test-docker.yaml
@@ -51,7 +51,21 @@ spec:
         image: kubearmor/kubearmor-init:latest
         imagePullPolicy: Never
         securityContext:
-          privileged: true
+          privileged: false
+          capabilities:
+            drop: 
+              - ALL
+            add: 
+              - SETUID 
+              - SETGID
+              - SETPCAP
+              - SYS_ADMIN
+              - SYS_PTRACE 
+              - MAC_ADMIN
+              - SYS_RESOURCE 
+              - IPC_LOCK
+              - CAP_DAC_OVERRIDE
+              - CAP_DAC_READ_SEARCH
         volumeMounts:
           - mountPath: /opt/kubearmor/BPF
             name: bpf
@@ -78,7 +92,21 @@ spec:
         image: kubearmor/kubearmor:latest
         imagePullPolicy: Never
         securityContext:
-          privileged: true
+          privileged: false
+          capabilities:
+            drop: 
+              - ALL
+            add: 
+              - SETUID 
+              - SETGID
+              - SETPCAP
+              - SYS_ADMIN
+              - SYS_PTRACE 
+              - MAC_ADMIN
+              - SYS_RESOURCE 
+              - IPC_LOCK
+              - CAP_DAC_OVERRIDE
+              - CAP_DAC_READ_SEARCH
         ports:
         - containerPort: 32767
         livenessProbe:

--- a/KubeArmor/build/kubearmor-test-k3s.yaml
+++ b/KubeArmor/build/kubearmor-test-k3s.yaml
@@ -51,7 +51,21 @@ spec:
         image: kubearmor/kubearmor-init:latest
         imagePullPolicy: Never
         securityContext:
-          privileged: true
+          privileged: false
+          capabilities:
+            drop: 
+              - ALL
+            add: 
+              - SETUID 
+              - SETGID
+              - SETPCAP
+              - SYS_ADMIN
+              - SYS_PTRACE 
+              - MAC_ADMIN
+              - SYS_RESOURCE 
+              - IPC_LOCK
+              - CAP_DAC_OVERRIDE
+              - CAP_DAC_READ_SEARCH              
         volumeMounts:
           - mountPath: /opt/kubearmor/BPF
             name: bpf
@@ -78,7 +92,21 @@ spec:
         image: kubearmor/kubearmor:latest
         imagePullPolicy: Never
         securityContext:
-          privileged: true
+          privileged: false
+          capabilities:
+            drop: 
+              - ALL
+            add: 
+              - SETUID 
+              - SETGID
+              - SETPCAP
+              - SYS_ADMIN
+              - SYS_PTRACE 
+              - MAC_ADMIN
+              - SYS_RESOURCE 
+              - IPC_LOCK
+              - CAP_DAC_OVERRIDE
+              - CAP_DAC_READ_SEARCH
         ports:
         - containerPort: 32767
         livenessProbe:

--- a/deployments/AKS/kubearmor.yaml
+++ b/deployments/AKS/kubearmor.yaml
@@ -101,7 +101,21 @@ spec:
         ports:
         - containerPort: 32767
         securityContext:
-          privileged: true
+          privileged: false
+          capabilities:
+            drop: 
+              - ALL
+            add: 
+              - SETUID 
+              - SETGID
+              - SETPCAP
+              - SYS_ADMIN
+              - SYS_PTRACE 
+              - MAC_ADMIN
+              - SYS_RESOURCE 
+              - IPC_LOCK
+              - CAP_DAC_OVERRIDE
+              - CAP_DAC_READ_SEARCH
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:
@@ -140,7 +154,21 @@ spec:
       - image: kubearmor/kubearmor-init:latest
         name: init
         securityContext:
-          privileged: true
+          privileged: false
+          capabilities:
+            drop: 
+              - ALL
+            add: 
+              - SETUID 
+              - SETGID
+              - SETPCAP
+              - SYS_ADMIN
+              - SYS_PTRACE 
+              - MAC_ADMIN
+              - SYS_RESOURCE 
+              - IPC_LOCK
+              - CAP_DAC_OVERRIDE
+              - CAP_DAC_READ_SEARCH
         volumeMounts:
         - mountPath: /opt/kubearmor/BPF
           name: bpf

--- a/deployments/BottleRocket/kubearmor.yaml
+++ b/deployments/BottleRocket/kubearmor.yaml
@@ -102,7 +102,21 @@ spec:
         ports:
         - containerPort: 32767
         securityContext:
-          privileged: true
+          privileged: false
+          capabilities:
+            drop: 
+              - ALL
+            add: 
+              - SETUID 
+              - SETGID
+              - SETPCAP
+              - SYS_ADMIN
+              - SYS_PTRACE 
+              - MAC_ADMIN
+              - SYS_RESOURCE 
+              - IPC_LOCK
+              - CAP_DAC_OVERRIDE
+              - CAP_DAC_READ_SEARCH
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:
@@ -135,13 +149,27 @@ spec:
           name: docker-storage-path
           readOnly: true
       dnsPolicy: ClusterFirstWithHostNet
-      hostNetwork: true
+      hostNetwork: false
       hostPID: true
       initContainers:
       - image: kubearmor/kubearmor-init:latest
         name: init
         securityContext:
-          privileged: true
+          privileged: false
+          capabilities:
+            drop: 
+              - ALL
+            add: 
+              - SETUID 
+              - SETGID
+              - SETPCAP
+              - SYS_ADMIN
+              - SYS_PTRACE 
+              - MAC_ADMIN
+              - SYS_RESOURCE 
+              - IPC_LOCK
+              - CAP_DAC_OVERRIDE
+              - CAP_DAC_READ_SEARCH
         volumeMounts:
         - mountPath: /opt/kubearmor/BPF
           name: bpf

--- a/deployments/EKS/kubearmor.yaml
+++ b/deployments/EKS/kubearmor.yaml
@@ -101,7 +101,21 @@ spec:
         ports:
         - containerPort: 32767
         securityContext:
-          privileged: true
+          privileged: false
+          capabilities:
+            drop: 
+              - ALL
+            add: 
+              - SETUID 
+              - SETGID
+              - SETPCAP
+              - SYS_ADMIN
+              - SYS_PTRACE 
+              - MAC_ADMIN
+              - SYS_RESOURCE 
+              - IPC_LOCK
+              - CAP_DAC_OVERRIDE
+              - CAP_DAC_READ_SEARCH
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:
@@ -140,7 +154,21 @@ spec:
       - image: kubearmor/kubearmor-init:latest
         name: init
         securityContext:
-          privileged: true
+          privileged: false
+          capabilities:
+            drop: 
+              - ALL
+            add: 
+              - SETUID 
+              - SETGID
+              - SETPCAP
+              - SYS_ADMIN
+              - SYS_PTRACE 
+              - MAC_ADMIN
+              - SYS_RESOURCE 
+              - IPC_LOCK
+              - CAP_DAC_OVERRIDE
+              - CAP_DAC_READ_SEARCH
         volumeMounts:
         - mountPath: /opt/kubearmor/BPF
           name: bpf

--- a/deployments/GKE/kubearmor.yaml
+++ b/deployments/GKE/kubearmor.yaml
@@ -101,7 +101,21 @@ spec:
         ports:
         - containerPort: 32767
         securityContext:
-          privileged: true
+          privileged: false
+          capabilities:
+            drop: 
+              - ALL
+            add: 
+              - SETUID 
+              - SETGID
+              - SETPCAP
+              - SYS_ADMIN
+              - SYS_PTRACE 
+              - MAC_ADMIN
+              - SYS_RESOURCE 
+              - IPC_LOCK
+              - CAP_DAC_OVERRIDE
+              - CAP_DAC_READ_SEARCH
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:
@@ -134,13 +148,27 @@ spec:
           name: docker-storage-path
           readOnly: true
       dnsPolicy: ClusterFirstWithHostNet
-      hostNetwork: true
+      hostNetwork: false
       hostPID: true
       initContainers:
       - image: kubearmor/kubearmor-init:latest
         name: init
         securityContext:
           privileged: true
+          capabilities:
+            drop: 
+              - ALL
+            add: 
+              - SETUID 
+              - SETGID
+              - SETPCAP
+              - SYS_ADMIN
+              - SYS_PTRACE 
+              - MAC_ADMIN
+              - SYS_RESOURCE 
+              - IPC_LOCK
+              - CAP_DAC_OVERRIDE
+              - CAP_DAC_READ_SEARCH
         volumeMounts:
         - mountPath: /opt/kubearmor/BPF
           name: bpf

--- a/deployments/OKE/kubearmor.yaml
+++ b/deployments/OKE/kubearmor.yaml
@@ -101,7 +101,21 @@ spec:
         ports:
         - containerPort: 32767
         securityContext:
-          privileged: true
+          privileged: false
+          capabilities:
+            drop: 
+              - ALL
+            add: 
+              - SETUID 
+              - SETGID
+              - SETPCAP
+              - SYS_ADMIN
+              - SYS_PTRACE 
+              - MAC_ADMIN
+              - SYS_RESOURCE 
+              - IPC_LOCK
+              - CAP_DAC_OVERRIDE
+              - CAP_DAC_READ_SEARCH
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:
@@ -137,7 +151,21 @@ spec:
       - image: kubearmor/kubearmor-init:latest
         name: init
         securityContext:
-          privileged: true
+          privileged: false
+          capabilities:
+            drop: 
+              - ALL
+            add: 
+              - SETUID 
+              - SETGID
+              - SETPCAP
+              - SYS_ADMIN
+              - SYS_PTRACE 
+              - MAC_ADMIN
+              - SYS_RESOURCE 
+              - IPC_LOCK
+              - CAP_DAC_OVERRIDE
+              - CAP_DAC_READ_SEARCH
         volumeMounts:
         - mountPath: /opt/kubearmor/BPF
           name: bpf

--- a/deployments/docker/kubearmor.yaml
+++ b/deployments/docker/kubearmor.yaml
@@ -101,7 +101,21 @@ spec:
         ports:
         - containerPort: 32767
         securityContext:
-          privileged: true
+          privileged: false
+          capabilities:
+            drop: 
+              - ALL
+            add: 
+              - SETUID 
+              - SETGID
+              - SETPCAP
+              - SYS_ADMIN
+              - SYS_PTRACE 
+              - MAC_ADMIN
+              - SYS_RESOURCE 
+              - IPC_LOCK
+              - CAP_DAC_OVERRIDE
+              - CAP_DAC_READ_SEARCH
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:
@@ -137,7 +151,21 @@ spec:
       - image: kubearmor/kubearmor-init:latest
         name: init
         securityContext:
-          privileged: true
+          privileged: false
+          capabilities:
+            drop: 
+              - ALL
+            add: 
+              - SETUID 
+              - SETGID
+              - SETPCAP
+              - SYS_ADMIN
+              - SYS_PTRACE 
+              - MAC_ADMIN
+              - SYS_RESOURCE 
+              - IPC_LOCK
+              - CAP_DAC_OVERRIDE
+              - CAP_DAC_READ_SEARCH
         volumeMounts:
         - mountPath: /opt/kubearmor/BPF
           name: bpf

--- a/deployments/generic/kubearmor.yaml
+++ b/deployments/generic/kubearmor.yaml
@@ -101,7 +101,21 @@ spec:
         ports:
         - containerPort: 32767
         securityContext:
-          privileged: true
+          privileged: false
+          capabilities:
+            drop: 
+              - ALL
+            add: 
+              - SETUID 
+              - SETGID
+              - SETPCAP
+              - SYS_ADMIN
+              - SYS_PTRACE 
+              - MAC_ADMIN
+              - SYS_RESOURCE 
+              - IPC_LOCK
+              - CAP_DAC_OVERRIDE
+              - CAP_DAC_READ_SEARCH
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:
@@ -140,7 +154,21 @@ spec:
       - image: kubearmor/kubearmor-init:latest
         name: init
         securityContext:
-          privileged: true
+          privileged: false
+          capabilities:
+            drop: 
+              - ALL
+            add: 
+              - SETUID 
+              - SETGID
+              - SETPCAP
+              - SYS_ADMIN
+              - SYS_PTRACE 
+              - MAC_ADMIN
+              - SYS_RESOURCE 
+              - IPC_LOCK
+              - CAP_DAC_OVERRIDE
+              - CAP_DAC_READ_SEARCH
         volumeMounts:
         - mountPath: /opt/kubearmor/BPF
           name: bpf

--- a/deployments/get/objects.go
+++ b/deployments/get/objects.go
@@ -383,7 +383,7 @@ func GenerateDaemonSet(env, namespace string) *appsv1.DaemonSet {
 	var label = map[string]string{
 		"kubearmor-app": kubearmor,
 	}
-	var privileged = bool(true)
+	var privileged = bool(false)
 	var terminationGracePeriodSeconds = int64(30)
 	var args = []string{
 		"-gRPC=" + strconv.Itoa(int(port)),
@@ -527,6 +527,23 @@ func GenerateDaemonSet(env, namespace string) *appsv1.DaemonSet {
 							Image: "kubearmor/kubearmor-init:latest",
 							SecurityContext: &corev1.SecurityContext{
 								Privileged: &privileged,
+								Capabilities: &corev1.Capabilities{
+									Drop: []corev1.Capability{
+										"ALL",
+									},
+									Add: []corev1.Capability{
+										"SETUID",
+										"SETGID",
+										"SETPCAP",
+										"SYS_ADMIN",
+										"SYS_PTRACE",
+										"MAC_ADMIN",
+										"SYS_RESOURCE",
+										"IPC_LOCK",
+										"CAP_DAC_OVERRIDE",
+										"CAP_DAC_READ_SEARCH",
+									},
+								},
 							},
 							VolumeMounts: containerVolumeMounts,
 						},
@@ -538,6 +555,23 @@ func GenerateDaemonSet(env, namespace string) *appsv1.DaemonSet {
 							ImagePullPolicy: "Always",
 							SecurityContext: &corev1.SecurityContext{
 								Privileged: &privileged,
+								Capabilities: &corev1.Capabilities{
+									Drop: []corev1.Capability{
+										"ALL",
+									},
+									Add: []corev1.Capability{
+										"SETUID",
+										"SETGID",
+										"SETPCAP",
+										"SYS_ADMIN",
+										"SYS_PTRACE",
+										"MAC_ADMIN",
+										"SYS_RESOURCE",
+										"IPC_LOCK",
+										"CAP_DAC_OVERRIDE",
+										"CAP_DAC_READ_SEARCH",
+									},
+								},
 							},
 							Args: args,
 							Env:  envs,

--- a/deployments/k3s/kubearmor.yaml
+++ b/deployments/k3s/kubearmor.yaml
@@ -102,6 +102,20 @@ spec:
         - containerPort: 32767
         securityContext:
           privileged: true
+          capabilities:
+            drop: 
+              - ALL
+            add: 
+              - SETUID 
+              - SETGID
+              - SETPCAP
+              - SYS_ADMIN
+              - SYS_PTRACE 
+              - MAC_ADMIN
+              - SYS_RESOURCE 
+              - IPC_LOCK
+              - CAP_DAC_OVERRIDE
+              - CAP_DAC_READ_SEARCH
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:
@@ -131,13 +145,27 @@ spec:
           name: containerd-storage-path
           readOnly: true
       dnsPolicy: ClusterFirstWithHostNet
-      hostNetwork: true
+      hostNetwork: false
       hostPID: true
       initContainers:
       - image: kubearmor/kubearmor-init:latest
         name: init
         securityContext:
-          privileged: true
+          privileged: false
+          capabilities:
+            drop: 
+              - ALL
+            add: 
+              - SETUID 
+              - SETGID
+              - SETPCAP
+              - SYS_ADMIN
+              - SYS_PTRACE 
+              - MAC_ADMIN
+              - SYS_RESOURCE 
+              - IPC_LOCK
+              - CAP_DAC_OVERRIDE
+              - CAP_DAC_READ_SEARCH
         volumeMounts:
         - mountPath: /opt/kubearmor/BPF
           name: bpf

--- a/deployments/microk8s/kubearmor.yaml
+++ b/deployments/microk8s/kubearmor.yaml
@@ -101,7 +101,21 @@ spec:
         ports:
         - containerPort: 32767
         securityContext:
-          privileged: true
+          privileged: false
+          capabilities:
+            drop: 
+              - ALL
+            add: 
+              - SETUID 
+              - SETGID
+              - SETPCAP
+              - SYS_ADMIN
+              - SYS_PTRACE 
+              - MAC_ADMIN
+              - SYS_RESOURCE 
+              - IPC_LOCK
+              - CAP_DAC_OVERRIDE
+              - CAP_DAC_READ_SEARCH
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:
@@ -137,7 +151,21 @@ spec:
       - image: kubearmor/kubearmor-init:latest
         name: init
         securityContext:
-          privileged: true
+          privileged: false
+          capabilities:
+            drop: 
+              - ALL
+            add: 
+              - SETUID 
+              - SETGID
+              - SETPCAP
+              - SYS_ADMIN
+              - SYS_PTRACE 
+              - MAC_ADMIN
+              - SYS_RESOURCE 
+              - IPC_LOCK
+              - CAP_DAC_OVERRIDE
+              - CAP_DAC_READ_SEARCH
         volumeMounts:
         - mountPath: /opt/kubearmor/BPF
           name: bpf

--- a/deployments/minikube/kubearmor.yaml
+++ b/deployments/minikube/kubearmor.yaml
@@ -100,7 +100,21 @@ spec:
         ports:
         - containerPort: 32767
         securityContext:
-          privileged: true
+          privileged: false
+          capabilities:
+            drop: 
+              - ALL
+            add: 
+              - SETUID 
+              - SETGID
+              - SETPCAP
+              - SYS_ADMIN
+              - SYS_PTRACE 
+              - MAC_ADMIN
+              - SYS_RESOURCE 
+              - IPC_LOCK
+              - CAP_DAC_OVERRIDE
+              - CAP_DAC_READ_SEARCH
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:
@@ -136,7 +150,21 @@ spec:
       - image: kubearmor/kubearmor-init:latest
         name: init
         securityContext:
-          privileged: true
+          privileged: false
+          capabilities:
+            drop: 
+              - ALL
+            add: 
+              - SETUID 
+              - SETGID
+              - SETPCAP
+              - SYS_ADMIN
+              - SYS_PTRACE 
+              - MAC_ADMIN
+              - SYS_RESOURCE 
+              - IPC_LOCK
+              - CAP_DAC_OVERRIDE
+              - CAP_DAC_READ_SEARCH
         volumeMounts:
         - mountPath: /opt/kubearmor/BPF
           name: bpf


### PR DESCRIPTION
This PR handles 
- remove `privileged: true` from Daemonset
- generation of manifest for Linux Capabilities in Daemonset
