### PR TITLE
fix(check): disable sys_exit_open syscall if not present

### DIFF
--- a/KubeArmor/BPF/system_monitor.c
+++ b/KubeArmor/BPF/system_monitor.c
@@ -1425,6 +1425,7 @@ struct tracepoint_syscalls_sys_exit_t {
     long ret;
 };
 
+#if defined(TRACEPOINT_EXIT_OPENAT)
 SEC("tracepoint/syscalls/sys_exit_openat")
 int sys_exit_openat(struct tracepoint_syscalls_sys_exit_t *args)
 {
@@ -1468,6 +1469,7 @@ int sys_exit_openat(struct tracepoint_syscalls_sys_exit_t *args)
 
     return 0;
 }
+#endif
 
 // == Syscall Hooks (Network) == //
 

--- a/KubeArmor/BPF/tests/checks/sys_exit_openat.c
+++ b/KubeArmor/BPF/tests/checks/sys_exit_openat.c
@@ -1,0 +1,20 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+/* Copyright 2022 Authors of KubeArmor */
+
+#ifndef KBUILD_MODNAME
+#define KBUILD_MODNAME "kubearmor_syscall_check"
+#endif
+
+#ifdef BTF_SUPPORTED
+#include "vmlinux.h"
+#else
+#include <linux/bpf.h>
+#endif
+
+#include <bpf_helpers.h>
+
+// CFlag=-DTRACEPOINT_EXIT_OPENAT
+SEC("tracepoint/syscalls/sys_exit_openat")
+int sys_exit_openat(struct pt_regs *ctx){
+        return 0;
+}

--- a/KubeArmor/BPF/tests/main.go
+++ b/KubeArmor/BPF/tests/main.go
@@ -49,6 +49,11 @@ func main() {
 		if err != nil {
 			log.Fatalf("[Failed] Cannot attach syscall %s\n", err.Error())
 		}
+	} else if strings.HasPrefix(fn, "sys_") {
+		_, err = link.Tracepoint("syscalls", fn, bpfModule.Programs[fn], nil)
+		if err != nil {
+			log.Fatalf("[Failed] Cannot attach tracepoint %s\n", err.Error())
+		}
 	} // other probe types goes here
 	/*else if (){
 

--- a/KubeArmor/monitor/systemMonitor.go
+++ b/KubeArmor/monitor/systemMonitor.go
@@ -187,6 +187,9 @@ var syscallsInKernelFeatureFlag = map[string][]string{
 		"security_path_unlink",
 		"security_path_rmdir",
 	},
+	"DTRACEPOINT_EXIT_OPENAT": {
+		"sys_exit_openat",
+	},
 }
 
 func isIgnored(item string, ignoreList []string) bool {
@@ -279,6 +282,10 @@ func (mon *SystemMonitor) InitBPF() error {
 		}
 
 		for _, sysTracepoint := range sysTracepoints {
+			if isIgnored(sysTracepoint[1], ignoreList) {
+				mon.Logger.Printf("Ignoring tracepoint %s", sysTracepoint[1])
+				continue
+			}
 			mon.Probes[sysTracepoint[1]], err = link.Tracepoint(sysTracepoint[0], sysTracepoint[1], mon.BpfModule.Programs[sysTracepoint[1]], nil)
 			if err != nil {
 				return fmt.Errorf("error:%s: %v", sysTracepoint, err)


### PR DESCRIPTION
**Purpose of PR**:
Update syscheck script to disable sys_exit_open() syscall if not present

**Fixes** 
While testing the latest release on Raspberry Pi 4,  this syscall is not present so it's better to disable them.

**Does this PR introduce a breaking change?**
No

**Additional information for reviewer?** :
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [ ] Bug fix. Fixes #<issue number>
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Commit has unit tests
- [ ] Commit has integration tests

<!--

The PR title message must follow convention:
`<type>(<scope>): <subject>`.

Where: <br />
- `type` is to define what type of PR is this.
  Most common types are:
    - `feat`      - for new features, not a new feature for build script
    - `fix`       - for bug fixes or improvements, not a fix for build script
    - `chore`     - changes not related to production code
    - `docs`      - changes related to documentation
    - `style`     - formatting, missing semi colons, linting fix etc; no significant production code changes
    - `test`      - adding missing tests, refactoring tests; no production code change
    - `refactor`  - refactoring production code, eg. renaming a variable or function name, there should not be any significant production code changes

- `scope` is a single word that best describes where the changes fit.
    - feature(`monitor`,`enforcer`)
    - test(`tests`, `bdd`)
    - chore(`build`)
- `subject` is a single line brief description of the changes made in the pull request.

-->