### PR TITLE
fix capabilities allow policy bug

### DIFF
--- a/KubeArmor/enforcer/appArmorProfile.go
+++ b/KubeArmor/enforcer/appArmorProfile.go
@@ -255,7 +255,7 @@ func (ae *AppArmorEnforcer) SetNetworkMatchProtocols(proto tp.NetworkProtocolTyp
 // SetCapabilitiesMatchCapabilities Function
 func (ae *AppArmorEnforcer) SetCapabilitiesMatchCapabilities(cap tp.CapabilitiesCapabilityType, prof *Profile, deny bool) {
 	if deny == false {
-		prof.Network = false
+		prof.Capabilities = false
 	}
 	rule := RuleConfig{}
 	rule.Deny = deny


### PR DESCRIPTION
Capability whitelist rules disabled network instead of caps due to the typo

Thank You @aishwarya25252 for reporting this.