### PR TITLE
fix(deployments): Update ClusterRole Rules

### DIFF
--- a/deployments/AKS/kubearmor.yaml
+++ b/deployments/AKS/kubearmor.yaml
@@ -29,13 +29,14 @@ rules:
   - pods
   - nodes
   - namespaces
+  - configmaps
   verbs:
   - patch
   - list
   - watch
   - update
 - apiGroups:
-  - security.kubearmor.io
+  - security.kubearmor.com
   resources:
   - kubearmorpolicies
   - kubearmorhostpolicies

--- a/deployments/BottleRocket/kubearmor.yaml
+++ b/deployments/BottleRocket/kubearmor.yaml
@@ -29,13 +29,14 @@ rules:
   - pods
   - nodes
   - namespaces
+  - configmaps
   verbs:
   - patch
   - list
   - watch
   - update
 - apiGroups:
-  - security.kubearmor.io
+  - security.kubearmor.com
   resources:
   - kubearmorpolicies
   - kubearmorhostpolicies

--- a/deployments/EKS/kubearmor.yaml
+++ b/deployments/EKS/kubearmor.yaml
@@ -29,13 +29,14 @@ rules:
   - pods
   - nodes
   - namespaces
+  - configmaps
   verbs:
   - patch
   - list
   - watch
   - update
 - apiGroups:
-  - security.kubearmor.io
+  - security.kubearmor.com
   resources:
   - kubearmorpolicies
   - kubearmorhostpolicies

--- a/deployments/GKE/kubearmor.yaml
+++ b/deployments/GKE/kubearmor.yaml
@@ -29,13 +29,14 @@ rules:
   - pods
   - nodes
   - namespaces
+  - configmaps
   verbs:
   - patch
   - list
   - watch
   - update
 - apiGroups:
-  - security.kubearmor.io
+  - security.kubearmor.com
   resources:
   - kubearmorpolicies
   - kubearmorhostpolicies

--- a/deployments/OKE/kubearmor.yaml
+++ b/deployments/OKE/kubearmor.yaml
@@ -29,13 +29,14 @@ rules:
   - pods
   - nodes
   - namespaces
+  - configmaps
   verbs:
   - patch
   - list
   - watch
   - update
 - apiGroups:
-  - security.kubearmor.io
+  - security.kubearmor.com
   resources:
   - kubearmorpolicies
   - kubearmorhostpolicies

--- a/deployments/docker/kubearmor.yaml
+++ b/deployments/docker/kubearmor.yaml
@@ -29,13 +29,14 @@ rules:
   - pods
   - nodes
   - namespaces
+  - configmaps
   verbs:
   - patch
   - list
   - watch
   - update
 - apiGroups:
-  - security.kubearmor.io
+  - security.kubearmor.com
   resources:
   - kubearmorpolicies
   - kubearmorhostpolicies

--- a/deployments/generic/kubearmor.yaml
+++ b/deployments/generic/kubearmor.yaml
@@ -29,13 +29,14 @@ rules:
   - pods
   - nodes
   - namespaces
+  - configmaps
   verbs:
   - patch
   - list
   - watch
   - update
 - apiGroups:
-  - security.kubearmor.io
+  - security.kubearmor.com
   resources:
   - kubearmorpolicies
   - kubearmorhostpolicies

--- a/deployments/get/objects.go
+++ b/deployments/get/objects.go
@@ -43,11 +43,11 @@ func GetClusterRole() *rbacv1.ClusterRole {
 		Rules: []rbacv1.PolicyRule{
 			{
 				APIGroups: []string{""},
-				Resources: []string{"pods", "nodes", "namespaces"},
+				Resources: []string{"pods", "nodes", "namespaces", "configmaps"},
 				Verbs:     []string{"patch", "list", "watch", "update"},
 			},
 			{
-				APIGroups: []string{"security.kubearmor.io"},
+				APIGroups: []string{"security.kubearmor.com"},
 				Resources: []string{"kubearmorpolicies", "kubearmorhostpolicies"},
 				Verbs:     []string{"get", "list", "watch", "update", "delete"},
 			},

--- a/deployments/k3s/kubearmor.yaml
+++ b/deployments/k3s/kubearmor.yaml
@@ -29,13 +29,14 @@ rules:
   - pods
   - nodes
   - namespaces
+  - configmaps
   verbs:
   - patch
   - list
   - watch
   - update
 - apiGroups:
-  - security.kubearmor.io
+  - security.kubearmor.com
   resources:
   - kubearmorpolicies
   - kubearmorhostpolicies

--- a/deployments/microk8s/kubearmor.yaml
+++ b/deployments/microk8s/kubearmor.yaml
@@ -29,13 +29,14 @@ rules:
   - pods
   - nodes
   - namespaces
+  - configmaps
   verbs:
   - patch
   - list
   - watch
   - update
 - apiGroups:
-  - security.kubearmor.io
+  - security.kubearmor.com
   resources:
   - kubearmorpolicies
   - kubearmorhostpolicies

--- a/deployments/minikube/kubearmor.yaml
+++ b/deployments/minikube/kubearmor.yaml
@@ -29,13 +29,14 @@ rules:
   - pods
   - nodes
   - namespaces
+  - configmaps
   verbs:
   - patch
   - list
   - watch
   - update
 - apiGroups:
-  - security.kubearmor.io
+  - security.kubearmor.com
   resources:
   - kubearmorpolicies
   - kubearmorhostpolicies


### PR DESCRIPTION
**Purpose of PR?**:
The clusterrole rules didn't have rules to access configmaps resources. This PR added it to the rules and there were a type in resource API group security.kubearmor.~~io~~com it also has been fixed with this PR. 
Fixes #1104 

**Does this PR introduce a breaking change?**
No
**If the changes in this PR are manually verified, list down the scenarios covered:**:
tested on AKE cluster with Ubuntu 18.04.6 LTS  5.4.0-1101-azure Kernel, everything is working fine.
**Additional information for reviewer?** :
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [x] Bug fix. Fixes #1104 
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`

<!--

The PR title message must follow convention:
`<type>(<scope>): <subject>`.

Where: <br />
- `type` is to define what type of PR is this.
  Most common types are:
    - `feat`      - for new features, not a new feature for build script
    - `fix`       - for bug fixes or improvements, not a fix for build script
    - `chore`     - changes not related to production code
    - `docs`      - changes related to documentation
    - `style`     - formatting, missing semi colons, linting fix etc; no significant production code changes
    - `test`      - adding missing tests, refactoring tests; no production code change
    - `refactor`  - refactoring production code, eg. renaming a variable or function name, there should not be any significant production code changes

- `scope` is a single word that best describes where the changes fit.
    - feature(`monitor`,`enforcer`)
    - test(`tests`, `bdd`)
    - chore(`build`)
- `subject` is a single line brief description of the changes made in the pull request.

-->