### PR TITLE
Fixes #769 Ignore empty policy in Kubeamor

### DIFF
--- a/KubeArmor/enforcer/appArmorTemplate.go
+++ b/KubeArmor/enforcer/appArmorTemplate.go
@@ -61,7 +61,7 @@ func (p *Profile) Init() {
 
 // Inspired from https://github.com/genuinetools/bane/blob/master/apparmor/template.go
 
-//BaseTemplate for AppArmor profiles
+// BaseTemplate for AppArmor profiles
 const BaseTemplate = `
 ## == Managed by KubeArmor == ##
 

--- a/KubeArmor/policy/policy.go
+++ b/KubeArmor/policy/policy.go
@@ -25,9 +25,22 @@ func (p *ServiceServer) ContainerPolicy(c context.Context, data *pb.Policy) (*pb
 	res := new(pb.Response)
 
 	err := json.Unmarshal(data.Policy, &policyEvent)
+
 	if err == nil {
-		p.UpdateContainerPolicy(policyEvent)
-		res.Status = 1
+
+		if policyEvent.Object.Metadata.Name != "" {
+
+			p.UpdateContainerPolicy(policyEvent)
+
+			res.Status = 1
+
+		} else {
+
+			kg.Warn("Empty Container Policy Event")
+
+			res.Status = 0
+		}
+
 	} else {
 		kg.Warn("Invalid Container Policy Event")
 		res.Status = 0
@@ -38,13 +51,27 @@ func (p *ServiceServer) ContainerPolicy(c context.Context, data *pb.Policy) (*pb
 
 // HostPolicy accepts host policy event on gRPC service and updates host security policies. It responds with 1 if success else 0.
 func (p *ServiceServer) HostPolicy(c context.Context, data *pb.Policy) (*pb.Response, error) {
+
 	policyEvent := tp.K8sKubeArmorHostPolicyEvent{}
 	res := new(pb.Response)
 
 	err := json.Unmarshal(data.Policy, &policyEvent)
 	if err == nil {
-		p.UpdateHostPolicy(policyEvent)
-		res.Status = 1
+
+		if policyEvent.Object.Metadata.Name != "" {
+
+			p.UpdateHostPolicy(policyEvent)
+
+			res.Status = 1
+
+		} else {
+
+			kg.Warn("Empty Host Policy Event")
+
+			res.Status = 0
+
+		}
+
 	} else {
 		kg.Warn("Invalid Host Policy Event")
 		res.Status = 0

--- a/pkg/KubeArmorController/api/v1/groupversion_info.go
+++ b/pkg/KubeArmorController/api/v1/groupversion_info.go
@@ -2,8 +2,8 @@
 // Copyright 2022 Authors of KubeArmor
 
 // Package v1 contains API Schema definitions for the security v1 API group
-//+kubebuilder:object:generate=true
-//+groupName=security.kubearmor.com
+// +kubebuilder:object:generate=true
+// +groupName=security.kubearmor.com
 package v1
 
 import (

--- a/pkg/KubeArmorHostPolicy/client/clientset/versioned/fake/register.go
+++ b/pkg/KubeArmorHostPolicy/client/clientset/versioned/fake/register.go
@@ -24,14 +24,14 @@ var localSchemeBuilder = runtime.SchemeBuilder{
 // AddToScheme adds all types of this clientset into the given scheme. This allows composition
 // of clientsets, like in:
 //
-//   import (
-//     "k8s.io/client-go/kubernetes"
-//     clientsetscheme "k8s.io/client-go/kubernetes/scheme"
-//     aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
-//   )
+//	import (
+//	  "k8s.io/client-go/kubernetes"
+//	  clientsetscheme "k8s.io/client-go/kubernetes/scheme"
+//	  aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
+//	)
 //
-//   kclientset, _ := kubernetes.NewForConfig(c)
-//   _ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
+//	kclientset, _ := kubernetes.NewForConfig(c)
+//	_ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
 //
 // After this, RawExtensions in Kubernetes types will serialize kube-aggregator types
 // correctly.

--- a/pkg/KubeArmorHostPolicy/client/clientset/versioned/scheme/register.go
+++ b/pkg/KubeArmorHostPolicy/client/clientset/versioned/scheme/register.go
@@ -24,14 +24,14 @@ var localSchemeBuilder = runtime.SchemeBuilder{
 // AddToScheme adds all types of this clientset into the given scheme. This allows composition
 // of clientsets, like in:
 //
-//   import (
-//     "k8s.io/client-go/kubernetes"
-//     clientsetscheme "k8s.io/client-go/kubernetes/scheme"
-//     aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
-//   )
+//	import (
+//	  "k8s.io/client-go/kubernetes"
+//	  clientsetscheme "k8s.io/client-go/kubernetes/scheme"
+//	  aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
+//	)
 //
-//   kclientset, _ := kubernetes.NewForConfig(c)
-//   _ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
+//	kclientset, _ := kubernetes.NewForConfig(c)
+//	_ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
 //
 // After this, RawExtensions in Kubernetes types will serialize kube-aggregator types
 // correctly.

--- a/pkg/KubeArmorPolicy/client/clientset/versioned/fake/register.go
+++ b/pkg/KubeArmorPolicy/client/clientset/versioned/fake/register.go
@@ -24,14 +24,14 @@ var localSchemeBuilder = runtime.SchemeBuilder{
 // AddToScheme adds all types of this clientset into the given scheme. This allows composition
 // of clientsets, like in:
 //
-//   import (
-//     "k8s.io/client-go/kubernetes"
-//     clientsetscheme "k8s.io/client-go/kubernetes/scheme"
-//     aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
-//   )
+//	import (
+//	  "k8s.io/client-go/kubernetes"
+//	  clientsetscheme "k8s.io/client-go/kubernetes/scheme"
+//	  aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
+//	)
 //
-//   kclientset, _ := kubernetes.NewForConfig(c)
-//   _ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
+//	kclientset, _ := kubernetes.NewForConfig(c)
+//	_ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
 //
 // After this, RawExtensions in Kubernetes types will serialize kube-aggregator types
 // correctly.

--- a/pkg/KubeArmorPolicy/client/clientset/versioned/scheme/register.go
+++ b/pkg/KubeArmorPolicy/client/clientset/versioned/scheme/register.go
@@ -24,14 +24,14 @@ var localSchemeBuilder = runtime.SchemeBuilder{
 // AddToScheme adds all types of this clientset into the given scheme. This allows composition
 // of clientsets, like in:
 //
-//   import (
-//     "k8s.io/client-go/kubernetes"
-//     clientsetscheme "k8s.io/client-go/kubernetes/scheme"
-//     aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
-//   )
+//	import (
+//	  "k8s.io/client-go/kubernetes"
+//	  clientsetscheme "k8s.io/client-go/kubernetes/scheme"
+//	  aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
+//	)
 //
-//   kclientset, _ := kubernetes.NewForConfig(c)
-//   _ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
+//	kclientset, _ := kubernetes.NewForConfig(c)
+//	_ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
 //
 // After this, RawExtensions in Kubernetes types will serialize kube-aggregator types
 // correctly.


### PR DESCRIPTION
~~I wrote a check for host policy and container policy. I placed them in the kubeamor/common/common.go file and imported them in the kubeamor/policy/policy.go file. If the policy file is empty, res.status is assigned 0, container policy is not updated and then there would be a warning log with message, "Empty policy Event" . The function~~

Does not apply anymore

Fixes #769 