### PR TITLE
Added grpc probe to kubeamor and kubearmor relay in a backward comptible way with K8<1.24 version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,8 @@ COPY . .
 WORKDIR /usr/src/KubeArmor/KubeArmor
 
 RUN go install github.com/golang/protobuf/protoc-gen-go@latest
+RUN GRPC_HEALTH_PROBE_VERSION=v0.4.15 && \
+    wget -qO/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-amd64
 RUN make
 
 ### Make executable image
@@ -31,6 +33,7 @@ RUN apk add apparmor@community apparmor-utils@community kubectl@testing
 
 COPY --from=builder /usr/src/KubeArmor/KubeArmor/kubearmor /KubeArmor/kubearmor
 COPY --from=builder /usr/src/KubeArmor/KubeArmor/templates/* /KubeArmor/templates/
+COPY --from=builder /bin/grpc_health_probe ./grpc_health_probe
 
 
 ENTRYPOINT ["/KubeArmor/kubearmor"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,8 @@ WORKDIR /usr/src/KubeArmor/KubeArmor
 
 RUN go install github.com/golang/protobuf/protoc-gen-go@latest
 RUN GRPC_HEALTH_PROBE_VERSION=v0.4.15 && \
-    wget -qO/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-amd64
+    wget -qO/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-amd64 && \
+    chmod +x /bin/grpc_health_probe
 RUN make
 
 ### Make executable image

--- a/KubeArmor/core/kubeArmor.go
+++ b/KubeArmor/core/kubeArmor.go
@@ -643,10 +643,10 @@ func KubeArmor() {
 			dm.Logger.Print("Started to monitor host security policies on gRPC")
 		}
 
-		pb.RegisterPolicyServiceServer(dm.Logger.LogServer, policyService)
+		pb.RegisterPolicyServiceServer(dm.Logger.Server, policyService)
 	}
 
-	reflection.Register(dm.Logger.LogServer) // Helps grpc clients list out what all svc/endpoints available
+	reflection.Register(dm.Logger.Server) // Helps grpc clients list out what all svc/endpoints available
 
 	// serve log feeds
 	go dm.ServeLogFeeds()

--- a/KubeArmor/go.mod
+++ b/KubeArmor/go.mod
@@ -16,8 +16,8 @@ replace (
 	github.com/kubearmor/KubeArmor/KubeArmor/monitor => ./monitor
 	github.com/kubearmor/KubeArmor/KubeArmor/policy => ./policy
 	github.com/kubearmor/KubeArmor/KubeArmor/types => ./types
-	github.com/kubearmor/KubeArmor/pkg/KubeArmorController => ../pkg/KubeArmorController
 	github.com/kubearmor/KubeArmor/deployments => ../deployments
+	github.com/kubearmor/KubeArmor/pkg/KubeArmorController => ../pkg/KubeArmorController
 	github.com/kubearmor/KubeArmor/protobuf => ../protobuf
 )
 
@@ -28,8 +28,8 @@ require (
 	github.com/containerd/typeurl v1.0.2
 	github.com/docker/docker v20.10.17+incompatible
 	github.com/google/uuid v1.3.0
-	github.com/kubearmor/KubeArmor/pkg/KubeArmorController v0.0.0-20230102134750-3c9ddc923c3f
 	github.com/kubearmor/KubeArmor/deployments v0.0.0-00010101000000-000000000000
+	github.com/kubearmor/KubeArmor/pkg/KubeArmorController v0.0.0-20230102134750-3c9ddc923c3f
 	github.com/kubearmor/KubeArmor/protobuf v0.0.0-20220908103453-7b92e248beb9
 	github.com/opencontainers/runtime-spec v1.0.3-0.20210326190908-1c3f411f0417
 	github.com/spf13/viper v1.13.0

--- a/deployments/AKS/kubearmor.yaml
+++ b/deployments/AKS/kubearmor.yaml
@@ -80,6 +80,15 @@ spec:
     spec:
       containers:
       - image: kubearmor/kubearmor-relay-server:latest
+        livenessProbe:
+          exec:
+            command:
+            - /bin/bash
+            - -c
+            - /grpc_health_probe
+            - -addr=:32767
+          initialDelaySeconds: 60
+          periodSeconds: 10
         name: kubearmor-relay-server
         ports:
         - containerPort: 32767
@@ -126,6 +135,9 @@ spec:
             - /bin/bash
             - -c
             - if [ -z $(pgrep kubearmor) ]; then exit 1; fi;
+            - '&&'
+            - /grpc_health_probe
+            - -addr=:32767
           initialDelaySeconds: 60
           periodSeconds: 10
         name: kubearmor

--- a/deployments/AKS/kubearmor.yaml
+++ b/deployments/AKS/kubearmor.yaml
@@ -83,10 +83,9 @@ spec:
         livenessProbe:
           exec:
             command:
-            - /bin/bash
+            - /bin/sh
             - -c
-            - /grpc_health_probe
-            - -addr=:32767
+            - /grpc_health_probe -addr=:32767
           initialDelaySeconds: 60
           periodSeconds: 10
         name: kubearmor-relay-server
@@ -134,10 +133,8 @@ spec:
             command:
             - /bin/bash
             - -c
-            - if [ -z $(pgrep kubearmor) ]; then exit 1; fi;
-            - '&&'
-            - /grpc_health_probe
-            - -addr=:32767
+            - /grpc_health_probe -addr=:32767 && if [ -z $(pgrep kubearmor) ]; then
+              exit 1; fi;
           initialDelaySeconds: 60
           periodSeconds: 10
         name: kubearmor

--- a/deployments/BottleRocket/kubearmor.yaml
+++ b/deployments/BottleRocket/kubearmor.yaml
@@ -83,10 +83,9 @@ spec:
         livenessProbe:
           exec:
             command:
-            - /bin/bash
+            - /bin/sh
             - -c
-            - /grpc_health_probe
-            - -addr=:32767
+            - /grpc_health_probe -addr=:32767
           initialDelaySeconds: 60
           periodSeconds: 10
         name: kubearmor-relay-server
@@ -135,10 +134,8 @@ spec:
             command:
             - /bin/bash
             - -c
-            - if [ -z $(pgrep kubearmor) ]; then exit 1; fi;
-            - '&&'
-            - /grpc_health_probe
-            - -addr=:32767
+            - /grpc_health_probe -addr=:32767 && if [ -z $(pgrep kubearmor) ]; then
+              exit 1; fi;
           initialDelaySeconds: 60
           periodSeconds: 10
         name: kubearmor

--- a/deployments/BottleRocket/kubearmor.yaml
+++ b/deployments/BottleRocket/kubearmor.yaml
@@ -80,6 +80,15 @@ spec:
     spec:
       containers:
       - image: kubearmor/kubearmor-relay-server:latest
+        livenessProbe:
+          exec:
+            command:
+            - /bin/bash
+            - -c
+            - /grpc_health_probe
+            - -addr=:32767
+          initialDelaySeconds: 60
+          periodSeconds: 10
         name: kubearmor-relay-server
         ports:
         - containerPort: 32767
@@ -127,6 +136,9 @@ spec:
             - /bin/bash
             - -c
             - if [ -z $(pgrep kubearmor) ]; then exit 1; fi;
+            - '&&'
+            - /grpc_health_probe
+            - -addr=:32767
           initialDelaySeconds: 60
           periodSeconds: 10
         name: kubearmor

--- a/deployments/EKS/kubearmor.yaml
+++ b/deployments/EKS/kubearmor.yaml
@@ -80,6 +80,15 @@ spec:
     spec:
       containers:
       - image: kubearmor/kubearmor-relay-server:latest
+        livenessProbe:
+          exec:
+            command:
+            - /bin/bash
+            - -c
+            - /grpc_health_probe
+            - -addr=:32767
+          initialDelaySeconds: 60
+          periodSeconds: 10
         name: kubearmor-relay-server
         ports:
         - containerPort: 32767
@@ -126,6 +135,9 @@ spec:
             - /bin/bash
             - -c
             - if [ -z $(pgrep kubearmor) ]; then exit 1; fi;
+            - '&&'
+            - /grpc_health_probe
+            - -addr=:32767
           initialDelaySeconds: 60
           periodSeconds: 10
         name: kubearmor

--- a/deployments/EKS/kubearmor.yaml
+++ b/deployments/EKS/kubearmor.yaml
@@ -83,10 +83,9 @@ spec:
         livenessProbe:
           exec:
             command:
-            - /bin/bash
+            - /bin/sh
             - -c
-            - /grpc_health_probe
-            - -addr=:32767
+            - /grpc_health_probe -addr=:32767
           initialDelaySeconds: 60
           periodSeconds: 10
         name: kubearmor-relay-server
@@ -134,10 +133,8 @@ spec:
             command:
             - /bin/bash
             - -c
-            - if [ -z $(pgrep kubearmor) ]; then exit 1; fi;
-            - '&&'
-            - /grpc_health_probe
-            - -addr=:32767
+            - /grpc_health_probe -addr=:32767 && if [ -z $(pgrep kubearmor) ]; then
+              exit 1; fi;
           initialDelaySeconds: 60
           periodSeconds: 10
         name: kubearmor

--- a/deployments/GKE/kubearmor.yaml
+++ b/deployments/GKE/kubearmor.yaml
@@ -80,6 +80,15 @@ spec:
     spec:
       containers:
       - image: kubearmor/kubearmor-relay-server:latest
+        livenessProbe:
+          exec:
+            command:
+            - /bin/bash
+            - -c
+            - /grpc_health_probe
+            - -addr=:32767
+          initialDelaySeconds: 60
+          periodSeconds: 10
         name: kubearmor-relay-server
         ports:
         - containerPort: 32767
@@ -126,6 +135,9 @@ spec:
             - /bin/bash
             - -c
             - if [ -z $(pgrep kubearmor) ]; then exit 1; fi;
+            - '&&'
+            - /grpc_health_probe
+            - -addr=:32767
           initialDelaySeconds: 60
           periodSeconds: 10
         name: kubearmor

--- a/deployments/GKE/kubearmor.yaml
+++ b/deployments/GKE/kubearmor.yaml
@@ -83,10 +83,9 @@ spec:
         livenessProbe:
           exec:
             command:
-            - /bin/bash
+            - /bin/sh
             - -c
-            - /grpc_health_probe
-            - -addr=:32767
+            - /grpc_health_probe -addr=:32767
           initialDelaySeconds: 60
           periodSeconds: 10
         name: kubearmor-relay-server
@@ -134,10 +133,8 @@ spec:
             command:
             - /bin/bash
             - -c
-            - if [ -z $(pgrep kubearmor) ]; then exit 1; fi;
-            - '&&'
-            - /grpc_health_probe
-            - -addr=:32767
+            - /grpc_health_probe -addr=:32767 && if [ -z $(pgrep kubearmor) ]; then
+              exit 1; fi;
           initialDelaySeconds: 60
           periodSeconds: 10
         name: kubearmor

--- a/deployments/OKE/kubearmor.yaml
+++ b/deployments/OKE/kubearmor.yaml
@@ -80,6 +80,15 @@ spec:
     spec:
       containers:
       - image: kubearmor/kubearmor-relay-server:latest
+        livenessProbe:
+          exec:
+            command:
+            - /bin/bash
+            - -c
+            - /grpc_health_probe
+            - -addr=:32767
+          initialDelaySeconds: 60
+          periodSeconds: 10
         name: kubearmor-relay-server
         ports:
         - containerPort: 32767
@@ -126,6 +135,9 @@ spec:
             - /bin/bash
             - -c
             - if [ -z $(pgrep kubearmor) ]; then exit 1; fi;
+            - '&&'
+            - /grpc_health_probe
+            - -addr=:32767
           initialDelaySeconds: 60
           periodSeconds: 10
         name: kubearmor

--- a/deployments/OKE/kubearmor.yaml
+++ b/deployments/OKE/kubearmor.yaml
@@ -83,10 +83,9 @@ spec:
         livenessProbe:
           exec:
             command:
-            - /bin/bash
+            - /bin/sh
             - -c
-            - /grpc_health_probe
-            - -addr=:32767
+            - /grpc_health_probe -addr=:32767
           initialDelaySeconds: 60
           periodSeconds: 10
         name: kubearmor-relay-server
@@ -134,10 +133,8 @@ spec:
             command:
             - /bin/bash
             - -c
-            - if [ -z $(pgrep kubearmor) ]; then exit 1; fi;
-            - '&&'
-            - /grpc_health_probe
-            - -addr=:32767
+            - /grpc_health_probe -addr=:32767 && if [ -z $(pgrep kubearmor) ]; then
+              exit 1; fi;
           initialDelaySeconds: 60
           periodSeconds: 10
         name: kubearmor

--- a/deployments/docker/kubearmor.yaml
+++ b/deployments/docker/kubearmor.yaml
@@ -80,6 +80,15 @@ spec:
     spec:
       containers:
       - image: kubearmor/kubearmor-relay-server:latest
+        livenessProbe:
+          exec:
+            command:
+            - /bin/bash
+            - -c
+            - /grpc_health_probe
+            - -addr=:32767
+          initialDelaySeconds: 60
+          periodSeconds: 10
         name: kubearmor-relay-server
         ports:
         - containerPort: 32767
@@ -126,6 +135,9 @@ spec:
             - /bin/bash
             - -c
             - if [ -z $(pgrep kubearmor) ]; then exit 1; fi;
+            - '&&'
+            - /grpc_health_probe
+            - -addr=:32767
           initialDelaySeconds: 60
           periodSeconds: 10
         name: kubearmor

--- a/deployments/docker/kubearmor.yaml
+++ b/deployments/docker/kubearmor.yaml
@@ -83,10 +83,9 @@ spec:
         livenessProbe:
           exec:
             command:
-            - /bin/bash
+            - /bin/sh
             - -c
-            - /grpc_health_probe
-            - -addr=:32767
+            - /grpc_health_probe -addr=:32767
           initialDelaySeconds: 60
           periodSeconds: 10
         name: kubearmor-relay-server
@@ -134,10 +133,8 @@ spec:
             command:
             - /bin/bash
             - -c
-            - if [ -z $(pgrep kubearmor) ]; then exit 1; fi;
-            - '&&'
-            - /grpc_health_probe
-            - -addr=:32767
+            - /grpc_health_probe -addr=:32767 && if [ -z $(pgrep kubearmor) ]; then
+              exit 1; fi;
           initialDelaySeconds: 60
           periodSeconds: 10
         name: kubearmor

--- a/deployments/generic/kubearmor.yaml
+++ b/deployments/generic/kubearmor.yaml
@@ -80,6 +80,15 @@ spec:
     spec:
       containers:
       - image: kubearmor/kubearmor-relay-server:latest
+        livenessProbe:
+          exec:
+            command:
+            - /bin/bash
+            - -c
+            - /grpc_health_probe
+            - -addr=:32767
+          initialDelaySeconds: 60
+          periodSeconds: 10
         name: kubearmor-relay-server
         ports:
         - containerPort: 32767
@@ -126,6 +135,9 @@ spec:
             - /bin/bash
             - -c
             - if [ -z $(pgrep kubearmor) ]; then exit 1; fi;
+            - '&&'
+            - /grpc_health_probe
+            - -addr=:32767
           initialDelaySeconds: 60
           periodSeconds: 10
         name: kubearmor

--- a/deployments/generic/kubearmor.yaml
+++ b/deployments/generic/kubearmor.yaml
@@ -83,10 +83,9 @@ spec:
         livenessProbe:
           exec:
             command:
-            - /bin/bash
+            - /bin/sh
             - -c
-            - /grpc_health_probe
-            - -addr=:32767
+            - /grpc_health_probe -addr=:32767
           initialDelaySeconds: 60
           periodSeconds: 10
         name: kubearmor-relay-server
@@ -134,10 +133,8 @@ spec:
             command:
             - /bin/bash
             - -c
-            - if [ -z $(pgrep kubearmor) ]; then exit 1; fi;
-            - '&&'
-            - /grpc_health_probe
-            - -addr=:32767
+            - /grpc_health_probe -addr=:32767 && if [ -z $(pgrep kubearmor) ]; then
+              exit 1; fi;
           initialDelaySeconds: 60
           periodSeconds: 10
         name: kubearmor

--- a/deployments/get/objects.go
+++ b/deployments/get/objects.go
@@ -149,6 +149,20 @@ func GetRelayDeployment(namespace string) *appsv1.Deployment {
 									ContainerPort: port,
 								},
 							},
+							LivenessProbe: &corev1.Probe{
+								ProbeHandler: corev1.ProbeHandler{
+									Exec: &corev1.ExecAction{
+										Command: []string{
+											"/bin/bash",
+											"-c",
+											"/grpc_health_probe",
+											"-addr=:32767",
+										},
+									},
+								},
+								InitialDelaySeconds: 60,
+								PeriodSeconds:       10,
+							},
 						},
 					},
 				},
@@ -612,6 +626,9 @@ func GenerateDaemonSet(env, namespace string) *appsv1.DaemonSet {
 											"/bin/bash",
 											"-c",
 											"if [ -z $(pgrep kubearmor) ]; then exit 1; fi;",
+											"&&",
+											"/grpc_health_probe",
+											"-addr=:32767",
 										},
 									},
 								},

--- a/deployments/get/objects.go
+++ b/deployments/get/objects.go
@@ -153,10 +153,9 @@ func GetRelayDeployment(namespace string) *appsv1.Deployment {
 								ProbeHandler: corev1.ProbeHandler{
 									Exec: &corev1.ExecAction{
 										Command: []string{
-											"/bin/bash",
+											"/bin/sh",
 											"-c",
-											"/grpc_health_probe",
-											"-addr=:32767",
+											"/grpc_health_probe -addr=:32767",
 										},
 									},
 								},
@@ -625,10 +624,7 @@ func GenerateDaemonSet(env, namespace string) *appsv1.DaemonSet {
 										Command: []string{
 											"/bin/bash",
 											"-c",
-											"if [ -z $(pgrep kubearmor) ]; then exit 1; fi;",
-											"&&",
-											"/grpc_health_probe",
-											"-addr=:32767",
+											"/grpc_health_probe -addr=:32767 && if [ -z $(pgrep kubearmor) ]; then exit 1; fi;",
 										},
 									},
 								},

--- a/deployments/k3s/kubearmor.yaml
+++ b/deployments/k3s/kubearmor.yaml
@@ -80,6 +80,15 @@ spec:
     spec:
       containers:
       - image: kubearmor/kubearmor-relay-server:latest
+        livenessProbe:
+          exec:
+            command:
+            - /bin/bash
+            - -c
+            - /grpc_health_probe
+            - -addr=:32767
+          initialDelaySeconds: 60
+          periodSeconds: 10
         name: kubearmor-relay-server
         ports:
         - containerPort: 32767
@@ -126,6 +135,9 @@ spec:
             - /bin/bash
             - -c
             - if [ -z $(pgrep kubearmor) ]; then exit 1; fi;
+            - '&&'
+            - /grpc_health_probe
+            - -addr=:32767
           initialDelaySeconds: 60
           periodSeconds: 10
         name: kubearmor

--- a/deployments/k3s/kubearmor.yaml
+++ b/deployments/k3s/kubearmor.yaml
@@ -83,10 +83,9 @@ spec:
         livenessProbe:
           exec:
             command:
-            - /bin/bash
+            - /bin/sh
             - -c
-            - /grpc_health_probe
-            - -addr=:32767
+            - /grpc_health_probe -addr=:32767
           initialDelaySeconds: 60
           periodSeconds: 10
         name: kubearmor-relay-server
@@ -134,10 +133,8 @@ spec:
             command:
             - /bin/bash
             - -c
-            - if [ -z $(pgrep kubearmor) ]; then exit 1; fi;
-            - '&&'
-            - /grpc_health_probe
-            - -addr=:32767
+            - /grpc_health_probe -addr=:32767 && if [ -z $(pgrep kubearmor) ]; then
+              exit 1; fi;
           initialDelaySeconds: 60
           periodSeconds: 10
         name: kubearmor

--- a/deployments/microk8s/kubearmor.yaml
+++ b/deployments/microk8s/kubearmor.yaml
@@ -80,6 +80,15 @@ spec:
     spec:
       containers:
       - image: kubearmor/kubearmor-relay-server:latest
+        livenessProbe:
+          exec:
+            command:
+            - /bin/bash
+            - -c
+            - /grpc_health_probe
+            - -addr=:32767
+          initialDelaySeconds: 60
+          periodSeconds: 10
         name: kubearmor-relay-server
         ports:
         - containerPort: 32767
@@ -126,6 +135,9 @@ spec:
             - /bin/bash
             - -c
             - if [ -z $(pgrep kubearmor) ]; then exit 1; fi;
+            - '&&'
+            - /grpc_health_probe
+            - -addr=:32767
           initialDelaySeconds: 60
           periodSeconds: 10
         name: kubearmor

--- a/deployments/microk8s/kubearmor.yaml
+++ b/deployments/microk8s/kubearmor.yaml
@@ -83,10 +83,9 @@ spec:
         livenessProbe:
           exec:
             command:
-            - /bin/bash
+            - /bin/sh
             - -c
-            - /grpc_health_probe
-            - -addr=:32767
+            - /grpc_health_probe -addr=:32767
           initialDelaySeconds: 60
           periodSeconds: 10
         name: kubearmor-relay-server
@@ -134,10 +133,8 @@ spec:
             command:
             - /bin/bash
             - -c
-            - if [ -z $(pgrep kubearmor) ]; then exit 1; fi;
-            - '&&'
-            - /grpc_health_probe
-            - -addr=:32767
+            - /grpc_health_probe -addr=:32767 && if [ -z $(pgrep kubearmor) ]; then
+              exit 1; fi;
           initialDelaySeconds: 60
           periodSeconds: 10
         name: kubearmor

--- a/deployments/minikube/kubearmor.yaml
+++ b/deployments/minikube/kubearmor.yaml
@@ -80,6 +80,15 @@ spec:
     spec:
       containers:
       - image: kubearmor/kubearmor-relay-server:latest
+        livenessProbe:
+          exec:
+            command:
+            - /bin/bash
+            - -c
+            - /grpc_health_probe
+            - -addr=:32767
+          initialDelaySeconds: 60
+          periodSeconds: 10
         name: kubearmor-relay-server
         ports:
         - containerPort: 32767
@@ -125,6 +134,9 @@ spec:
             - /bin/bash
             - -c
             - if [ -z $(pgrep kubearmor) ]; then exit 1; fi;
+            - '&&'
+            - /grpc_health_probe
+            - -addr=:32767
           initialDelaySeconds: 60
           periodSeconds: 10
         name: kubearmor

--- a/deployments/minikube/kubearmor.yaml
+++ b/deployments/minikube/kubearmor.yaml
@@ -83,10 +83,9 @@ spec:
         livenessProbe:
           exec:
             command:
-            - /bin/bash
+            - /bin/sh
             - -c
-            - /grpc_health_probe
-            - -addr=:32767
+            - /grpc_health_probe -addr=:32767
           initialDelaySeconds: 60
           periodSeconds: 10
         name: kubearmor-relay-server
@@ -133,10 +132,8 @@ spec:
             command:
             - /bin/bash
             - -c
-            - if [ -z $(pgrep kubearmor) ]; then exit 1; fi;
-            - '&&'
-            - /grpc_health_probe
-            - -addr=:32767
+            - /grpc_health_probe -addr=:32767 && if [ -z $(pgrep kubearmor) ]; then
+              exit 1; fi;
           initialDelaySeconds: 60
           periodSeconds: 10
         name: kubearmor


### PR DESCRIPTION
**Purpose of PR?**:

Fixes https://github.com/kubearmor/kubearmor-relay-server/issues/18

**Does this PR introduce a breaking change?**
No
**If the changes in this PR are manually verified, list down the scenarios covered:**:
Deployed manifest files and examined pods
