### PR TITLE
add support for Amazon Linux 2023

### DIFF
--- a/getting-started/support_matrix.md
+++ b/getting-started/support_matrix.md
@@ -69,6 +69,7 @@ Following distributions are tested for VM/Bare-metal based installations:
 | Fedora | Fedora 34 / 35 | Full | Full |
 | Rocky Linux | Rocky Linux >= 8.5 | Full | Full |
 | AWS | Amazon Linux 2022 | Full | Full |
+| AWS | Amazon Linux 2023 | Full | Full |
 | RaspberryPi (ARM) | Debian | Full | Full |
 
 > **Note**


### PR DESCRIPTION
**Support for KubeArmor on [Amazon Linux 2023](https://aws.amazon.com/linux/amazon-linux-2023/)**:
Fixes: #1194 

- [x] Check if policy enforcement, observability, audit rules, network segmentation is supported
- [x] Get output of `karmor probe` (in the comment)
- [x] Update [kubearmor support matrix](https://github.com/kubearmor/KubeArmor/blob/main/getting-started/support_matrix.md)
- [x] Provide and attach `karmor sysdump` : [karmor-sysdump-Tue Apr  4 05_54_10 UTC 2023.zip](https://github.com/kubearmor/KubeArmor/files/11145355/karmor-sysdump-Tue.Apr.4.05_54_10.UTC.2023.zip)

