### PR TITLE
feat(enforcer): update default posture to audit

### DIFF
--- a/KubeArmor/Makefile
+++ b/KubeArmor/Makefile
@@ -43,7 +43,7 @@ run: build
 	cd $(CURDIR); sudo rm -f /tmp/kubearmor.log
 	cd $(CURDIR)/BPF; make clean
 	cd $(CURDIR)/BPF; make
-	cd $(CURDIR); sudo -E ./kubearmor -logPath=/tmp/kubearmor.log -enableKubeArmorPolicy -enableKubeArmorHostPolicy -hostVisibility=process,file,network,capabilities
+	cd $(CURDIR); sudo -E ./kubearmor -logPath=/tmp/kubearmor.log -enableKubeArmorPolicy -enableKubeArmorHostPolicy -hostVisibility=process,file,network,capabilities -defaultFilePosture block -defaultCapabilitiesPosture block -defaultNetworkPosture block -hostDefaultFilePosture block -hostDefaultCapabilitiesPosture block -hostDefaultNetworkPosture block
 
 .PHONY: run-container
 run-container: build

--- a/KubeArmor/build/kubearmor-test-containerd.yaml
+++ b/KubeArmor/build/kubearmor-test-containerd.yaml
@@ -89,6 +89,12 @@ spec:
         - -gRPC=32767
         - -logPath=/tmp/kubearmor.log
         - -enableKubeArmorHostPolicy
+        - -defaultFilePosture=block
+        - -defaultCapabilitiesPosture=block
+        - -defaultNetworkPosture=block
+        - -hostDefaultCapabilitiesPosture=block
+        - -hostDefaultNetworkPosture=block
+        - -hostDefaultFilePosture=block
         image: kubearmor/kubearmor:latest
         imagePullPolicy: Never
         securityContext:

--- a/KubeArmor/build/kubearmor-test-crio.yaml
+++ b/KubeArmor/build/kubearmor-test-crio.yaml
@@ -89,6 +89,12 @@ spec:
         - -gRPC=32767
         - -logPath=/tmp/kubearmor.log
         - -enableKubeArmorHostPolicy
+        - -defaultFilePosture=block
+        - -defaultCapabilitiesPosture=block
+        - -defaultNetworkPosture=block
+        - -hostDefaultCapabilitiesPosture=block
+        - -hostDefaultNetworkPosture=block
+        - -hostDefaultFilePosture=block
         image: kubearmor/kubearmor:latest
         imagePullPolicy: Never
         livenessProbe:

--- a/KubeArmor/build/kubearmor-test-docker.yaml
+++ b/KubeArmor/build/kubearmor-test-docker.yaml
@@ -89,6 +89,12 @@ spec:
         - -gRPC=32767
         - -logPath=/tmp/kubearmor.log
         - -enableKubeArmorHostPolicy
+        - -defaultFilePosture=block
+        - -defaultCapabilitiesPosture=block
+        - -defaultNetworkPosture=block
+        - -hostDefaultCapabilitiesPosture=block
+        - -hostDefaultNetworkPosture=block
+        - -hostDefaultFilePosture=block
         image: kubearmor/kubearmor:latest
         imagePullPolicy: Never
         securityContext:

--- a/KubeArmor/build/kubearmor-test-k3s.yaml
+++ b/KubeArmor/build/kubearmor-test-k3s.yaml
@@ -89,6 +89,12 @@ spec:
         - -gRPC=32767
         - -logPath=/tmp/kubearmor.log
         - -enableKubeArmorHostPolicy
+        - -defaultFilePosture=block
+        - -defaultCapabilitiesPosture=block
+        - -defaultNetworkPosture=block
+        - -hostDefaultCapabilitiesPosture=block
+        - -hostDefaultNetworkPosture=block
+        - -hostDefaultFilePosture=block
         image: kubearmor/kubearmor:latest
         imagePullPolicy: Never
         securityContext:

