### PR TITLE
fix：KubeArmor running in host mode is dropping events due to busy event channel

### DIFF
--- a/KubeArmor/monitor/systemMonitor.go
+++ b/KubeArmor/monitor/systemMonitor.go
@@ -633,6 +633,8 @@ func (mon *SystemMonitor) TraceSyscall() {
 				select {
 				case mon.SyscallChannel <- dataRaw:
 				default:
+					// channel is full, wait for a short time before retrying
+					time.Sleep(1 * time.Second)
 					mon.Logger.Warn("Event droped due to busy event channel")
 				}
 			}()


### PR DESCRIPTION
**Purpose of PR?**:
Bugfix: KubeArmor running in host mode is dropping events due to busy event channel
Fixes #1155
**Does this PR introduce a breaking change?**

**If the changes in this PR are manually verified, list down the scenarios covered:**:

**Additional information for reviewer?** :
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [x] Bug fix. Fixes #<issue number>
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Commit has unit tests
- [ ] Commit has integration tests

<!--

The PR title message must follow convention:
`<type>(<scope>): <subject>`.

Where: <br />
- `type` is to define what type of PR is this.
  Most common types are:
    - `feat`      - for new features, not a new feature for build script
    - `fix`       - for bug fixes or improvements, not a fix for build script
    - `chore`     - changes not related to production code
    - `docs`      - changes related to documentation
    - `style`     - formatting, missing semi colons, linting fix etc; no significant production code changes
    - `test`      - adding missing tests, refactoring tests; no production code change
    - `refactor`  - refactoring production code, eg. renaming a variable or function name, there should not be any significant production code changes

- `scope` is a single word that best describes where the changes fit.
    - feature(`monitor`,`enforcer`)
    - test(`tests`, `bdd`)
    - chore(`build`)
- `subject` is a single line brief description of the changes made in the pull request.

-->