### PR TITLE
fix(chore): build time printed during kubearmor startup 

### DIFF
--- a/KubeArmor/Makefile
+++ b/KubeArmor/Makefile
@@ -12,6 +12,13 @@ DLV_LPORT       := 2345
 DLV_RPORT       := $(shell expr $(DLV_LPORT) + $(NETNEXT))
 KUBEARMOR_PID    = $(shell pgrep kubearmor)
 
+ifeq (, $(shell which govvv))
+$(shell go install github.com/ahmetb/govvv)	# This works for older go version
+$(shell go install github.com/ahmetb/govvv@latest) # This works for new go version
+endif
+
+GIT_INFO := $(shell govvv -flags)
+
 .PHONY: build
 build: protobuf
 	cd $(CURDIR); go mod tidy
@@ -25,7 +32,7 @@ ifneq (, $(shell which llvm-strip))
 	fi
 endif
 endif
-	cd $(CURDIR); go build -o kubearmor main.go
+	cd $(CURDIR); go build -ldflags "$(GIT_INFO)" -o kubearmor main.go
 
 .PHONY: protobuf
 protobuf:

--- a/KubeArmor/main.go
+++ b/KubeArmor/main.go
@@ -7,13 +7,27 @@ package main
 import (
 	"os"
 	"path/filepath"
-	"syscall"
-	"time"
 
 	cfg "github.com/kubearmor/KubeArmor/KubeArmor/config"
 	"github.com/kubearmor/KubeArmor/KubeArmor/core"
 	kg "github.com/kubearmor/KubeArmor/KubeArmor/log"
 )
+
+var GitCommit string
+var GitBranch string
+var BuildDate string
+
+func printBuildDetails() {
+	if GitCommit == "" {
+		return
+	}
+	kg.Printf("BUILD-INFO: commit: %v, branch: %v, date: %v",
+		GitCommit, GitBranch, BuildDate)
+}
+
+func init() {
+	printBuildDetails()
+}
 
 func main() {
 	if os.Geteuid() != 0 {
@@ -30,11 +44,6 @@ func main() {
 	if err := os.Chdir(dir); err != nil {
 		kg.Err(err.Error())
 		return
-	}
-
-	if finfo, err := os.Stat(os.Args[0]); err == nil {
-		stat := finfo.Sys().(*syscall.Stat_t)
-		kg.Printf("Build Time: %v", time.Unix(int64(stat.Ctim.Sec), int64(stat.Ctim.Nsec)))
 	}
 
 	if err := cfg.LoadConfig(); err != nil {


### PR DESCRIPTION
Signed-off-by: saurabh3460 <saurabh3460@gmail.com>

**Purpose of PR?**: This correct the build time printed during kubearmor startup
Fixes #1055 

**Does this PR introduce a breaking change?** no

**If the changes in this PR are manually verified, list down the scenarios covered:**:

**Additional information for reviewer?** :
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [x] Bug fix. Fixes #1055 
- [x] New feature (non-breaking change which adds functionality)
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`

<!--

The PR title message must follow convention:
`<type>(<scope>): <subject>`.

Where: <br />
- `type` is to define what type of PR is this.
  Most common types are:
    - `feat`      - for new features, not a new feature for build script
    - `fix`       - for bug fixes or improvements, not a fix for build script
    - `chore`     - changes not related to production code
    - `docs`      - changes related to documentation
    - `style`     - formatting, missing semi colons, linting fix etc; no significant production code changes
    - `test`      - adding missing tests, refactoring tests; no production code change
    - `refactor`  - refactoring production code, eg. renaming a variable or function name, there should not be any significant production code changes

- `scope` is a single word that best describes where the changes fit.
    - feature(`monitor`,`enforcer`)
    - test(`tests`, `bdd`)
    - chore(`build`)
- `subject` is a single line brief description of the changes made in the pull request.

-->