### PR TITLE
fix(monitor(bpf)): store full path from path_mknod

### DIFF
--- a/KubeArmor/BPF/system_monitor.c
+++ b/KubeArmor/BPF/system_monitor.c
@@ -889,6 +889,13 @@ static __always_inline int security_path_task_arg(struct pt_regs *ctx){
 }
 
 #if defined(SECURITY_PATH)
+SEC("kprobe/security_path_mknod")
+int kprobe__security_path_mknod(struct pt_regs *ctx){
+    if (skip_syscall())
+		return 0;
+    return security_path__dir_path_args(ctx);
+}
+
 SEC("kprobe/security_path_unlink")
 int kprobe__security_path_unlink(struct pt_regs *ctx){
     if (skip_syscall())

--- a/KubeArmor/monitor/systemMonitor.go
+++ b/KubeArmor/monitor/systemMonitor.go
@@ -268,7 +268,7 @@ func (mon *SystemMonitor) InitBPF() error {
 	systemCalls := []string{"open", "openat", "execve", "execveat", "socket", "connect", "accept", "bind", "listen", "unlink", "unlinkat", "rmdir", "ptrace", "chown", "setuid", "setgid", "fchownat", "mount", "umount"}
 	// {category, event}
 	sysTracepoints := [][2]string{{"syscalls", "sys_exit_openat"}}
-	sysKprobes := []string{"do_exit", "security_bprm_check", "security_file_open", "security_path_unlink", "security_path_rmdir", "security_ptrace_access_check"}
+	sysKprobes := []string{"do_exit", "security_bprm_check", "security_file_open", "security_path_mknod", "security_path_unlink", "security_path_rmdir", "security_ptrace_access_check"}
 	netSyscalls := []string{"tcp_connect"}
 	netRetSyscalls := []string{"inet_csk_accept"}
 


### PR DESCRIPTION

**Purpose of PR?**:

Fixes #1118
We leverage security hooks to find out full paths for resources. With file creation related operations, if an enforcement is in place our security hook would never be called since the execution is blocked by a security hook upper in the stack. This commit adds an additional hook to store the full path information which should help us handle cases where `security_file_open` is never called. 

**Does this PR introduce a breaking change?**
No

**If the changes in this PR are manually verified, list down the scenarios covered:**:
Check touch based Alerts on denials



**Checklist:**
- [x] Bug fix. Fixes #<issue number>
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Commit has unit tests
- [ ] Commit has integration tests

<!--

The PR title message must follow convention:
`<type>(<scope>): <subject>`.

Where: <br />
- `type` is to define what type of PR is this.
  Most common types are:
    - `feat`      - for new features, not a new feature for build script
    - `fix`       - for bug fixes or improvements, not a fix for build script
    - `chore`     - changes not related to production code
    - `docs`      - changes related to documentation
    - `style`     - formatting, missing semi colons, linting fix etc; no significant production code changes
    - `test`      - adding missing tests, refactoring tests; no production code change
    - `refactor`  - refactoring production code, eg. renaming a variable or function name, there should not be any significant production code changes

- `scope` is a single word that best describes where the changes fit.
    - feature(`monitor`,`enforcer`)
    - test(`tests`, `bdd`)
    - chore(`build`)
- `subject` is a single line brief description of the changes made in the pull request.

-->