### PR TITLE
add klm

### DIFF
--- a/KubeArmor/enforcer/appArmorTemplate.go
+++ b/KubeArmor/enforcer/appArmorTemplate.go
@@ -122,16 +122,16 @@ profile {{.Name}} flags=(attach_disconnected,mediate_deleted) {
 	
 		## == POLICY START == ##
 	{{range $value, $data := .FilePaths}}{{$suffix := ""}}{{if and $data.Dir $data.Recursive}}{{$suffix = "{,**}"}}{{else if $data.Dir}}{{$suffix = "{,*}"}}{{end}}{{if $data.Deny}}{{if and $data.ReadOnly $data.OwnerOnly}}
-		deny owner {{$value}}{{$suffix}} w,
-		deny other {{$value}}{{$suffix}} rw,
-	{{else if $data.OwnerOnly}}	owner {{$value}}{{$suffix}} rw,
-		deny other {{$value}}{{$suffix}} rw,
-	{{else if $data.ReadOnly}}	deny {{$value}}{{$suffix}} w,
-	{{else}}	deny {{$value}}{{$suffix}} rw,{{end}}
-	{{end}}{{if $data.Allow}}{{if and $data.ReadOnly $data.OwnerOnly}}	owner {{$value}}{{$suffix}} r,
-	{{else if $data.OwnerOnly}}	owner {{$value}}{{$suffix}} rw,
-	{{else if $data.ReadOnly}}	{{$value}}{{$suffix}} r,
-	{{else}}	{{$value}}{{$suffix}} rw,
+		deny owner {{$value}}{{$suffix}} klw,
+		deny other {{$value}}{{$suffix}} klmrw,
+	{{else if $data.OwnerOnly}}	owner {{$value}}{{$suffix}} klmrw,
+		deny other {{$value}}{{$suffix}} klmrw,
+	{{else if $data.ReadOnly}}	deny {{$value}}{{$suffix}} klw,
+	{{else}}	deny {{$value}}{{$suffix}} klmrw,{{end}}
+	{{end}}{{if $data.Allow}}{{if and $data.ReadOnly $data.OwnerOnly}}	owner {{$value}}{{$suffix}} lmr,
+	{{else if $data.OwnerOnly}}	owner {{$value}}{{$suffix}} klmrw,
+	{{else if $data.ReadOnly}}	{{$value}}{{$suffix}} lmr,
+	{{else}}	{{$value}}{{$suffix}} klmrw,
 	{{end}}{{end}}{{end}}
 	{{range $value, $data := .ProcessPaths}}{{$suffix := ""}}{{if and $data.Dir $data.Recursive}}{{$suffix = "{,**}"}}{{else if $data.Dir}}{{$suffix = "{,*}"}}{{end}}{{if $data.Deny}}{{if $data.OwnerOnly}}
 		owner {{$value}}{{$suffix}} ix,


### PR DESCRIPTION
add `klm` flag to the generated AppArmor profile:
r - read - permission to read data
w - write - permission to create, delete, write to a file and extend it
a - append - permission to create, and extend a file. The append permission is limited that it only gives permission for applications to open a file with O_APPEND, it can not be used to enforce a generic file write is append only. If an application only has the append permission in the profile and it tries to write to the file even if it is an appending write, the write will be failed.
l - link - permission to link to a file (combined with /** to determine if permissions apply to subtree)
k - lock - permission to lock a file, is combined with write perm to determine if it has permission to take exclusive lock
m - memory map executable - permission to memory map a file executable
x - executable - determines if a file is executable, allow forms of the rule must be accompanied by x qualifiers. When specified as part of an allow rule it must be accompanied by qualifiers.
