### PR TITLE
enforcer: fix directory rule behaviour

### DIFF
--- a/KubeArmor/enforcer/appArmorTemplate.go
+++ b/KubeArmor/enforcer/appArmorTemplate.go
@@ -80,7 +80,7 @@ profile {{.Name}} flags=(attach_disconnected,mediate_deleted) {
 	## == PRE END == ##
 
 	## == POLICY START == ##
-{{range $value, $data := .FilePaths}}{{$suffix := ""}}{{if and $data.Dir $data.Recursive}}{{$suffix = "**"}}{{else if $data.Dir}}{{$suffix = "*"}}{{end}}{{if $data.Deny}}{{if and $data.ReadOnly $data.OwnerOnly}}
+{{range $value, $data := .FilePaths}}{{$suffix := ""}}{{if and $data.Dir $data.Recursive}}{{$suffix = "{,**}"}}{{else if $data.Dir}}{{$suffix = "{,*}"}}{{end}}{{if $data.Deny}}{{if and $data.ReadOnly $data.OwnerOnly}}
 	deny owner {{$value}}{{$suffix}} w,
 	deny other {{$value}}{{$suffix}} rw,
 {{else if $data.OwnerOnly}}	owner {{$value}}{{$suffix}} rw,
@@ -92,7 +92,7 @@ profile {{.Name}} flags=(attach_disconnected,mediate_deleted) {
 {{else if $data.ReadOnly}}	{{$value}}{{$suffix}} r,
 {{else}}	{{$value}}{{$suffix}} rw,
 {{end}}{{end}}{{end}}
-{{range $value, $data := .ProcessPaths}}{{$suffix := ""}}{{if and $data.Dir $data.Recursive}}{{$suffix = "**"}}{{else if $data.Dir}}{{$suffix = "*"}}{{end}}{{if $data.Deny}}{{if $data.OwnerOnly}}
+{{range $value, $data := .ProcessPaths}}{{$suffix := ""}}{{if and $data.Dir $data.Recursive}}{{$suffix = "{,**}"}}{{else if $data.Dir}}{{$suffix = "{,*}"}}{{end}}{{if $data.Deny}}{{if $data.OwnerOnly}}
 	owner {{$value}}{{$suffix}} ix,
 	deny other {{$value}}{{$suffix}} x,{{else}}
 	deny {{$value}}{{$suffix}} x,{{end}}{{end}}{{if $data.Allow}}{{if $data.OwnerOnly}}
@@ -121,7 +121,7 @@ profile {{.Name}} flags=(attach_disconnected,mediate_deleted) {
 		## == PRE END == ##
 	
 		## == POLICY START == ##
-	{{range $value, $data := .FilePaths}}{{$suffix := ""}}{{if and $data.Dir $data.Recursive}}{{$suffix = "**"}}{{else if $data.Dir}}{{$suffix = "*"}}{{end}}{{if $data.Deny}}{{if and $data.ReadOnly $data.OwnerOnly}}
+	{{range $value, $data := .FilePaths}}{{$suffix := ""}}{{if and $data.Dir $data.Recursive}}{{$suffix = "{,**}"}}{{else if $data.Dir}}{{$suffix = "{,*}"}}{{end}}{{if $data.Deny}}{{if and $data.ReadOnly $data.OwnerOnly}}
 		deny owner {{$value}}{{$suffix}} w,
 		deny other {{$value}}{{$suffix}} rw,
 	{{else if $data.OwnerOnly}}	owner {{$value}}{{$suffix}} rw,
@@ -133,7 +133,7 @@ profile {{.Name}} flags=(attach_disconnected,mediate_deleted) {
 	{{else if $data.ReadOnly}}	{{$value}}{{$suffix}} r,
 	{{else}}	{{$value}}{{$suffix}} rw,
 	{{end}}{{end}}{{end}}
-	{{range $value, $data := .ProcessPaths}}{{$suffix := ""}}{{if and $data.Dir $data.Recursive}}{{$suffix = "**"}}{{else if $data.Dir}}{{$suffix = "*"}}{{end}}{{if $data.Deny}}{{if $data.OwnerOnly}}
+	{{range $value, $data := .ProcessPaths}}{{$suffix := ""}}{{if and $data.Dir $data.Recursive}}{{$suffix = "{,**}"}}{{else if $data.Dir}}{{$suffix = "{,*}"}}{{end}}{{if $data.Deny}}{{if $data.OwnerOnly}}
 		owner {{$value}}{{$suffix}} ix,
 		deny other {{$value}}{{$suffix}} x,{{else}}
 		deny {{$value}}{{$suffix}} x,{{end}}{{end}}{{if $data.Allow}}{{if $data.OwnerOnly}}

--- a/KubeArmor/enforcer/bpflsm/enforcer.go
+++ b/KubeArmor/enforcer/bpflsm/enforcer.go
@@ -61,7 +61,7 @@ func NewBPFEnforcer(node tp.Node, logger *fd.Feeder) (*BPFEnforcer, error) {
 		Type:       ebpf.Hash,
 		KeySize:    512,
 		ValueSize:  2,
-		MaxEntries: 128,
+		MaxEntries: 256,
 	}
 
 	be.BPFContainerMap, err = ebpf.NewMapWithOptions(&ebpf.MapSpec{


### PR DESCRIPTION
AppArmor `**` or `*` rule doesn't include the directory itself. Taking an example of ps and proc. ps tries to access the `proc` directory itself before reading the underlying directories. When we save allow ps -> /proc/**, it didn't include the /proc/ directory itself so we update the directory rule to include both directory itself and the recursive pattern identifier.
Now we would use /proc/{,**}. `{}` signifies alternation and we provide it with to either match recursively (**) or the dir itself (empty string) 

BPFLSM kernel space refers to /proc/ as /proc since everything is a file. So we added a additional file rule from userspace when we need to deal with Directory Rules.