### PR TITLE
manifest(deploy): do not enable Host Policy Enforcement by default

### DIFF
--- a/deployments/AKS/kubearmor.yaml
+++ b/deployments/AKS/kubearmor.yaml
@@ -109,7 +109,6 @@ spec:
       containers:
       - args:
         - -gRPC=32767
-        - -enableKubeArmorHostPolicy
         env:
         - name: KUBEARMOR_NODENAME
           valueFrom:

--- a/deployments/BottleRocket/kubearmor.yaml
+++ b/deployments/BottleRocket/kubearmor.yaml
@@ -109,7 +109,6 @@ spec:
       containers:
       - args:
         - -gRPC=32767
-        - -enableKubeArmorHostPolicy
         - -criSocket=unix:///run/dockershim.sock
         env:
         - name: KUBEARMOR_NODENAME

--- a/deployments/EKS/kubearmor.yaml
+++ b/deployments/EKS/kubearmor.yaml
@@ -109,7 +109,6 @@ spec:
       containers:
       - args:
         - -gRPC=32767
-        - -enableKubeArmorHostPolicy
         env:
         - name: KUBEARMOR_NODENAME
           valueFrom:

--- a/deployments/GKE/kubearmor.yaml
+++ b/deployments/GKE/kubearmor.yaml
@@ -109,7 +109,6 @@ spec:
       containers:
       - args:
         - -gRPC=32767
-        - -enableKubeArmorHostPolicy
         env:
         - name: KUBEARMOR_NODENAME
           valueFrom:

--- a/deployments/OKE/kubearmor.yaml
+++ b/deployments/OKE/kubearmor.yaml
@@ -109,7 +109,6 @@ spec:
       containers:
       - args:
         - -gRPC=32767
-        - -enableKubeArmorHostPolicy
         env:
         - name: KUBEARMOR_NODENAME
           valueFrom:

--- a/deployments/docker/kubearmor.yaml
+++ b/deployments/docker/kubearmor.yaml
@@ -109,7 +109,6 @@ spec:
       containers:
       - args:
         - -gRPC=32767
-        - -enableKubeArmorHostPolicy
         env:
         - name: KUBEARMOR_NODENAME
           valueFrom:

--- a/deployments/generic/kubearmor.yaml
+++ b/deployments/generic/kubearmor.yaml
@@ -109,7 +109,6 @@ spec:
       containers:
       - args:
         - -gRPC=32767
-        - -enableKubeArmorHostPolicy
         env:
         - name: KUBEARMOR_NODENAME
           valueFrom:

--- a/deployments/get/defaults.go
+++ b/deployments/get/defaults.go
@@ -112,9 +112,7 @@ var envVar = []corev1.EnvVar{
 // Environment Specific Daemonset Configuration
 var defaultConfigs = map[string]DaemonSetConfig{
 	"generic": {
-		Args: []string{
-			"-enableKubeArmorHostPolicy",
-		},
+		Args: []string{},
 		Envs: envVar,
 		VolumeMounts: []corev1.VolumeMount{
 			apparmorVolMnt,
@@ -166,9 +164,7 @@ var defaultConfigs = map[string]DaemonSetConfig{
 		},
 	},
 	"oke": {
-		Args: []string{
-			"-enableKubeArmorHostPolicy",
-		},
+		Args: []string{},
 		Envs: envVar,
 		VolumeMounts: []corev1.VolumeMount{
 			apparmorVolMnt,
@@ -206,9 +202,7 @@ var defaultConfigs = map[string]DaemonSetConfig{
 		},
 	},
 	"docker": {
-		Args: []string{
-			"-enableKubeArmorHostPolicy",
-		},
+		Args: []string{},
 		Envs: envVar,
 		VolumeMounts: []corev1.VolumeMount{
 			apparmorVolMnt,
@@ -284,9 +278,7 @@ var defaultConfigs = map[string]DaemonSetConfig{
 		},
 	},
 	"microk8s": {
-		Args: []string{
-			"-enableKubeArmorHostPolicy",
-		},
+		Args: []string{},
 		Envs: envVar,
 		VolumeMounts: []corev1.VolumeMount{
 			apparmorVolMnt,
@@ -324,9 +316,7 @@ var defaultConfigs = map[string]DaemonSetConfig{
 		},
 	},
 	"k3s": {
-		Args: []string{
-			"-enableKubeArmorHostPolicy",
-		},
+		Args: []string{},
 		Envs: envVar,
 		VolumeMounts: []corev1.VolumeMount{
 			apparmorVolMnt,
@@ -364,9 +354,7 @@ var defaultConfigs = map[string]DaemonSetConfig{
 		},
 	},
 	"gke": {
-		Args: []string{
-			"-enableKubeArmorHostPolicy",
-		},
+		Args: []string{},
 		Envs: envVar,
 		VolumeMounts: []corev1.VolumeMount{
 			apparmorVolMnt,
@@ -418,9 +406,7 @@ var defaultConfigs = map[string]DaemonSetConfig{
 		},
 	},
 	"eks": {
-		Args: []string{
-			"-enableKubeArmorHostPolicy",
-		},
+		Args: []string{},
 		Envs: envVar,
 		VolumeMounts: []corev1.VolumeMount{
 			apparmorVolMnt,
@@ -473,7 +459,6 @@ var defaultConfigs = map[string]DaemonSetConfig{
 	},
 	"bottlerocket": {
 		Args: []string{
-			"-enableKubeArmorHostPolicy",
 			"-criSocket=unix:///run/dockershim.sock",
 		},
 		Envs: envVar,
@@ -527,9 +512,7 @@ var defaultConfigs = map[string]DaemonSetConfig{
 		},
 	},
 	"aks": {
-		Args: []string{
-			"-enableKubeArmorHostPolicy",
-		},
+		Args: []string{},
 		Envs: envVar,
 		VolumeMounts: []corev1.VolumeMount{
 			apparmorVolMnt,

--- a/deployments/k3s/kubearmor.yaml
+++ b/deployments/k3s/kubearmor.yaml
@@ -109,7 +109,6 @@ spec:
       containers:
       - args:
         - -gRPC=32767
-        - -enableKubeArmorHostPolicy
         env:
         - name: KUBEARMOR_NODENAME
           valueFrom:

--- a/deployments/microk8s/kubearmor.yaml
+++ b/deployments/microk8s/kubearmor.yaml
@@ -109,7 +109,6 @@ spec:
       containers:
       - args:
         - -gRPC=32767
-        - -enableKubeArmorHostPolicy
         env:
         - name: KUBEARMOR_NODENAME
           valueFrom:


### PR DESCRIPTION
**Purpose of PR?**:
Enabling KubeArmor Host policy increases the visibility and load on KubeArmor by a lot and most of the managed providers don't need host policy enforcement, so disabling it by default

<!--

The PR title message must follow convention:
`<type>(<scope>): <subject>`.

Where: <br />
- `type` is to define what type of PR is this.
  Most common types are:
    - `feat`      - for new features, not a new feature for build script
    - `fix`       - for bug fixes or improvements, not a fix for build script
    - `chore`     - changes not related to production code
    - `docs`      - changes related to documentation
    - `style`     - formatting, missing semi colons, linting fix etc; no significant production code changes
    - `test`      - adding missing tests, refactoring tests; no production code change
    - `refactor`  - refactoring production code, eg. renaming a variable or function name, there should not be any significant production code changes

- `scope` is a single word that best describes where the changes fit.
    - feature(`monitor`,`enforcer`)
    - test(`tests`, `bdd`)
    - chore(`build`)
- `subject` is a single line brief description of the changes made in the pull request.

-->