### PR TITLE
fix(CI): increase build & push CI timeout

### DIFF
--- a/.github/workflows/ci-controllers-release.yml
+++ b/.github/workflows/ci-controllers-release.yml
@@ -41,7 +41,7 @@ jobs:
         working-directory: ./pkg/KubeArmorAnnotation
     if: needs.check.outputs.annotation == 'true'
     runs-on: ubuntu-20.04
-    timeout-minutes: 20
+    timeout-minutes: 40
     steps:
       - uses: actions/setup-go@v3
         with:
@@ -74,7 +74,7 @@ jobs:
         working-directory: ./pkg/KubeArmorHostPolicy
     if: needs.check.outputs.hostpolicy == 'true'
     runs-on: ubuntu-20.04
-    timeout-minutes: 20
+    timeout-minutes: 40
     steps:
       - uses: actions/setup-go@v3
         with:
@@ -107,7 +107,7 @@ jobs:
         working-directory: ./pkg/KubeArmorPolicy
     if: needs.check.outputs.policy == 'true'
     runs-on: ubuntu-20.04
-    timeout-minutes: 20
+    timeout-minutes: 40
     steps:
       - uses: actions/setup-go@v3
         with:

--- a/.github/workflows/ci-latest-release.yml
+++ b/.github/workflows/ci-latest-release.yml
@@ -21,7 +21,7 @@ jobs:
     name: Create KubeArmor latest release
     if: github.repository == 'kubearmor/kubearmor'
     runs-on: ubuntu-20.04
-    timeout-minutes: 20
+    timeout-minutes: 40
     steps:
       - uses: actions/checkout@v3
         with:
@@ -85,7 +85,7 @@ jobs:
     needs: build
     if: github.ref != 'refs/heads/main'
     runs-on: ubuntu-20.04
-    timeout-minutes: 20
+    timeout-minutes: 40
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/ci-stable-release.yml
+++ b/.github/workflows/ci-stable-release.yml
@@ -12,7 +12,7 @@ jobs:
     name: Create KubeArmor stable release
     if: github.repository == 'kubearmor/kubearmor'
     runs-on: ubuntu-20.04
-    timeout-minutes: 20
+    timeout-minutes: 40
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
**Purpose of PR?**: Current CI timeout is 20 minutes, it works fine for the old build & push logic. but now that we are cross building docker images for diffrent CPU architectures, we need ti increase it as we started to see jobs getting canceled due to timeout.

Fixes #

**Does this PR introduce a breaking change?**

**If the changes in this PR are manually verified, list down the scenarios covered:**:

**Additional information for reviewer?** :
Continuation of https://github.com/kubearmor/KubeArmor/pull/975


**Checklist:**
- [ ] Bug fix. Fixes #<issue number>
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Commit has unit tests
- [ ] Commit has integration tests

<!--

The PR title message must follow convention:
`<type>(<scope>): <subject>`.

Where: <br />
- `type` is to define what type of PR is this.
  Most common types are:
    - `feat`      - for new features, not a new feature for build script
    - `fix`       - for bug fixes or improvements, not a fix for build script
    - `chore`     - changes not related to production code
    - `docs`      - changes related to documentation
    - `style`     - formatting, missing semi colons, linting fix etc; no significant production code changes
    - `test`      - adding missing tests, refactoring tests; no production code change
    - `refactor`  - refactoring production code, eg. renaming a variable or function name, there should not be any significant production code changes

- `scope` is a single word that best describes where the changes fit.
    - feature(`monitor`,`enforcer`)
    - test(`tests`, `bdd`)
    - chore(`build`)
- `subject` is a single line brief description of the changes made in the pull request.

-->