### PR TITLE
copy ignore list to BPF module

### DIFF
--- a/KubeArmor/build/compile.sh
+++ b/KubeArmor/build/compile.sh
@@ -12,3 +12,4 @@ else
 fi
 
 cp *.bpf.o /opt/kubearmor/BPF/
+cp *.bpf.o ignore.lst /opt/kubearmor/BPF/

--- a/KubeArmor/build/compile.sh
+++ b/KubeArmor/build/compile.sh
@@ -11,5 +11,4 @@ else
     make
 fi
 
-cp *.bpf.o /opt/kubearmor/BPF/
 cp *.bpf.o ignore.lst /opt/kubearmor/BPF/


### PR DESCRIPTION
kubearmor will require this information inside container image at the time of loading ebpf based system monitor. 

Signed-off-by: rksharma95 <ramakant@accuknox.com>