### PR TITLE
manifest: update default init container tag to stable

### DIFF
--- a/deployments/AKS/kubearmor.yaml
+++ b/deployments/AKS/kubearmor.yaml
@@ -183,7 +183,7 @@ spec:
       hostNetwork: true
       hostPID: true
       initContainers:
-      - image: kubearmor/kubearmor-init:latest
+      - image: kubearmor/kubearmor-init:stable
         name: init
         securityContext:
           capabilities:

--- a/deployments/BottleRocket/kubearmor.yaml
+++ b/deployments/BottleRocket/kubearmor.yaml
@@ -184,7 +184,7 @@ spec:
       hostNetwork: true
       hostPID: true
       initContainers:
-      - image: kubearmor/kubearmor-init:latest
+      - image: kubearmor/kubearmor-init:stable
         name: init
         securityContext:
           capabilities:

--- a/deployments/EKS/kubearmor.yaml
+++ b/deployments/EKS/kubearmor.yaml
@@ -183,7 +183,7 @@ spec:
       hostNetwork: true
       hostPID: true
       initContainers:
-      - image: kubearmor/kubearmor-init:latest
+      - image: kubearmor/kubearmor-init:stable
         name: init
         securityContext:
           capabilities:

--- a/deployments/GKE/kubearmor.yaml
+++ b/deployments/GKE/kubearmor.yaml
@@ -183,7 +183,7 @@ spec:
       hostNetwork: true
       hostPID: true
       initContainers:
-      - image: kubearmor/kubearmor-init:latest
+      - image: kubearmor/kubearmor-init:stable
         name: init
         securityContext:
           capabilities:

--- a/deployments/OKE/kubearmor.yaml
+++ b/deployments/OKE/kubearmor.yaml
@@ -180,7 +180,7 @@ spec:
       hostNetwork: true
       hostPID: true
       initContainers:
-      - image: kubearmor/kubearmor-init:latest
+      - image: kubearmor/kubearmor-init:stable
         name: init
         securityContext:
           capabilities:

--- a/deployments/docker/kubearmor.yaml
+++ b/deployments/docker/kubearmor.yaml
@@ -180,7 +180,7 @@ spec:
       hostNetwork: true
       hostPID: true
       initContainers:
-      - image: kubearmor/kubearmor-init:latest
+      - image: kubearmor/kubearmor-init:stable
         name: init
         securityContext:
           capabilities:

--- a/deployments/generic/kubearmor.yaml
+++ b/deployments/generic/kubearmor.yaml
@@ -183,7 +183,7 @@ spec:
       hostNetwork: true
       hostPID: true
       initContainers:
-      - image: kubearmor/kubearmor-init:latest
+      - image: kubearmor/kubearmor-init:stable
         name: init
         securityContext:
           capabilities:

--- a/deployments/get/objects.go
+++ b/deployments/get/objects.go
@@ -548,7 +548,7 @@ func GenerateDaemonSet(env, namespace string) *appsv1.DaemonSet {
 					InitContainers: []corev1.Container{
 						{
 							Name:  "init",
-							Image: "kubearmor/kubearmor-init:latest",
+							Image: "kubearmor/kubearmor-init:stable",
 							SecurityContext: &corev1.SecurityContext{
 								Privileged: &privileged,
 								Capabilities: &corev1.Capabilities{

--- a/deployments/k3s/kubearmor.yaml
+++ b/deployments/k3s/kubearmor.yaml
@@ -180,7 +180,7 @@ spec:
       hostNetwork: true
       hostPID: true
       initContainers:
-      - image: kubearmor/kubearmor-init:latest
+      - image: kubearmor/kubearmor-init:stable
         name: init
         securityContext:
           capabilities:

--- a/deployments/microk8s/kubearmor.yaml
+++ b/deployments/microk8s/kubearmor.yaml
@@ -180,7 +180,7 @@ spec:
       hostNetwork: true
       hostPID: true
       initContainers:
-      - image: kubearmor/kubearmor-init:latest
+      - image: kubearmor/kubearmor-init:stable
         name: init
         securityContext:
           capabilities:

--- a/deployments/minikube/kubearmor.yaml
+++ b/deployments/minikube/kubearmor.yaml
@@ -179,7 +179,7 @@ spec:
       hostNetwork: true
       hostPID: true
       initContainers:
-      - image: kubearmor/kubearmor-init:latest
+      - image: kubearmor/kubearmor-init:stable
         name: init
         securityContext:
           capabilities:


### PR DESCRIPTION
Change default init container image to use stable tag cause latest can have breaking changes

**Purpose of PR?**:
Ref Breaking Changes in #1087

**Does this PR introduce a breaking change?**

**If the changes in this PR are manually verified, list down the scenarios covered:**:

**Additional information for reviewer?** :
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [ ] Bug fix. Fixes #<issue number>
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Commit has unit tests
- [ ] Commit has integration tests

<!--

The PR title message must follow convention:
`<type>(<scope>): <subject>`.

Where: <br />
- `type` is to define what type of PR is this.
  Most common types are:
    - `feat`      - for new features, not a new feature for build script
    - `fix`       - for bug fixes or improvements, not a fix for build script
    - `chore`     - changes not related to production code
    - `docs`      - changes related to documentation
    - `style`     - formatting, missing semi colons, linting fix etc; no significant production code changes
    - `test`      - adding missing tests, refactoring tests; no production code change
    - `refactor`  - refactoring production code, eg. renaming a variable or function name, there should not be any significant production code changes

- `scope` is a single word that best describes where the changes fit.
    - feature(`monitor`,`enforcer`)
    - test(`tests`, `bdd`)
    - chore(`build`)
- `subject` is a single line brief description of the changes made in the pull request.

-->