### PR TITLE
[WIP] Test ArchLinux-6.2.1 support

### DIFF
--- a/getting-started/support_matrix.md
+++ b/getting-started/support_matrix.md
@@ -70,6 +70,7 @@ Following distributions are tested for VM/Bare-metal based installations:
 | Rocky Linux | Rocky Linux >= 8.5 | Full | Full |
 | AWS | Amazon Linux 2022 | Full | Full |
 | RaspberryPi (ARM) | Debian | Full | Full |
+| ArchLinux | ArchLinux-6.2.1   | Full | Full |
 
 > **Note**
 > Full: Supports both enforcement and observability  


### PR DESCRIPTION
Adresses issue [#1093](https://github.com/kubearmor/KubeArmor/issues/1093)
This pr is made to add ArchLinux-6.2.1 to the support matrix.
Multiubuntu system has been run on a k3s and policy has been enforced.

`karmor sysdump` Output.
[karmor-sysdump-Mon Apr  3 16_05_30 IST 2023.zip](https://github.com/kubearmor/KubeArmor/files/11137453/karmor-sysdump-Mon.Apr.3.16_05_30.IST.2023.zip)

