### PR TITLE
Made changes in support_matix.md about Amazon Linux 2 Signed-off-by: Hari Vamsi<h20220031@goa.bits-pilani.ac.in>

### DIFF
--- a/getting-started/support_matrix.md
+++ b/getting-started/support_matrix.md
@@ -23,7 +23,9 @@ KubeArmor supports following types of workloads:
 
 Amazon Linux 2 currently is shipped with SELinux as the LSM (Linux Security Module). KubeArmor supports SELinux only for host-based policy enforcement. On Amazon Linux 2, Kubearmor currently supports observability/policy audits using ebpf based engine.
 
-The latest versions of Amazon Linux 2 ship with a new LSM type called BPF-LSM and Kubearmor [intends](https://github.com/kubearmor/KubeArmor/issues/484) to support it soon).
+The latest versions of Amazon Linux 2 ship with a new LSM type called BPF-LSM and Kubearmor [intends](https://github.com/kubearmor/KubeArmor/issues/484) to support it soon). 
+
+Update: On Amazon Linux 2 with Kernel Version 5.10, Kubearmor is found to be running on systemd mode. The enforcement is sometimes partial with following supported LSM's: "Capability,Yama,Lockdown,SELinux,BPF". Refer [Issue](https://github.com/kubearmor/KubeArmor/issues/919).
 
 ### Platform I am interested is not listed here! What can I do?
 


### PR DESCRIPTION
Signed-off-by: Hari Vamsi <h20220031@goa.bits-pilani.ac.in>
Updated support_matrix.md file
Fixes #919 

New update about KubeArmor support on Amazon Linux 2 (Kernel Version 5.10) with screenshots attached in the issue thread.

Previously KubeArmor supported only few LSM's. With the latest update in kernel version the support has been increased. This has been added to the support_matrix.md file as an update.    