### PR TITLE
fix(enforcer): allow ptrace in default apparmorHostProfile

### DIFF
--- a/KubeArmor/enforcer/appArmorEnforcer.go
+++ b/KubeArmor/enforcer/appArmorEnforcer.go
@@ -354,6 +354,7 @@ func (ae *AppArmorEnforcer) CreateAppArmorHostProfile() error {
 		"  umount,\n" +
 		"  signal,\n" +
 		"  unix,\n" +
+		"  ptrace,\n" +
 		"\n" +
 		"  file,\n" +
 		"  network,\n" +

--- a/KubeArmor/enforcer/appArmorHostProfile.go
+++ b/KubeArmor/enforcer/appArmorHostProfile.go
@@ -529,6 +529,7 @@ func (ae *AppArmorEnforcer) GenerateHostProfileHead() string {
 		"  umount,\n" +
 		"  signal,\n" +
 		"  unix,\n" +
+		"  ptrace,\n" +
 		"\n" +
 		"  file,\n" +
 		"  network,\n" +


### PR DESCRIPTION
**Purpose of PR?**:
Currently the default apparmor host profile deny all ptrace access, this PR handles that case and after merging it all the access to ptrace will be allowed by default for the host. 


**Does this PR introduce a breaking change?**
No
**If the changes in this PR are manually verified, list down the scenarios covered:**:

**Additional information for reviewer?** :
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [x] Bug fix.
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`

<!--

The PR title message must follow convention:
`<type>(<scope>): <subject>`.

Where: <br />
- `type` is to define what type of PR is this.
  Most common types are:
    - `feat`      - for new features, not a new feature for build script
    - `fix`       - for bug fixes or improvements, not a fix for build script
    - `chore`     - changes not related to production code
    - `docs`      - changes related to documentation
    - `style`     - formatting, missing semi colons, linting fix etc; no significant production code changes
    - `test`      - adding missing tests, refactoring tests; no production code change
    - `refactor`  - refactoring production code, eg. renaming a variable or function name, there should not be any significant production code changes

- `scope` is a single word that best describes where the changes fit.
    - feature(`monitor`,`enforcer`)
    - test(`tests`, `bdd`)
    - chore(`build`)
- `subject` is a single line brief description of the changes made in the pull request.

-->