### PR TITLE
fix of make run command in self managed k8s env

### DIFF
--- a/contribution/development_guide.md
+++ b/contribution/development_guide.md
@@ -235,10 +235,9 @@
         $ cd KubeArmor/KubeArmor
         ~/KubeArmor/KubeArmor$ make run
         ```
-        > **Note** If you have followed all necessary steps, and still getting logs like <br>
-        `2023-02-01 18:50:57.983600 INFO The node information is not available` <br>
-        It is due to discrepancy between the actual hostname (obtained by running `hostname`) and the hostname used by Kubernetes (under `kubectl get nodes -o wide`) may be due to case sensitivity issue. K8s converts the hostname to lowercase, which results in a mismatch with the actual hostname.
-        To resolve this, change the hostname to a lowercase version using the command `hostnamectl set-hostname <lowercase-hostname>`
+        > **Note** If you have followed all the above steps and still getting the warning `The node information is not available`, then this could be due to the case-sensitivity discrepancy in the actual hostname (obtained by running `hostname`) and the hostname used by Kubernetes (under `kubectl get nodes -o wide`).<br>
+        K8s converts the hostname to lowercase, which results in a mismatch with the actual hostname.<br>
+        To resolve this, change the hostname to lowercase using the command `hostnamectl set-hostname <lowercase-hostname>`.
          
    * Annotation controller
       

--- a/contribution/development_guide.md
+++ b/contribution/development_guide.md
@@ -195,6 +195,9 @@
 
         KubeArmor does not work with Docker Desktops on Windows and macOS because KubeArmor integrates with Linux-kernel native primitives (including LSMs).
 
+        > **Note** If you have done all steps and while doing `make run` ,you get logs like `2023-02-01 18:50:57.983600	INFO	The node information is not available`.<br> 
+         Then it is due to a mismatch between the hostname(can be obatined by running `hostname`) and the hostname shown under Name section in the output of `kubectl get nodes -o wide`. This can happen when the hostname has different letter casing from the name shown in the output.And, it happens because kubernetes lowers the casing. To resolve this, change the hostname to a some lowercase name with the command `hostnamectl set-hostname <lowercase-hostname>`.
+
    * Development Setup
 
      In order to install all dependencies, please run the following command.

--- a/contribution/development_guide.md
+++ b/contribution/development_guide.md
@@ -195,7 +195,8 @@
 
         KubeArmor does not work with Docker Desktops on Windows and macOS because KubeArmor integrates with Linux-kernel native primitives (including LSMs).
 
-        > **Note** If you have done all steps and while doing `make run` ,you get logs like `2023-02-01 18:50:57.983600	INFO	The node information is not available`.<br> 
+        > **Note** If you have done all steps and while doing `make run` ,you get logs like <br>
+        `2023-02-01 18:50:57.983600	INFO	The node information is not available`.<br> 
          Then it is due to a mismatch between the hostname(can be obatined by running `hostname`) and the hostname shown under Name section in the output of `kubectl get nodes -o wide`. This can happen when the hostname has different letter casing from the name shown in the output.And, it happens because kubernetes lowers the casing. To resolve this, change the hostname to a some lowercase name with the command `hostnamectl set-hostname <lowercase-hostname>`.
 
    * Development Setup

--- a/contribution/development_guide.md
+++ b/contribution/development_guide.md
@@ -195,9 +195,6 @@
 
         KubeArmor does not work with Docker Desktops on Windows and macOS because KubeArmor integrates with Linux-kernel native primitives (including LSMs).
 
-        > **Note** If you have done all steps and while doing `make run` ,you get logs like <br>
-        `2023-02-01 18:50:57.983600	INFO	The node information is not available`.<br> 
-         Then it is due to a mismatch between the hostname(can be obatined by running `hostname`) and the hostname shown under Name section in the output of `kubectl get nodes -o wide`. This can happen when the hostname has different letter casing from the name shown in the output.And, it happens because kubernetes lowers the casing. To resolve this, change the hostname to a some lowercase name with the command `hostnamectl set-hostname <lowercase-hostname>`.
 
    * Development Setup
 
@@ -238,6 +235,11 @@
         $ cd KubeArmor/KubeArmor
         ~/KubeArmor/KubeArmor$ make run
         ```
