### PR TITLE
fix(core, monitor): events getting lost/missing pod metadata

### DIFF
--- a/KubeArmor/BPF/system_monitor.c
+++ b/KubeArmor/BPF/system_monitor.c
@@ -447,9 +447,10 @@ static __always_inline u32 skip_syscall()
     }
 
     u32 pid = bpf_get_current_pid_tgid() >> 32;
-    if (bpf_map_lookup_elem(&pid_ns_map,&pid) != 0) {
-        return 0;
+    if (bpf_map_lookup_elem(&pid_ns_map,&pid) == 0) {
+        return add_pid_ns();
     }
+    return 0;
 
 #elif defined(MONITOR_CONTAINER)
 
@@ -458,9 +459,10 @@ static __always_inline u32 skip_syscall()
         return 1;
     }
 
-    if (bpf_map_lookup_elem(&pid_ns_map,&pid_ns) != 0) {
-        return 0;
+    if (bpf_map_lookup_elem(&pid_ns_map,&pid_ns) == 0) {
+        return add_pid_ns();
     }
+    return 0;
 
 #else // MONITOR_CONTAINER or MONITOR_CONTAINER_AND_HOST
 
@@ -468,17 +470,17 @@ static __always_inline u32 skip_syscall()
     if (pid_ns == PROC_PID_INIT_INO) { // host
         u32 pid = bpf_get_current_pid_tgid() >> 32;
         if (bpf_map_lookup_elem(&pid_ns_map,&pid) != 0) {
-            return 0;
+            return add_pid_ns();
         }
     } else { // container
-        if (bpf_map_lookup_elem(&pid_ns_map,&pid_ns) != 0) {
-            return 0;
+        if (bpf_map_lookup_elem(&pid_ns_map,&pid_ns) == 0) {
+            return add_pid_ns();
         }
     }
+    return 0;
 
 #endif /* MONITOR_CONTAINER || MONITOR_HOST */
 
-    return 1;
 }
 
 // == Context Management == //

--- a/KubeArmor/core/kubeUpdate.go
+++ b/KubeArmor/core/kubeUpdate.go
@@ -339,6 +339,8 @@ func (dm *KubeArmorDaemon) UpdateEndPointWithPod(action string, pod tp.K8sPod) {
 			dm.UpdateEndPointWithPod("ADDED", pod)
 
 		} else {
+			newEndPoint.NamespaceName = pod.Metadata["namespaceName"]
+			newEndPoint.EndPointName = pod.Metadata["podName"]
 			newEndPoint.Labels = map[string]string{}
 			newEndPoint.Identities = []string{"namespaceName=" + pod.Metadata["namespaceName"]}
 


### PR DESCRIPTION
**Purpose of PR?**:
Fixes #1014 

This PR fixes 2 bugs related to telemetry events:
1. Core daemon - Events with missing pod name and NS coming in when pod is restarted
2. Monitor - Events being dropped at kernel level unless the container has made an EXEC syscall

**Does this PR introduce a breaking change?**
No

**If the changes in this PR are manually verified, list down the scenarios covered:**:

#### For 1:
- Deploy some workloads (https://github.com/GoogleCloudPlatform/microservices-demo/blob/main/release/kubernetes-manifests.yaml)
- Install kubearmor and try to get karmor logs for a pod
- Restart the pod
- Try to get `karmor logs --logFilter=all` again. It would work now, didn't work earlier.

Thanks to @Shreyas220 for debugging along.

#### For 2:
- Deploy google microservices (we'll target the frontend service in particular because it calls exec once and before kubearmor starts)
- Install kubearmor after that
- If you check, you won't get any events related to network, process operations.
- Now exec into the frontend pod, you'll start getting all types of logs.

This has been fixed by updating the monitor to update the PidNS map on all syscalls instead of just exec.
Thanks to @achrefbensaad for the fix!

**Additional information for reviewer?** :

**Checklist:**
- [x] Bug fix. Fixes #<issue number>
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Commit has unit tests
- [ ] Commit has integration tests

<!--

The PR title message must follow convention:
`<type>(<scope>): <subject>`.

Where: <br />
- `type` is to define what type of PR is this.
  Most common types are:
    - `feat`      - for new features, not a new feature for build script
    - `fix`       - for bug fixes or improvements, not a fix for build script
    - `chore`     - changes not related to production code
    - `docs`      - changes related to documentation
    - `style`     - formatting, missing semi colons, linting fix etc; no significant production code changes
    - `test`      - adding missing tests, refactoring tests; no production code change
    - `refactor`  - refactoring production code, eg. renaming a variable or function name, there should not be any significant production code changes

- `scope` is a single word that best describes where the changes fit.
    - feature(`monitor`,`enforcer`)
    - test(`tests`, `bdd`)
    - chore(`build`)
- `subject` is a single line brief description of the changes made in the pull request.

-->