--- a/KubeArmor/config/config.go
+++ b/KubeArmor/config/config.go
@@ -133,13 +133,13 @@ func readCmdLineParams() {
 	kvmAgentB := flag.Bool(ConfigKubearmorVM, false, "enabling KubeArmorVM")
 	k8sEnvB := flag.Bool(ConfigK8sEnv, true, "is k8s env?")
 
-	defaultFilePosture := flag.String(ConfigDefaultFilePosture, "block", "configuring default enforcement action in global file context {allow|audit|block}")
-	defaultNetworkPosture := flag.String(ConfigDefaultNetworkPosture, "block", "configuring default enforcement action in global network context {allow|audit|block}")
-	defaultCapabilitiesPosture := flag.String(ConfigDefaultCapabilitiesPosture, "block", "configuring default enforcement action in global capability context {allow|audit|block}")
+	defaultFilePosture := flag.String(ConfigDefaultFilePosture, "audit", "configuring default enforcement action in global file context {allow|audit|block}")
+	defaultNetworkPosture := flag.String(ConfigDefaultNetworkPosture, "audit", "configuring default enforcement action in global network context {allow|audit|block}")
+	defaultCapabilitiesPosture := flag.String(ConfigDefaultCapabilitiesPosture, "audit", "configuring default enforcement action in global capability context {allow|audit|block}")
 
-	hostDefaultFilePosture := flag.String(ConfigHostDefaultFilePosture, "block", "configuring default enforcement action in global file context {allow|audit|block}")
-	hostDefaultNetworkPosture := flag.String(ConfigHostDefaultNetworkPosture, "block", "configuring default enforcement action in global network context {allow|audit|block}")
-	hostDefaultCapabilitiesPosture := flag.String(ConfigHostDefaultCapabilitiesPosture, "block", "configuring default enforcement action in global capability context {allow|audit|block}")
+	hostDefaultFilePosture := flag.String(ConfigHostDefaultFilePosture, "audit", "configuring default enforcement action in global file context {allow|audit|block}")
+	hostDefaultNetworkPosture := flag.String(ConfigHostDefaultNetworkPosture, "audit", "configuring default enforcement action in global network context {allow|audit|block}")
+	hostDefaultCapabilitiesPosture := flag.String(ConfigHostDefaultCapabilitiesPosture, "audit", "configuring default enforcement action in global capability context {allow|audit|block}")
 
 	coverageTestB := flag.Bool(ConfigCoverageTest, false, "enabling CoverageTest")
 

--- a/KubeArmor/main_test.go
+++ b/KubeArmor/main_test.go
@@ -12,6 +12,7 @@ import (
 
 var clusterPtr, gRPCPtr, logPathPtr *string
 var enableKubeArmorPolicyPtr, enableKubeArmorHostPolicyPtr, enableKubeArmorVMPtr, coverageTestPtr *bool
+var defaultFilePosturePtr, defaultCapabilitiesPosturePtr, defaultNetworkPosturePtr, hostDefaultCapabilitiesPosturePtr, hostDefaultNetworkPosturePtr, hostDefaultFilePosturePtr *string
 
 func init() {
 	// options (string)
@@ -20,6 +21,15 @@ func init() {
 	// options (string)
 	gRPCPtr = flag.String("gRPC", "32767", "gRPC port number")
 	logPathPtr = flag.String("logPath", "none", "log file path")
+
+	// options (string)
+	defaultFilePosturePtr = flag.String("defaultFilePosture", "block", "configuring default enforcement action in global file context {allow|audit|block}")
+	defaultNetworkPosturePtr = flag.String("defaultNetworkPosture", "block", "configuring default enforcement action in global network context {allow|audit|block}")
+	defaultCapabilitiesPosturePtr = flag.String("defaultCapabilitiesPosture", "block", "configuring default enforcement action in global capability context {allow|audit|block}")
+
+	hostDefaultFilePosturePtr = flag.String("hostDefaultFilePosture", "block", "configuring default enforcement action in global file context {allow|audit|block}")
+	hostDefaultNetworkPosturePtr = flag.String("hostDefaultNetworkPosture", "block", "configuring default enforcement action in global network context {allow|audit|block}")
+	hostDefaultCapabilitiesPosturePtr = flag.String("hostDefaultCapabilitiesPosture", "block", "configuring default enforcement action in global capability context {allow|audit|block}")
 
 	// options (boolean)
 	enableKubeArmorPolicyPtr = flag.Bool("enableKubeArmorPolicy", true, "enabling KubeArmorPolicy")
@@ -37,6 +47,12 @@ func TestMain(t *testing.T) {
 
 	// Set os args to set flags in main
 	os.Args = []string{"cmd", "--cluster", *clusterPtr, "--gRPC", *gRPCPtr, "--logPath", *logPathPtr,
+		"--defaultFilePosture", *defaultFilePosturePtr,
+		"--defaultNetworkPosture", *defaultNetworkPosturePtr,
+		"--defaultCapabilitiesPosture", *defaultCapabilitiesPosturePtr,
+		"--hostDefaultFilePosture", *hostDefaultFilePosturePtr,
+		"--hostDefaultNetworkPosture", *hostDefaultNetworkPosturePtr,
+		"--hostDefaultCapabilitiesPosture", *hostDefaultCapabilitiesPosturePtr,
 		"--enableKubeArmorPolicy", strconv.FormatBool(*enableKubeArmorPolicyPtr),
 		"--enableKubeArmorHostPolicy", strconv.FormatBool(*enableKubeArmorHostPolicyPtr),
 		"--enableKubeArmorVm", strconv.FormatBool(*enableKubeArmorVMPtr),

--- a/getting-started/default_posture.md
+++ b/getting-started/default_posture.md
@@ -9,6 +9,8 @@ KubeArmor has 4 types of resources: Process, File, Network and Capabilities. Def
 
 ### Global Default Posture
 
+> **Note** By default, KubeArmor set the Global default posture to `audit`
+
 Global default posture is configured using configuration options passed to KubeArmor using configuration file
 
 ```yaml

--- a/tests/test-scenarios-github.sh
+++ b/tests/test-scenarios-github.sh
@@ -126,6 +126,20 @@ function start_and_wait_for_kubearmor_initialization() {
 
     cd $ARMOR_HOME
 
+    if [ "$DEFAULT_POSTURE" == "allow" ]; then
+        ARMOR_OPTIONS+=("-defaultFilePosture=allow")
+        ARMOR_OPTIONS+=("-defaultNetworkPosture=allow")
+        ARMOR_OPTIONS+=("-defaultCapabilitiesPosture=allow")
+    elif [ "$DEFAULT_POSTURE" == "audit" ]; then # Current default posture is "audit" and for testing we need block based posture
+        ARMOR_OPTIONS+=("-defaultFilePosture=block")
+        ARMOR_OPTIONS+=("-defaultNetworkPosture=block")
+        ARMOR_OPTIONS+=("-defaultCapabilitiesPosture=block")
+    else # block
+        ARMOR_OPTIONS+=("-defaultFilePosture=block")
+        ARMOR_OPTIONS+=("-defaultNetworkPosture=block")
+        ARMOR_OPTIONS+=("-defaultCapabilitiesPosture=block")
+    fi
+
     echo "Options: -logPath=$ARMOR_LOG ${ARMOR_OPTIONS[@]}"
     if [[ ! " ${ARMOR_OPTIONS[@]} " =~ "-enableKubeArmorHostPolicy" ]]; then
         SKIP_HOST_POLICY=1


### PR DESCRIPTION

**Purpose of PR?**:
It changes the default posture behavior of KubeArmor to be Audit instead of denying everything. The reason being, auto-discovering rules may not result in an exhaustive policy thus may deny actions which can cause the application to fail.

**Does this PR introduce a breaking change?**
Lenient whitelist policy might break.

**If the changes in this PR are manually verified, list down the scenarios covered:**:
Manually verified with allow based policy resulting in "Audit" logs for actions which are not allowed.

**Additional information for reviewer?** :
_Mention if this PR is part of any design or a continuation of previous PRs_
No

**Checklist:**
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
- [x ] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Commit has unit tests
- [ ] Commit has integration tests

<!--

The PR title message must follow convention:
`<type>(<scope>): <subject>`.

Where: <br />
- `type` is to define what type of PR is this.
  Most common types are:
    - `feat`      - for new features, not a new feature for build script
    - `fix`       - for bug fixes or improvements, not a fix for build script
    - `chore`     - changes not related to production code
    - `docs`      - changes related to documentation
    - `style`     - formatting, missing semi colons, linting fix etc; no significant production code changes
    - `test`      - adding missing tests, refactoring tests; no production code change
    - `refactor`  - refactoring production code, eg. renaming a variable or function name, there should not be any significant production code changes

- `scope` is a single word that best describes where the changes fit.
    - feature(`monitor`,`enforcer`)
    - test(`tests`, `bdd`)
    - chore(`build`)
- `subject` is a single line brief description of the changes made in the pull request.

-->