### PR TITLE
use recursive flag during signing

### DIFF
--- a/.github/workflows/ci-latest-release.yml
+++ b/.github/workflows/ci-latest-release.yml
@@ -92,15 +92,15 @@ jobs:
       - name: Get Image Digest
         id: digest
         run: | 
-          echo "imagedigest=$(docker buildx imagetools inspect kubearmor/kubearmor:${{ steps.vars.outputs.tag }} --format "{{json (index .Manifest)}}" | jq -r '.manifests[0].digest')" >> $GITHUB_OUTPUT
-          echo "initdigest=$(docker buildx imagetools inspect kubearmor/kubearmor-init:${{ steps.vars.outputs.tag }} --format "{{json (index .Manifest)}}" | jq -r '.manifests[0].digest')" >> $GITHUB_OUTPUT 
+          echo "imagedigest=$(jq -r '.["containerimage.digest"]' kubearmor.json)" >> $GITHUB_OUTPUT
+          echo "initdigest=$(jq -r '.["containerimage.digest"]' kubearmor-init.json)" >> $GITHUB_OUTPUT
 
       - name: Sign the Container Images
         env:
           COSIGN_EXPERIMENTAL: "true"
         run: |
-          cosign sign kubearmor/kubearmor@${{ steps.digest.outputs.imagedigest }}
-          cosign sign kubearmor/kubearmor-init@${{ steps.digest.outputs.initdigest }}
+          cosign sign -r kubearmor/kubearmor@${{ steps.digest.outputs.imagedigest }}
+          cosign sign -r kubearmor/kubearmor-init@${{ steps.digest.outputs.initdigest }}
 
   push-stable-version:
     name: Create KubeArmor stable release
@@ -152,12 +152,15 @@ jobs:
       - name: Get Image Digest
         id: digest
         run: | 
-          echo "imagedigest=$(docker buildx imagetools inspect kubearmor/kubearmor:${{ steps.vars.outputs.tag }} --format "{{json (index .Manifest)}}" | jq -r '.manifests[0].digest')" >> $GITHUB_OUTPUT
-          echo "initdigest=$(docker buildx imagetools inspect kubearmor/kubearmor-init:${{ steps.vars.outputs.tag }} --format "{{json (index .Manifest)}}" | jq -r '.manifests[0].digest')" >> $GITHUB_OUTPUT 
+          ls -l
+          echo "imagedigest=$(jq -r '.["containerimage.digest"]' kubearmor.json)" >> $GITHUB_OUTPUT
+          echo "initdigest=$(jq -r '.["containerimage.digest"]' kubearmor-init.json)" >> $GITHUB_OUTPUT
+          echo $imagedigest 
+          echo $initdigest 
 
       - name: Sign the Container Images
         env:
           COSIGN_EXPERIMENTAL: "true"
         run: |
-          cosign sign kubearmor/kubearmor@${{ steps.digest.outputs.imagedigest }}
-          cosign sign kubearmor/kubearmor-init@${{ steps.digest.outputs.initdigest }}
+          cosign sign -r kubearmor/kubearmor@${{ steps.digest.outputs.imagedigest }}
+          cosign sign -r kubearmor/kubearmor-init@${{ steps.digest.outputs.initdigest }}

--- a/KubeArmor/build/push_kubearmor.sh
+++ b/KubeArmor/build/push_kubearmor.sh
@@ -42,14 +42,14 @@ pwd
 
 # push $REPO
 echo "[INFO] Pushing $REPO:$VERSION"
-cd $ARMOR_HOME/..; docker buildx build --platform $PLATFORMS -t $REPO:$VERSION -f Dockerfile --push $LABEL $STABEL_LABEL .
+cd $ARMOR_HOME/..; docker buildx build --metadata-file kubearmor.json --platform $PLATFORMS -t $REPO:$VERSION -f Dockerfile --push $LABEL $STABEL_LABEL .
 
 [[ $? -ne 0 ]] && echo "[FAILED] Failed to push $REPO:$VERSION" && exit 1
 echo "[PASSED] Pushed $REPO:$VERSION"
 
 # push $REPO-init
 echo "[INFO] Pushing $REPO-init:$VERSION"
-cd $ARMOR_HOME/..; docker buildx build --platform $PLATFORMS -t $REPO-init:$VERSION -f Dockerfile.init --push $LABEL $STABEL_LABEL .
+cd $ARMOR_HOME/..; docker buildx build --metadata-file kubearmor-init.json --platform $PLATFORMS -t $REPO-init:$VERSION -f Dockerfile.init --push $LABEL $STABEL_LABEL .
 
 [[ $? -ne 0 ]] && echo "[FAILED] Failed to push $REPO-init:$VERSION" && exit 1
 echo "[PASSED] Pushed $REPO-init:$VERSION"


### PR DESCRIPTION
Signed-off-by: Anurag <contact.anurag7@gmail.com>

**Purpose of PR?**:
- This PR uses parent digest to sign the images. 
- This PR also introduces recursive flag during the build process which will sign the platform specific images. 


**Does this PR introduce a breaking change?**
- No 
**If the changes in this PR are manually verified, list down the scenarios covered:**:

- Tested this on my demo repository 

**Additional information for reviewer?** :
- This PR is a continuation of signing images patches. 

**Checklist:**
- [x] Bug fix. Fixes #<issue number>
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Commit has unit tests
- [ ] Commit has integration tests

<!--

The PR title message must follow convention:
`<type>(<scope>): <subject>`.

Where: <br />
- `type` is to define what type of PR is this.
  Most common types are:
    - `feat`      - for new features, not a new feature for build script
    - `fix`       - for bug fixes or improvements, not a fix for build script
    - `chore`     - changes not related to production code
    - `docs`      - changes related to documentation
    - `style`     - formatting, missing semi colons, linting fix etc; no significant production code changes
    - `test`      - adding missing tests, refactoring tests; no production code change
    - `refactor`  - refactoring production code, eg. renaming a variable or function name, there should not be any significant production code changes

- `scope` is a single word that best describes where the changes fit.
    - feature(`monitor`,`enforcer`)
    - test(`tests`, `bdd`)
    - chore(`build`)
- `subject` is a single line brief description of the changes made in the pull request.

-->