### PR TITLE
added keys to GetOptions function struct

### DIFF
--- a/tests/util/kartutil.go
+++ b/tests/util/kartutil.go
@@ -40,10 +40,10 @@ func isK8sEnv() bool {
 
 func getOptions() kins.Options {
 	return kins.Options{
-		"kube-system",
-		"kubearmor/kubearmor:stable",
-		"",
-		false,
+		Namespace:      "kube-system",
+		KubearmorImage: "kubearmor/kubearmor:stable",
+		Audit:          "",
+		Force:          false,
 	}
 }
 


### PR DESCRIPTION
Options in the install packages has new Fields. kartutil is linked to an older install package so it works with the less number of fields. But when you import it to kubearmor-client, client is bound with updated install package so it fails to build when importing the `tests` package.

This fixes it by putting the keys.