### PR TITLE
fix(tests): Use enforcer-agnostic annotation in tests

### DIFF
--- a/tests/block/block_test.go
+++ b/tests/block/block_test.go
@@ -54,10 +54,7 @@ var _ = Describe("Posture", func() {
 	// var sql string
 
 	BeforeEach(func() {
-		wp = getWpsqlPod("wordpress-",
-			"container.apparmor.security.beta.kubernetes.io/wordpress: localhost/kubearmor-wordpress-mysql-wordpress-wordpress")
-		// sql = getWpsqlPod("mysql-",
-		// 	"container.apparmor.security.beta.kubernetes.io/mysql: localhost/kubearmor-wordpress-mysql-mysql-mysql")
+		wp = getWpsqlPod("wordpress-", "kubearmor-policy: enabled")
 	})
 
 	AfterEach(func() {

--- a/tests/configmap/kubearmor_config_test.go
+++ b/tests/configmap/kubearmor_config_test.go
@@ -64,9 +64,9 @@ var _ = Describe("KubeArmor-Config", func() {
 	var partialyAnnotated string
 	var fullyAnnotated string
 	BeforeEach(func() {
-		unannotated = getUnannotatedPod("unannotated-", "container.apparmor.security.beta.kubernetes.io/ubuntu-1: localhost/kubearmor-unannotated-unannotated-deployment-ubuntu-1")
-		partialyAnnotated = getPartialyAnnotatedPod("partialyannotated-", "container.apparmor.security.beta.kubernetes.io/ubuntu-1: localhost/kubearmor-partialyannotated-partialyannotated-deployment-ubuntu-1")
-		fullyAnnotated = getFullyAnnotatedPod("fullyannotated-", "container.apparmor.security.beta.kubernetes.io/ubuntu-1: localhost/kubearmor-fullyannotated-fullyannotated-deployment-ubuntu-1")
+		unannotated = getUnannotatedPod("unannotated-", "kubearmor-policy: enabled")
+		partialyAnnotated = getPartialyAnnotatedPod("partialyannotated-", "kubearmor-policy: enabled")
+		fullyAnnotated = getFullyAnnotatedPod("fullyannotated-", "kubearmor-policy: enabled")
 		cm := NewDefaultConfigMapData()
 		cm.CreateKAConfigMap()
 	})

--- a/tests/ksp/ksp_test.go
+++ b/tests/ksp/ksp_test.go
@@ -44,13 +44,9 @@ func getUbuntuPod(name string, ant string) string {
 var _ = Describe("Ksp", func() {
 	var ub1, ub3, ub4 string
 	BeforeEach(func() {
-		ub1 = getUbuntuPod("ubuntu-1",
-			"container.apparmor.security.beta.kubernetes.io/ubuntu-1-container: localhost/kubearmor-multiubuntu-ubuntu-1-deployment-ubuntu-1-container")
-		ub3 = getUbuntuPod("ubuntu-3",
-			"container.apparmor.security.beta.kubernetes.io/ubuntu-3-container: localhost/kubearmor-multiubuntu-ubuntu-3-deployment-ubuntu-3-container")
-		ub4 = getUbuntuPod("ubuntu-4",
-			"container.apparmor.security.beta.kubernetes.io/ubuntu-4-container: localhost/kubearmor-multiubuntu-ubuntu-4-deployment-ubuntu-4-container")
-		fmt.Print(ub1, ub4, ub3)
+		ub1 = getUbuntuPod("ubuntu-1", "kubearmor-policy: enabled")
+		ub3 = getUbuntuPod("ubuntu-3", "kubearmor-policy: enabled")
+		ub4 = getUbuntuPod("ubuntu-4", "kubearmor-policy: enabled")
 	})
 
 	AfterEach(func() {

--- a/tests/multicontainer/multicontainer_test.go
+++ b/tests/multicontainer/multicontainer_test.go
@@ -39,7 +39,7 @@ func getMultiContainerPod(name string, ant string) string {
 var _ = Describe("Multicontainer", func() {
 	var multicontainer string
 	BeforeEach(func() {
-		multicontainer = getMultiContainerPod("multicontainer-", "container.apparmor.security.beta.kubernetes.io/container-1: localhost/kubearmor-multicontainer-multicontainer-deployment-container-1")
+		multicontainer = getMultiContainerPod("multicontainer-", "kubearmor-policy: enabled")
 	})
 
 	AfterEach(func() {

--- a/tests/smoke/smoke_test.go
+++ b/tests/smoke/smoke_test.go
@@ -42,10 +42,8 @@ var _ = Describe("Smoke", func() {
 	var sql string
 
 	BeforeEach(func() {
-		wp = getWpsqlPod("wordpress-",
-			"container.apparmor.security.beta.kubernetes.io/wordpress: localhost/kubearmor-wordpress-mysql-wordpress-wordpress")
-		sql = getWpsqlPod("mysql-",
-			"container.apparmor.security.beta.kubernetes.io/mysql: localhost/kubearmor-wordpress-mysql-mysql-mysql")
+		wp = getWpsqlPod("wordpress-", "kubearmor-policy: enabled")
+		sql = getWpsqlPod("mysql-", "kubearmor-policy: enabled")
 	})
 
 	AfterEach(func() {

--- a/tests/syscalls/syscalls_test.go
+++ b/tests/syscalls/syscalls_test.go
@@ -41,8 +41,7 @@ var _ = Describe("Syscalls", func() {
 	_ = ubuntu
 
 	BeforeEach(func() {
-		ubuntu = getUbuntuPod("ubuntu-1-deployment-",
-			"container.apparmor.security.beta.kubernetes.io/ubuntu-1-container: localhost/kubearmor-syscalls-ubuntu-1-deployment-ubuntu-1-container")
+		ubuntu = getUbuntuPod("ubuntu-1-deployment-", "kubearmor-policy: enabled")
 	})
 
 	AfterEach(func() {

--- a/tests/visibility/visibility_test.go
+++ b/tests/visibility/visibility_test.go
@@ -42,8 +42,7 @@ var _ = Describe("Visibility", func() {
 	var wp string
 
 	BeforeEach(func() {
-		wp = getWpsqlPod("wordpress-",
-			"container.apparmor.security.beta.kubernetes.io/wordpress: localhost/kubearmor-wordpress-mysql-wordpress-wordpress")
+		wp = getWpsqlPod("wordpress-", "kubearmor-policy: enabled")
 	})
 
 	AfterEach(func() {


### PR DESCRIPTION
**Purpose of PR?**:
At this point the ginkgo tests are implemented in such a way that they will work only if current enforcer is AppArmor due to the dependency on AppArmor annotations. Merging this PR will enable the tests to work with bpflsm enforcer too.

_As GH action doesn't support enabling bpflsm for now this fix will enable users do testing locally with KubeArmor running as system process._
Fixes #1129 

**Does this PR introduce a breaking change?**
No
**If the changes in this PR are manually verified, list down the scenarios covered:**:
tested for both AppArmor and BPFLSM enforcer, able to run the tests in both scenarios.
**Additional information for reviewer?** :
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [x] Bug fix. Fixes #<issue number>
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`

<!--

The PR title message must follow convention:
`<type>(<scope>): <subject>`.

Where: <br />
- `type` is to define what type of PR is this.
  Most common types are:
    - `feat`      - for new features, not a new feature for build script
    - `fix`       - for bug fixes or improvements, not a fix for build script
    - `chore`     - changes not related to production code
    - `docs`      - changes related to documentation
    - `style`     - formatting, missing semi colons, linting fix etc; no significant production code changes
    - `test`      - adding missing tests, refactoring tests; no production code change
    - `refactor`  - refactoring production code, eg. renaming a variable or function name, there should not be any significant production code changes

- `scope` is a single word that best describes where the changes fit.
    - feature(`monitor`,`enforcer`)
    - test(`tests`, `bdd`)
    - chore(`build`)
- `subject` is a single line brief description of the changes made in the pull request.

-->