### PR TITLE
fix(bpf): use helper function to read task file

### DIFF
--- a/KubeArmor/BPF/system_monitor.c
+++ b/KubeArmor/BPF/system_monitor.c
@@ -340,8 +340,10 @@ static __always_inline u32 get_task_ppid(struct task_struct *task)
 
 }
 
-static struct file *get_task_file(struct task_struct *task) {
-  return BPF_CORE_READ(task, mm, exe_file);
+static struct file *get_task_file(struct task_struct *task)
+{
+  struct mm_struct *mm = READ_KERN(task->mm);
+  return READ_KERN(mm->exe_file);
 }
 
 // == Pid NS Management == //


### PR DESCRIPTION
**Purpose of PR?**:

This commit fixed the bug introduced by https://github.com/kubearmor/KubeArmor/pull/759 for non BTF environments by using BPF CORE READ instead of using the helper function which reads based on availability of BTF.

Fixes #1007

**Does this PR introduce a breaking change?**
No

**If the changes in this PR are manually verified, list down the scenarios covered:**:
Test on Ubuntu 18.04 with kernel version 4.15.xx

**Additional information for reviewer?** :
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [x] Bug fix. 
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`

<!--

The PR title message must follow convention:
`<type>(<scope>): <subject>`.

Where: <br />
- `type` is to define what type of PR is this.
  Most common types are:
    - `feat`      - for new features, not a new feature for build script
    - `fix`       - for bug fixes or improvements, not a fix for build script
    - `chore`     - changes not related to production code
    - `docs`      - changes related to documentation
    - `style`     - formatting, missing semi colons, linting fix etc; no significant production code changes
    - `test`      - adding missing tests, refactoring tests; no production code change
    - `refactor`  - refactoring production code, eg. renaming a variable or function name, there should not be any significant production code changes

- `scope` is a single word that best describes where the changes fit.
    - feature(`monitor`,`enforcer`)
    - test(`tests`, `bdd`)
    - chore(`build`)
- `subject` is a single line brief description of the changes made in the pull request.

-->