### PR TITLE
fix(core, common): handle error for closing io streams

### DIFF
--- a/KubeArmor/common/common.go
+++ b/KubeArmor/common/common.go
@@ -221,8 +221,12 @@ func GetCommandOutputWithErr(cmd string, args []string) (string, error) {
 	}
 
 	go func() {
-		defer stdin.Close()
-		_, _ = io.WriteString(stdin, "values written to stdin are passed to cmd's standard input")
+		defer func() {
+			if err = stdin.Close(); err != nil {
+				kg.Warnf("Error closing stdin %s\n", err)
+			}
+		}()
+		_, err = io.WriteString(stdin, "values written to stdin are passed to cmd's standard input")
 	}()
 
 	out, err := res.CombinedOutput()
@@ -251,7 +255,11 @@ func GetCommandOutputWithoutErr(cmd string, args []string) string {
 	}
 
 	go func() {
-		defer stdin.Close()
+		defer func() {
+			if err = stdin.Close(); err != nil {
+				kg.Warnf("Error closing stdin %s\n", err)
+			}
+		}()
 		_, _ = io.WriteString(stdin, "values written to stdin are passed to cmd's standard input")
 	}()
 

--- a/KubeArmor/core/kubeUpdate.go
+++ b/KubeArmor/core/kubeUpdate.go
@@ -96,7 +96,11 @@ func (dm *KubeArmorDaemon) WatchK8sNodes() {
 	kg.Printf("GlobalCfg.Host=%s, KUBEARMOR_NODENAME=%s", cfg.GlobalCfg.Host, os.Getenv("KUBEARMOR_NODENAME"))
 	for {
 		if resp := K8s.WatchK8sNodes(); resp != nil {
-			defer resp.Body.Close()
+			defer func() {
+				if err := resp.Body.Close(); err != nil {
+					kg.Warnf("Error closing http stream %s\n", err)
+				}
+			}()
 
 			decoder := json.NewDecoder(resp.Body)
 			for {
@@ -498,7 +502,11 @@ func (dm *KubeArmorDaemon) UpdateEndPointWithPod(action string, pod tp.K8sPod) {
 func (dm *KubeArmorDaemon) WatchK8sPods() {
 	for {
 		if resp := K8s.WatchK8sPods(); resp != nil {
-			defer resp.Body.Close()
+			defer func() {
+				if err := resp.Body.Close(); err != nil {
+					kg.Warnf("Error closing http stream %s\n", err)
+				}
+			}()
 
 			decoder := json.NewDecoder(resp.Body)
 			for {
@@ -2285,7 +2293,11 @@ func (dm *KubeArmorDaemon) WatchHostSecurityPolicies() {
 		}
 
 		if resp := K8s.WatchK8sHostSecurityPolicies(); resp != nil {
-			defer resp.Body.Close()
+			defer func() {
+				if err := resp.Body.Close(); err != nil {
+					kg.Warnf("Error closing http stream %s\n", err)
+				}
+			}()
 
 			decoder := json.NewDecoder(resp.Body)
 			for {


### PR DESCRIPTION
**Purpose of PR?**:
There some unhandled errors in `common` and `core` packages reported by the `gosec` in the CI, all are related to the potential errors may occurred  while closing the io stream.  This PR fixes those issues. 
```
[/home/runner/work/KubeArmor/KubeArmor/KubeArmor/common/common.go:254] - G307 (CWE-703): Deferring unsafe method "Close" on type "io.WriteCloser" (Confidence: HIGH, Severity: MEDIUM)
    253: 	go func() {
  > 254: 		defer stdin.Close()
    255: 		_, _ = io.WriteString(stdin, "values written to stdin are passed to cmd's standard input")

[/home/runner/work/KubeArmor/KubeArmor/KubeArmor/common/common.go:224] - G307 (CWE-703): Deferring unsafe method "Close" on type "io.WriteCloser" (Confidence: HIGH, Severity: MEDIUM)
    223: 	go func() {
  > 224: 		defer stdin.Close()
    225: 		_, _ = io.WriteString(stdin, "values written to stdin are passed to cmd's standard input")

[/home/runner/work/KubeArmor/KubeArmor/KubeArmor/core/kubeUpdate.go:2292] - G307 (CWE-703): Deferring unsafe method "Close" on type "io.ReadCloser" (Confidence: HIGH, Severity: MEDIUM)
    2291: 		if resp := K8s.WatchK8sHostSecurityPolicies(); resp != nil {
  > 2292: 			defer resp.Body.Close()
    2293: 

[/home/runner/work/KubeArmor/KubeArmor/KubeArmor/core/kubeUpdate.go:505] - G307 (CWE-703): Deferring unsafe method "Close" on type "io.ReadCloser" (Confidence: HIGH, Severity: MEDIUM)
    504: 		if resp := K8s.WatchK8sPods(); resp != nil {
  > 505: 			defer resp.Body.Close()
    506: 

[/home/runner/work/KubeArmor/KubeArmor/KubeArmor/core/kubeUpdate.go:99] - G307 (CWE-703): Deferring unsafe method "Close" on type "io.ReadCloser" (Confidence: HIGH, Severity: MEDIUM)
    98: 		if resp := K8s.WatchK8sNodes(); resp != nil {
  > 99: 			defer resp.Body.Close()
```


**Does this PR introduce a breaking change?**
No
**If the changes in this PR are manually verified, list down the scenarios covered:**:

**Additional information for reviewer?** :
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [x] Bug fix.
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`

<!--

The PR title message must follow convention:
`<type>(<scope>): <subject>`.

Where: <br />
- `type` is to define what type of PR is this.
  Most common types are:
    - `feat`      - for new features, not a new feature for build script
    - `fix`       - for bug fixes or improvements, not a fix for build script
    - `chore`     - changes not related to production code
    - `docs`      - changes related to documentation
    - `style`     - formatting, missing semi colons, linting fix etc; no significant production code changes
    - `test`      - adding missing tests, refactoring tests; no production code change
    - `refactor`  - refactoring production code, eg. renaming a variable or function name, there should not be any significant production code changes

- `scope` is a single word that best describes where the changes fit.
    - feature(`monitor`,`enforcer`)
    - test(`tests`, `bdd`)
    - chore(`build`)
- `subject` is a single line brief description of the changes made in the pull request.

-->