### PR TITLE
core: setup visibibility map for unorchestrated workloads

### DIFF
--- a/KubeArmor/core/kubeArmor.go
+++ b/KubeArmor/core/kubeArmor.go
@@ -467,6 +467,8 @@ func KubeArmor() {
 	// Un-orchestrated workloads
 	if !dm.K8sEnabled && cfg.GlobalCfg.Policy {
 
+		dm.SetContainerNSVisibility()
+
 		// Check if cri socket set, if not then auto detect
 		if cfg.GlobalCfg.CRISocket == "" {
 			if kl.GetCRISocket("") == "" {

--- a/KubeArmor/core/unorchestratedUpdates.go
+++ b/KubeArmor/core/unorchestratedUpdates.go
@@ -15,6 +15,27 @@ import (
 	tp "github.com/kubearmor/KubeArmor/KubeArmor/types"
 )
 
+// SetContainerVisibility function enables visibility flag arguments for un-orchestrated container and updates the visibility map
+func (dm *KubeArmorDaemon) SetContainerNSVisibility() {
+
+	visibility := tp.Visibility{}
+
+	if strings.Contains(cfg.GlobalCfg.Visibility, "process") {
+		visibility.Process = true
+	}
+	if strings.Contains(cfg.GlobalCfg.Visibility, "file") {
+		visibility.File = true
+	}
+	if strings.Contains(cfg.GlobalCfg.Visibility, "network") {
+		visibility.Network = true
+	}
+	if strings.Contains(cfg.GlobalCfg.Visibility, "capabilities") {
+		visibility.Capabilities = true
+	}
+
+	dm.UpdateVisibility("ADDED", "container_namespace", visibility)
+}
+
 // ====================================== //
 // == Container Security Policy Update == //
 // ====================================== //


### PR DESCRIPTION
This PR populates visibility map of unorchestrated containers where namespace is custom set to "container_namespace" based on the config values

Tested on Docker
