### PR TITLE
fix(enforcer): correct rule handling for matchDirectories

### DIFF
--- a/KubeArmor/enforcer/bpflsm/rulesHandling.go
+++ b/KubeArmor/enforcer/bpflsm/rulesHandling.go
@@ -415,7 +415,7 @@ func dirtoMap(idx int, p, src string, m map[InnerKey][2]uint8, val [2]uint8) {
 		}
 		if oldval, ok := m[key]; ok {
 			if oldval[idx]&DIR != 0 {
-				val[idx] = val[idx] | DIR
+				val[idx] = oldval[idx] | HINT
 			}
 		}
 		m[key] = val


### PR DESCRIPTION
We use hints to optimise directory map lookups in kernel space, but there are chances a particular path could both be actual directory rule and hint at the same time. We had incorrect handling where when hints are added they overrid the actual directory rule config. This commit fixes that handling
