### PR TITLE
Fix(Monitor): change lock to rlock for readonly in pidmap

### DIFF
--- a/KubeArmor/monitor/processTree.go
+++ b/KubeArmor/monitor/processTree.go
@@ -174,8 +174,8 @@ func (mon *SystemMonitor) GetExecPath(containerID string, hostPid uint32) string
 	ActiveHostPidMap := *(mon.ActiveHostPidMap)
 	ActivePidMapLock := *(mon.ActivePidMapLock)
 
-	ActivePidMapLock.Lock()
-	defer ActivePidMapLock.Unlock()
+	ActivePidMapLock.RLock()
+	defer ActivePidMapLock.RUnlock()
 
 	if pidMap, ok := ActiveHostPidMap[containerID]; ok {
 		if node, ok := pidMap[hostPid]; ok {
@@ -198,8 +198,8 @@ func (mon *SystemMonitor) GetCommand(containerID string, hostPid uint32) string 
 	ActiveHostPidMap := *(mon.ActiveHostPidMap)
 	ActivePidMapLock := *(mon.ActivePidMapLock)
 
-	ActivePidMapLock.Lock()
-	defer ActivePidMapLock.Unlock()
+	ActivePidMapLock.RLock()
+	defer ActivePidMapLock.RUnlock()
 
 	if pidMap, ok := ActiveHostPidMap[containerID]; ok {
 		if node, ok := pidMap[hostPid]; ok {
@@ -251,7 +251,7 @@ func (mon *SystemMonitor) CleanUpExitedHostPids() {
 
 		for containerID, pidMap := range ActiveHostPidMap {
 			for pid, pidNode := range pidMap {
-				if pidNode.Exited && now.After(pidNode.ExitedTime.Add(time.Second*5)) {
+				if pidNode.Exited && now.After(pidNode.ExitedTime.Add(time.Second*10)) {
 					delete(pidMap, pid)
 				}
 			}

--- a/KubeArmor/monitor/systemMonitor.go
+++ b/KubeArmor/monitor/systemMonitor.go
@@ -264,7 +264,7 @@ func (mon *SystemMonitor) WatchAppArmorAlerts() {
 			continue
 		}
 
-		ActivePidMapLock.Lock()
+		ActivePidMapLock.RLock()
 		if match := profilergx.FindAllStringSubmatch(string(rawEvent.Data), -1); len(match) != 0 {
 			a, _ := strconv.Atoi(match[0][4])
 			for cID, pidInfor := range ActiveHostPidMap {
@@ -290,7 +290,7 @@ func (mon *SystemMonitor) WatchAppArmorAlerts() {
 				}
 			}
 		}
-		ActivePidMapLock.Unlock()
+		ActivePidMapLock.RUnlock()
 	}
 
 }


### PR DESCRIPTION
**Purpose of PR?**: Fix event loss for alerts and telemetry by allowing paralel reading of ActivePidMap 



**Does this PR introduce a breaking change?** No

**If the changes in this PR are manually verified, list down the scenarios covered:**:

**Additional information for reviewer?** :
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
<!--

The PR title message must follow convention:
`<type>(<scope>): <subject>`.

Where: <br />
- `type` is to define what type of PR is this.
  Most common types are:
    - `feat`      - for new features, not a new feature for build script
    - `fix`       - for bug fixes or improvements, not a fix for build script
    - `chore`     - changes not related to production code
    - `docs`      - changes related to documentation
    - `style`     - formatting, missing semi colons, linting fix etc; no significant production code changes
    - `test`      - adding missing tests, refactoring tests; no production code change
    - `refactor`  - refactoring production code, eg. renaming a variable or function name, there should not be any significant production code changes

- `scope` is a single word that best describes where the changes fit.
    - feature(`monitor`,`enforcer`)
    - test(`tests`, `bdd`)
    - chore(`build`)
- `subject` is a single line brief description of the changes made in the pull request.

-->