### PR TITLE
feat(monitor): mount/unmount syscall support

### DIFF
--- a/KubeArmor/monitor/logUpdate.go
+++ b/KubeArmor/monitor/logUpdate.go
@@ -286,6 +286,49 @@ func (mon *SystemMonitor) UpdateLogs() {
 				log.Operation = "Syscall"
 				log.Data = "syscall=" + getSyscallName(int32(msg.ContextSys.EventID)) + " userid=" + strconv.Itoa(uid)
 
+			case SysMount:
+				if len(msg.ContextArgs) != 5 {
+					continue
+				}
+				var source, target, fstype, data string
+				var flags int
+
+				if val, ok := msg.ContextArgs[0].(string); ok {
+					source = val
+				}
+				if val, ok := msg.ContextArgs[1].(string); ok {
+					target = val
+				}
+				if val, ok := msg.ContextArgs[2].(string); ok {
+					fstype = val
+				}
+				if val, ok := msg.ContextArgs[3].(int32); ok {
+					flags = int(val)
+				}
+				if val, ok := msg.ContextArgs[4].(string); ok {
+					data = val
+				}
+
+				log.Operation = "Syscall"
+				log.Data = "syscall=" + getSyscallName(int32(msg.ContextSys.EventID)) + " source=" + source + " target=" + target + " filesystem=" + fstype + " mountflag=" + strconv.Itoa(flags) + " data=" + data
+
+			case SysUmount:
+				if len(msg.ContextArgs) != 2 {
+					continue
+				}
+				var target string
+				var flags int
+
+				if val, ok := msg.ContextArgs[0].(string); ok {
+					target = val
+				}
+				if val, ok := msg.ContextArgs[1].(int32); ok {
+					flags = int(val)
+				}
+
+				log.Operation = "Syscall"
+				log.Data = "syscall=" + getSyscallName(int32(msg.ContextSys.EventID)) + " target=" + target + " flag=" + strconv.Itoa(flags)
+
 			case SysClose:
 				if len(msg.ContextArgs) != 1 {
 					continue

--- a/KubeArmor/monitor/syscalls_amd64.go
+++ b/KubeArmor/monitor/syscalls_amd64.go
@@ -20,6 +20,9 @@ const (
 	SysSetuid = 105
 	SysSetgid = 106
 
+	SysMount  = 165
+	SysUmount = 166
+
 	SysSocket  = 41
 	SysConnect = 42
 	SysAccept  = 43

--- a/KubeArmor/monitor/syscalls_arm64.go
+++ b/KubeArmor/monitor/syscalls_arm64.go
@@ -23,6 +23,9 @@ const (
 	SysSetuid = 146
 	SysSetgid = 144
 
+	SysMount  = 165
+	SysUmount = 166
+
 	SysSocket  = 198
 	SysConnect = 203
 	SysAccept  = 202

--- a/KubeArmor/monitor/systemMonitor.go
+++ b/KubeArmor/monitor/systemMonitor.go
@@ -259,7 +259,7 @@ func (mon *SystemMonitor) InitBPF() error {
 	mon.Logger.Print("Initialized the eBPF system monitor")
 
 	// sysPrefix := bcc.GetSyscallPrefix()
-	systemCalls := []string{"open", "openat", "execve", "execveat", "socket", "connect", "accept", "bind", "listen", "unlink", "unlinkat", "rmdir", "ptrace", "chown", "setuid", "setgid", "fchownat"}
+	systemCalls := []string{"open", "openat", "execve", "execveat", "socket", "connect", "accept", "bind", "listen", "unlink", "unlinkat", "rmdir", "ptrace", "chown", "setuid", "setgid", "fchownat", "mount", "umount"}
 	// {category, event}
 	sysTracepoints := [][2]string{{"syscalls", "sys_exit_openat"}}
 	sysKprobes := []string{"do_exit", "security_bprm_check", "security_file_open", "security_path_unlink", "security_path_rmdir", "security_ptrace_access_check"}
@@ -524,6 +524,15 @@ func (mon *SystemMonitor) TraceSyscall() {
 				if len(args) != 1 {
 					continue
 				}
+			} else if ctx.EventID == SysMount {
+				if len(args) != 5 {
+					continue
+				}
+			} else if ctx.EventID == SysUmount {
+				if len(args) != 2 {
+					continue
+				}
+
 			} else if ctx.EventID == SysExecve {
 				if len(args) == 2 { // enter
 					// build a pid node

--- a/tests/ksp/ksp_test.go
+++ b/tests/ksp/ksp_test.go
@@ -567,6 +567,55 @@ var _ = Describe("Ksp", func() {
 
 		})
 
+		It("mount will be blocked by default for a pod", func() {
+			// Start KubeArmor Logs
+			err := KarmorLogStart("policy", "multiubuntu", "Syscall", ub3)
+			Expect(err).To(BeNil())
+
+			// execute mount inside the pod
+			sout, _, err := K8sExecInPod(ub3, "multiubuntu",
+				[]string{"bash", "-c", "mkdir /mnt/test"})
+			Expect(err).To(BeNil())
+			sout, _, err = K8sExecInPod(ub3, "multiubuntu",
+				[]string{"bash", "-c", "mount /home /mnt/test"})
+			Expect(err).To(BeNil())
+			fmt.Printf("OUTPUT: %s\n", sout)
+
+			expect := protobuf.Alert{
+				PolicyName: "DefaultPosture",
+				Action:     "Block",
+				Result:     "Permission denied",
+				Data:       "syscall=SYS_MOUNT",
+			}
+
+			res, err := KarmorGetTargetAlert(5*time.Second, &expect)
+			Expect(err).To(BeNil())
+			Expect(res.Found).To(BeTrue())
+		})
+
+		It("umount will be blocked by default for a pod as the capability not added", func() {
+			// Start KubeArmor Logs
+			err := KarmorLogStart("policy", "multiubuntu", "Syscall", ub3)
+			Expect(err).To(BeNil())
+
+			// execute umount inside the pod
+			sout, _, err := K8sExecInPod(ub3, "multiubuntu",
+				[]string{"bash", "-c", "umount /mnt"})
+			Expect(err).To(BeNil())
+			fmt.Printf("OUTPUT: %s\n", sout)
+
+			expect := protobuf.Alert{
+				PolicyName: "DefaultPosture",
+				Action:     "Block",
+				Result:     "Operation not permitted",
+				Data:       "syscall=SYS_UMOUNT2",
+			}
+
+			res, err := KarmorGetTargetAlert(5*time.Second, &expect)
+			Expect(err).To(BeNil())
+			Expect(res.Found).To(BeTrue())
+		})
+
 	})
 
 	Describe("Apply Files Policies", func() {

--- a/tests/util/karmorlog.go
+++ b/tests/util/karmorlog.go
@@ -128,6 +128,11 @@ func getAlertWithInfo(alert *pb.Alert, target *pb.Alert) bool {
 			return false
 		}
 	}
+	if target.Data != "" {
+		if !strings.Contains(alert.Data, target.Data) {
+			return false
+		}
+	}
 
 	return true
 }


### PR DESCRIPTION
**Purpose of PR?**:
This PR adds support for mount and unmount syscalls. after merging the KubeArmor will be able to trace all events of mount/unmount system call. It also makes both the syscalls auditable, so both can be audit at syscall level using an audit policy.
```
syscalls:
  matchSyscalls:
  - syscall:
    - mount
    - umount2

```
Fixes #1011 

**Does this PR introduce a breaking change?**
No
**If the changes in this PR are manually verified, list down the scenarios covered:**:

**Additional information for reviewer?** :
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [x] Fixes #1011
- [x] New feature (non-breaking change which adds functionality)
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [x] Commit has integration tests

<!--

The PR title message must follow convention:
`<type>(<scope>): <subject>`.

Where: <br />
- `type` is to define what type of PR is this.
  Most common types are:
    - `feat`      - for new features, not a new feature for build script
    - `fix`       - for bug fixes or improvements, not a fix for build script
    - `chore`     - changes not related to production code
    - `docs`      - changes related to documentation
    - `style`     - formatting, missing semi colons, linting fix etc; no significant production code changes
    - `test`      - adding missing tests, refactoring tests; no production code change
    - `refactor`  - refactoring production code, eg. renaming a variable or function name, there should not be any significant production code changes

- `scope` is a single word that best describes where the changes fit.
    - feature(`monitor`,`enforcer`)
    - test(`tests`, `bdd`)
    - chore(`build`)
- `subject` is a single line brief description of the changes made in the pull request.

-->