### PR TITLE
Updating Karts package name 

### DIFF
--- a/tests/go.mod
+++ b/tests/go.mod
@@ -1,4 +1,4 @@
-module github.com/kubearmor/karts
+module github.com/kubearmor/KubeArmor/tests
 
 go 1.18
 

--- a/tests/smoke/smoke_test.go
+++ b/tests/smoke/smoke_test.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"time"
 
-	. "github.com/kubearmor/karts/util"
+	. "github.com/kubearmor/KubeArmor/tests/util"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )

--- a/tests/syscalls/syscalls_test.go
+++ b/tests/syscalls/syscalls_test.go
@@ -6,7 +6,7 @@ package syscalls
 import (
 	"time"
 
-	. "github.com/kubearmor/karts/util"
+	. "github.com/kubearmor/KubeArmor/tests/util"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )


### PR DESCRIPTION
Currently we have this module `github.com/kubearmor/karts`, but I wanted it to be accessible in other repos, for example in kubearmor-client, so that I may be able to use it there. I was not able to get the current Karts package there. Now it should be visible as a Go package that can be used anywhere. 

cc @daemon1024  