### PR TITLE
fix(monitor): fix UpdateNsKeyMap and DestroyBPFMaps functions

### DIFF
--- a/KubeArmor/monitor/systemMonitor.go
+++ b/KubeArmor/monitor/systemMonitor.go
@@ -271,6 +271,10 @@ func (mon *SystemMonitor) initBPFMaps() error {
 
 // DestroyBPFMaps Function
 func (mon *SystemMonitor) DestroyBPFMaps() {
+	if mon.BpfNsVisibilityMap == nil {
+		return
+	}
+
 	err := mon.BpfNsVisibilityMap.Unpin()
 	if err != nil {
 		mon.Logger.Warnf("error unpinning bpf map kubearmor_visibility %v", err)
@@ -340,19 +344,19 @@ func (mon *SystemMonitor) UpdateNsKeyMap(action string, nsKey NsKey, visibility 
 
 		err = visibilityMap.Put(file.Key, file.Value)
 		if err != nil {
-			mon.Logger.Warnf("Cannot update visibility map. nskey=%+v, value=%+v, scope=file", nsKey)
+			mon.Logger.Warnf("Cannot update visibility map. nskey=%+v, value=%+v, scope=file", nsKey, file.Value)
 		}
 		err = visibilityMap.Put(process.Key, process.Value)
 		if err != nil {
-			mon.Logger.Warnf("Cannot update visibility map. nskey=%+v, value=%+v, scope=process", nsKey)
+			mon.Logger.Warnf("Cannot update visibility map. nskey=%+v, value=%+v, scope=process", nsKey, process.Value)
 		}
 		err = visibilityMap.Put(network.Key, network.Value)
 		if err != nil {
-			mon.Logger.Warnf("Cannot update visibility map. nskey=%+v, value=%+v, scope=network", nsKey)
+			mon.Logger.Warnf("Cannot update visibility map. nskey=%+v, value=%+v, scope=network", nsKey, network.Value)
 		}
 		err = visibilityMap.Put(capability.Key, capability.Value)
 		if err != nil {
-			mon.Logger.Warnf("Cannot update visibility map. nskey=%+v, value=%+v, scope=capability", nsKey)
+			mon.Logger.Warnf("Cannot update visibility map. nskey=%+v, value=%+v, scope=capability", nsKey, capability.Value)
 		}
 		mon.Logger.Printf("Updated visibility map with key=%+v for cid %s", nsKey, mon.NsMap[nsKey])
 	} else if action == "DELETED" {


### PR DESCRIPTION
The following errors occur when executing `KubeArmor/KubeArmor/build/test_kubearmor.sh` or `go test` in the directory `KubeArmor/KubeArmor/monitor`.

```bash
  > go test
  # github.com/kubearmor/KubeArmor/KubeArmor/monitor
  ./systemMonitor.go:343:4: (*github.com/kubearmor/KubeArmor/KubeArmor/feeder.Feeder).Warnf format %+v reads arg #2, but call has 1 arg
  ./systemMonitor.go:347:4: (*github.com/kubearmor/KubeArmor/KubeArmor/feeder.Feeder).Warnf format %+v reads arg #2, but call has 1 arg
  ./systemMonitor.go:351:4: (*github.com/kubearmor/KubeArmor/KubeArmor/feeder.Feeder).Warnf format %+v reads arg #2, but call has 1 arg
  ./systemMonitor.go:355:4: (*github.com/kubearmor/KubeArmor/KubeArmor/feeder.Feeder).Warnf format %+v reads arg #2, but call has 1 arg
  FAIL  github.com/kubearmor/KubeArmor/KubeArmor/monitor [build failed]
```

This commit corrects the process in `KubeArmor/monitor/systemMonitor.go` so that the test can be executed normally.

When running the test, the error occurs when calling `mon.Logger.Warnf()`, which is called in the `UpdateNsKeyMap()`. This error occurs due to missing arguments.

The current implementation does not properly output the message. Also, the test cannot be executed.

Therefore, we will modify it so that this error is not output when `mon.Logger.Warnf()` is called.

Also, when the test was run again with this modification, an error occurred in `DestroyBPFMaps(`) due to a nil check failure of `mon.BpfNsVisibilityMap`.

Therefore, the logic to check for nil in `DestroyBPFMaps()` is also corrected.

**Purpose of PR?**:

Fixes #

I haven't created an issue.

**Does this PR introduce a breaking change?**

No.
Fixed processing to run [tests](https://github.com/kubearmor/KubeArmor/tree/main/KubeArmor/monitor) under monitor.

**If the changes in this PR are manually verified, list down the scenarios covered:**:

The following tests can be executed

- [systemMonitor_test.go](https://github.com/kubearmor/KubeArmor/blob/main/KubeArmor/monitor/systemMonitor_test.go)

**Additional information for reviewer?** :
_Mention if this PR is part of any design or a continuation of previous PRs_

Please let me know if there are other appropriate ways to implement this.

**Checklist:**
- [x] Bug fix. Fixes #<issue number>
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Commit has unit tests
- [ ] Commit has integration tests

<!--

The PR title message must follow convention:
`<type>(<scope>): <subject>`.

Where: <br />
- `type` is to define what type of PR is this.
  Most common types are:
    - `feat`      - for new features, not a new feature for build script
    - `fix`       - for bug fixes or improvements, not a fix for build script
    - `chore`     - changes not related to production code
    - `docs`      - changes related to documentation
    - `style`     - formatting, missing semi colons, linting fix etc; no significant production code changes
    - `test`      - adding missing tests, refactoring tests; no production code change
    - `refactor`  - refactoring production code, eg. renaming a variable or function name, there should not be any significant production code changes

- `scope` is a single word that best describes where the changes fit.
    - feature(`monitor`,`enforcer`)
    - test(`tests`, `bdd`)
    - chore(`build`)
- `subject` is a single line brief description of the changes made in the pull request.

-->