+        > **Note** If you have followed all necessary steps, and still getting logs like <br>
+        `2023-02-01 18:50:57.983600 INFO The node information is not available` <br>
+        It is due to discrepancy between the actual hostname (obtained by running `hostname`) and the hostname used by Kubernetes (under `kubectl get nodes -o wide`) may be due to case sensitivity issue. K8s converts the hostname to lowercase, which results in a mismatch with the actual hostname.
+        To resolve this, change the hostname to a lowercase version using the command `hostnamectl set-hostname <lowercase-hostname>`
+         
    * Annotation controller
       
       Starting from KubeArmor v0.5 annotations are applied via an annotation controller, the controller code can be found under `pkg/KubeArmorAnnotation`.

--- a/getting-started/FAQ.md
+++ b/getting-started/FAQ.md
@@ -96,3 +96,7 @@ KubeArmor defines 3 policy actions: Allow, Block and Audit.
 
 If Block policy is used and there are no supported enforcement mechanism on the platform then the policy enforcement wouldn't be observed. But we will still be able to see the observability data for the applied Block policy, which can help us in identifying any suspicious activity.
 </details>
+
+<details><summary><h4>Why can't I find the KubeArmor node when using `make run`?</h4></summary>
+ If you have followed all necessary steps, it may be due to a mismatch between the hostname(can be obatined by running `hostname`) and the hostname shown under  Name  section in the output of `kubectl get nodes -o wide`. This can happen when the hostname has different letter casing from the name shown in the output.And, it happens because kubernetes lowers the casing.  To resolve this, change the hostname to a some lowercase name with the command `hostnamectl set-hostname` <lowercase-hostname>.
+</details>

--- a/getting-started/FAQ.md
+++ b/getting-started/FAQ.md
@@ -97,6 +97,3 @@ KubeArmor defines 3 policy actions: Allow, Block and Audit.
 If Block policy is used and there are no supported enforcement mechanism on the platform then the policy enforcement wouldn't be observed. But we will still be able to see the observability data for the applied Block policy, which can help us in identifying any suspicious activity.
 </details>
 
-<details><summary><h4>Why can't I find the KubeArmor node when using `make run`?</h4></summary>
- If you have followed all necessary steps, it may be due to a mismatch between the hostname(can be obatined by running `hostname`) and the hostname shown under  Name  section in the output of `kubectl get nodes -o wide`. This can happen when the hostname has different letter casing from the name shown in the output.And, it happens because kubernetes lowers the casing.  To resolve this, change the hostname to a some lowercase name with the command `hostnamectl set-hostname` <lowercase-hostname>.
-</details>


### PR DESCRIPTION
Signed-off-by: Jatin <jatin_a@ch.iitr.ac.in>

**Purpose of PR?**:

Due to lower casing kubernetes in host name, many people face diffficulty in executing `make run`

**Does this PR introduce a breaking change?**
no

**If the changes in this PR are manually verified, list down the scenarios covered:**:

**Additional information for reviewer?** :
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [x] Bug fix. Fixes https://github.com/kubearmor/KubeArmor/issues/1083
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
- [ ] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Commit has unit tests
- [ ] Commit has integration tests

<!--

The PR title message must follow convention:
`<type>(<scope>): <subject>`.

Where: <br />
- `type` is to define what type of PR is this.
  Most common types are:
    - `feat`      - for new features, not a new feature for build script
    - `fix`       - for bug fixes or improvements, not a fix for build script
    - `chore`     - changes not related to production code
    - `docs`      - changes related to documentation
    - `style`     - formatting, missing semi colons, linting fix etc; no significant production code changes
    - `test`      - adding missing tests, refactoring tests; no production code change
    - `refactor`  - refactoring production code, eg. renaming a variable or function name, there should not be any significant production code changes

- `scope` is a single word that best describes where the changes fit.
    - feature(`monitor`,`enforcer`)
    - test(`tests`, `bdd`)
    - chore(`build`)
- `subject` is a single line brief description of the changes made in the pull request.

-->