### PR TITLE
Fix for owner object in logs in unorchestrated workloads

### DIFF
--- a/KubeArmor/core/dockerHandler.go
+++ b/KubeArmor/core/dockerHandler.go
@@ -182,6 +182,11 @@ func (dm *KubeArmorDaemon) SetContainerVisibility(containerID string) {
 	container.EndPointName = container.ContainerName
 	container.NamespaceName = "container_namespace"
 
+	// owner info
+	container.Owner.Name = container.ContainerName
+	container.Owner.Namespace = container.NamespaceName
+	container.Owner.Ref = "Container"
+
 	dm.Containers[container.ContainerID] = container
 }
 
@@ -298,14 +303,11 @@ func (dm *KubeArmorDaemon) UpdateDockerContainer(containerID, action string) {
 
 		dm.ContainersLock.Lock()
 		if _, ok := dm.Containers[containerID]; !ok {
-			fmt.Printf("WE ARE HERE ______________________------------------------+++++++++++++++++++++++----------\n")
-
 			dm.Containers[containerID] = container
 			dm.ContainersLock.Unlock()
 		} else if dm.Containers[containerID].PidNS == 0 && dm.Containers[containerID].MntNS == 0 {
 			// this entry was updated by kubernetes before docker detects it
 			// thus, we here use the info given by kubernetes instead of the info given by docker
-			fmt.Printf("YAAAAAAAAAAAAAAAAAAA HERE ______________________------------------------+++++++++++++++++++++++----------\n")
 			container.NamespaceName = dm.Containers[containerID].NamespaceName
 			container.EndPointName = dm.Containers[containerID].EndPointName
 			container.Labels = dm.Containers[containerID].Labels

--- a/KubeArmor/core/dockerHandler.go
+++ b/KubeArmor/core/dockerHandler.go
@@ -298,12 +298,14 @@ func (dm *KubeArmorDaemon) UpdateDockerContainer(containerID, action string) {
 
 		dm.ContainersLock.Lock()
 		if _, ok := dm.Containers[containerID]; !ok {
+			fmt.Printf("WE ARE HERE ______________________------------------------+++++++++++++++++++++++----------\n")
+
 			dm.Containers[containerID] = container
 			dm.ContainersLock.Unlock()
 		} else if dm.Containers[containerID].PidNS == 0 && dm.Containers[containerID].MntNS == 0 {
 			// this entry was updated by kubernetes before docker detects it
 			// thus, we here use the info given by kubernetes instead of the info given by docker
-
+			fmt.Printf("YAAAAAAAAAAAAAAAAAAA HERE ______________________------------------------+++++++++++++++++++++++----------\n")
 			container.NamespaceName = dm.Containers[containerID].NamespaceName
 			container.EndPointName = dm.Containers[containerID].EndPointName
 			container.Labels = dm.Containers[containerID].Labels


### PR DESCRIPTION
**Purpose of PR?**:

Currently in unorchestrated workloads owner object is empty, after this fix owner object will have values such as Name, namespacename, ref.

Fixes in PR:
- updated the owner info of the container.

Example :
```
== Log / 2023-06-07 14:43:07.272859 ==
HostName: prateek-lenovo-ideapad-310-15isk
NamespaceName: container_namespace
PodName: quizzical_mccarthy
ContainerName: quizzical_mccarthy
ContainerID: 3554aeb218ca6d01c6110a1918a3fef522efb10347376a98ba8464dbfaa004ef
Type: ContainerLog
Source: /bin/sh
Resource: /dev/urandom
Operation: Syscall
Data: syscall=SYS_FCHOWNAT userid=0 group=0 mode=0
Result: Passed
HostPID: 368003
HostPPID: 367994
Owner: map[Name:quizzical_mccarthy Namespace:container_namespace Ref:Container]
PID: 1
PPID: 367994
ProcessName: /usr/bin/dash

```

Verified for Docker.


<!--

The PR title message must follow convention:
`<type>(<scope>): <subject>`.

Where: <br />
- `type` is to define what type of PR is this.
  Most common types are:
    - `feat`      - for new features, not a new feature for build script
    - `fix`       - for bug fixes or improvements, not a fix for build script
    - `chore`     - changes not related to production code
    - `docs`      - changes related to documentation
    - `style`     - formatting, missing semi colons, linting fix etc; no significant production code changes
    - `test`      - adding missing tests, refactoring tests; no production code change
    - `refactor`  - refactoring production code, eg. renaming a variable or function name, there should not be any significant production code changes

- `scope` is a single word that best describes where the changes fit.
    - feature(`monitor`,`enforcer`)
    - test(`tests`, `bdd`)
    - chore(`build`)
- `subject` is a single line brief description of the changes made in the pull request.

-->