### PR TITLE
chore(CI): Update CRI-O installation script to fetch latest version

### DIFF
--- a/contribution/self-managed-k8s/crio/install_crio.sh
+++ b/contribution/self-managed-k8s/crio/install_crio.sh
@@ -10,7 +10,10 @@ if [ "$NAME" != "Ubuntu" ]; then
 fi
 
 OS="x${NAME}_${VERSION_ID}"
-VERSION=1.23
+
+# install cri-o corresponding to the latest k3s version
+VERSION=$(curl -w '%{url_effective}' -L -s -S https://update.k3s.io/v1-release/channels/stable -o /dev/null | sed -e 's|.*/v||' | cut -d '.' -f1,2)
+echo "Installing CRI-O version $VERSION"
 
 # get signing keys
 echo "deb [signed-by=/usr/share/keyrings/libcontainers-archive-keyring.gpg] https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/$OS/ /" | sudo tee /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list


### PR DESCRIPTION
**Purpose of PR?**:

Fixes #1197 

**Does this PR introduce a breaking change?**
No

**If the changes in this PR are manually verified, list down the scenarios covered:**:
Tested in GH CI.

**Additional information for reviewer?** :
This PR updates the CRI-O installation script and adds a way to install the latest version by getting the current stable k3s version first.
This should work with any cluster however we've used k3s because our CI is based on k3s.

**Checklist:**
- [x] Bug fix. Fixes #<issue number>
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Commit has unit tests
- [ ] Commit has integration tests

<!--

The PR title message must follow convention:
`<type>(<scope>): <subject>`.

Where: <br />
- `type` is to define what type of PR is this.
  Most common types are:
    - `feat`      - for new features, not a new feature for build script
    - `fix`       - for bug fixes or improvements, not a fix for build script
    - `chore`     - changes not related to production code
    - `docs`      - changes related to documentation
    - `style`     - formatting, missing semi colons, linting fix etc; no significant production code changes
    - `test`      - adding missing tests, refactoring tests; no production code change
    - `refactor`  - refactoring production code, eg. renaming a variable or function name, there should not be any significant production code changes

- `scope` is a single word that best describes where the changes fit.
    - feature(`monitor`,`enforcer`)
    - test(`tests`, `bdd`)
    - chore(`build`)
- `subject` is a single line brief description of the changes made in the pull request.

-->