### PR TITLE
fix(monitor): set actual process name in logs instead of symlinks

### DIFF
--- a/KubeArmor/monitor/logUpdate.go
+++ b/KubeArmor/monitor/logUpdate.go
@@ -6,7 +6,6 @@ package monitor
 import (
 	"fmt"
 	"strconv"
-	"strings"
 
 	kl "github.com/kubearmor/KubeArmor/KubeArmor/common"
 	tp "github.com/kubearmor/KubeArmor/KubeArmor/types"
@@ -95,25 +94,22 @@ func (mon *SystemMonitor) BuildLogBase(eventID int32, msg ContextCombined) tp.Lo
 
 // UpdateLogBase Function (SYS_EXECVE, SYS_EXECVEAT)
 func (mon *SystemMonitor) UpdateLogBase(eventID int32, log tp.Log) tp.Log {
-	if log.ParentProcessName == "" || !strings.HasPrefix(log.ParentProcessName, "/") {
-		parentProcessName := mon.GetParentExecPath(log.ContainerID, uint32(log.HostPID))
-		if parentProcessName != "" {
-			log.ParentProcessName = parentProcessName
-		}
+
+	// update the process paths, since we would have received actual exec paths from bprm hook
+
+	parentProcessName := mon.GetParentExecPath(log.ContainerID, uint32(log.HostPID))
+	if parentProcessName != "" {
+		log.ParentProcessName = parentProcessName
 	}
 
-	if log.ProcessName == "" || !strings.HasPrefix(log.ProcessName, "/") {
-		processName := mon.GetExecPath(log.ContainerID, uint32(log.HostPID))
-		if processName != "" {
-			log.ProcessName = processName
-		}
+	processName := mon.GetExecPath(log.ContainerID, uint32(log.HostPID))
+	if processName != "" {
+		log.ProcessName = processName
 	}
 
-	if log.Source == "" || !strings.HasPrefix(log.Source, "/") {
-		source := mon.GetExecPath(log.ContainerID, uint32(log.HostPPID))
-		if source != "" {
-			log.Source = source
-		}
+	source := mon.GetExecPath(log.ContainerID, uint32(log.HostPPID))
+	if source != "" {
+		log.Source = source
 	}
 
 	return log


### PR DESCRIPTION
We resolved actual process names in and stored it in the userspace process map, but we never updated the log base created in kprobe event.

This PR removes the null check and updates the log base with actual process names in the kretprobe event which we would have recieved from the bprm hook which was triggered before kretprobe execve(at)

**Purpose of PR?**:

Fixes #984

**Does this PR introduce a breaking change?**
No

**If the changes in this PR are manually verified, list down the scenarios covered:**:
Check Telemetry Info using kArmor logs

**Additional information for reviewer?** :
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [ ] Bug fix. Fixes #984
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Commit has unit tests
- [ ] Commit has integration tests

<!--

The PR title message must follow convention:
`<type>(<scope>): <subject>`.

Where: <br />
- `type` is to define what type of PR is this.
  Most common types are:
    - `feat`      - for new features, not a new feature for build script
    - `fix`       - for bug fixes or improvements, not a fix for build script
    - `chore`     - changes not related to production code
    - `docs`      - changes related to documentation
    - `style`     - formatting, missing semi colons, linting fix etc; no significant production code changes
    - `test`      - adding missing tests, refactoring tests; no production code change
    - `refactor`  - refactoring production code, eg. renaming a variable or function name, there should not be any significant production code changes

- `scope` is a single word that best describes where the changes fit.
    - feature(`monitor`,`enforcer`)
    - test(`tests`, `bdd`)
    - chore(`build`)
- `subject` is a single line brief description of the changes made in the pull request.

-->