### PR TITLE
code changes(deployments/makegen): kubearmor apps bypass mutation

### DIFF
--- a/deployments/annotations/kubearmor-annotation-manager.yaml
+++ b/deployments/annotations/kubearmor-annotation-manager.yaml
@@ -305,3 +305,7 @@ webhooks:
     resources:
     - pods
   sideEffects: NoneOnDryRun
+  objectSelector:
+    matchExpressions:
+    - key: "kubearmor-app"
+      operator: DoesNotExist

--- a/deployments/controller/kubearmor-controller-manager.yaml
+++ b/deployments/controller/kubearmor-controller-manager.yaml
@@ -1259,3 +1259,7 @@ webhooks:
     resources:
     - pods
   sideEffects: NoneOnDryRun
+  objectSelector:
+    matchExpressions:
+    - key: "kubearmor-app"
+      operator: DoesNotExist

--- a/deployments/get/objects.go
+++ b/deployments/get/objects.go
@@ -992,6 +992,14 @@ func GetAnnotationsControllerMutationAdmissionConfiguration(namespace string, ca
 					},
 				},
 				SideEffects: &KubeArmorControllerMutationSideEffect,
+				ObjectSelector: &metav1.LabelSelector{
+					MatchExpressions: []metav1.LabelSelectorRequirement{
+						{
+							Key:      "kubearmor-app",
+							Operator: metav1.LabelSelectorOpDoesNotExist,
+						},
+					},
+				},
 			},
 		},
 	}

--- a/pkg/KubeArmorController/config/webhook/manifests.yaml
+++ b/pkg/KubeArmorController/config/webhook/manifests.yaml
@@ -26,3 +26,7 @@ webhooks:
     resources:
     - pods
   sideEffects: NoneOnDryRun
+  objectSelector:
+    matchExpressions:
+    - key: "kubearmor-app"
+      operator: DoesNotExist


### PR DESCRIPTION
Signed-off-by: Achref ben saad <achref@accuknox.com>

**Purpose of PR?**:  We need to allow kubearmor resources to bypass the mutation webhook in order for the node snitch to run properly.

Node snitch will run before kubearmor does, if node snitch is bocked, kubearmor will never be deployed.

Fixes #

**Does this PR introduce a breaking change?**

**If the changes in this PR are manually verified, list down the scenarios covered:**:

**Additional information for reviewer?** :
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [ ] Bug fix. Fixes #<issue number>
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Commit has unit tests
- [ ] Commit has integration tests

<!--

The PR title message must follow convention:
`<type>(<scope>): <subject>`.

Where: <br />
- `type` is to define what type of PR is this.
  Most common types are:
    - `feat`      - for new features, not a new feature for build script
    - `fix`       - for bug fixes or improvements, not a fix for build script
    - `chore`     - changes not related to production code
    - `docs`      - changes related to documentation
    - `style`     - formatting, missing semi colons, linting fix etc; no significant production code changes
    - `test`      - adding missing tests, refactoring tests; no production code change
    - `refactor`  - refactoring production code, eg. renaming a variable or function name, there should not be any significant production code changes

- `scope` is a single word that best describes where the changes fit.
    - feature(`monitor`,`enforcer`)
    - test(`tests`, `bdd`)
    - chore(`build`)
- `subject` is a single line brief description of the changes made in the pull request.

-->