### PR TITLE
handling empty owner field

### DIFF
--- a/KubeArmor/feeder/feeder.go
+++ b/KubeArmor/feeder/feeder.go
@@ -602,17 +602,17 @@ func (fd *Feeder) PushLog(log tp.Log) {
 
 		pbAlert.NamespaceName = log.NamespaceName
 
-		var o *pb.Podowner
-		if log.Owner != nil {
-			o = &pb.Podowner{
+		var owner *pb.Podowner
+		if log.Owner != nil && (log.Owner.Ref != "" || log.Owner.Name != "" || log.Owner.Namespace != "") {
+			owner = &pb.Podowner{
 				Ref:       log.Owner.Ref,
 				Name:      log.Owner.Name,
 				Namespace: log.Owner.Namespace,
 			}
 		}
 
-		if pbAlert.Owner == nil {
-			pbAlert.Owner = o
+		if pbAlert.Owner == nil && owner != nil {
+			pbAlert.Owner = owner
 		}
 
 		pbAlert.PodName = log.PodName
@@ -688,17 +688,17 @@ func (fd *Feeder) PushLog(log tp.Log) {
 
 		pbLog.NamespaceName = log.NamespaceName
 
-		var o *pb.Podowner
-		if log.Owner != nil {
-			o = &pb.Podowner{
+		var owner *pb.Podowner
+		if log.Owner != nil && (log.Owner.Ref != "" || log.Owner.Name != "" || log.Owner.Namespace != "") {
+			owner = &pb.Podowner{
 				Ref:       log.Owner.Ref,
 				Name:      log.Owner.Name,
 				Namespace: log.Owner.Namespace,
 			}
 		}
 
-		if pbLog.Owner == nil {
-			pbLog.Owner = o
+		if pbLog.Owner == nil && owner != nil {
+			pbLog.Owner = owner
 		}
 
 		pbLog.PodName = log.PodName


### PR DESCRIPTION
**Purpose of PR?**:
Currently we're getting empty owner field in `karmor logs`, when owner's log info is empty. This pr resolves it.
Added some checks to checkout empty log owner info.

Logs having empty owner info:
```== Log / 2023-06-13 16:49:56.060713 ==
ClusterName: default
HostName: prateek-lenovo-ideapad-310-15isk
NamespaceName: default
PodName: nginx
ContainerName: 2455eecdfe6f80c7647c7e39340635a38198751e29db6863faab8b1c6ef37ec2
ContainerID: 2455eecdfe6f80c7647c7e39340635a38198751e29db6863faab8b1c6ef37ec2
Type: ContainerLog
Source: /usr/sbin/nginx
Resource: /etc/group
Operation: File
Data: syscall=SYS_OPENAT fd=-100 flags=O_RDONLY|O_CLOEXEC
Result: Passed
HostPID: 131118
HostPPID: 131059
PID: 30
PPID: 1
ParentProcessName: /usr/sbin/nginx
ProcessName: /usr/sbin/nginx
```
Logs having owner info:
```
== Log / 2023-06-13 16:49:56.725239 ==
ClusterName: default
HostName: prateek-lenovo-ideapad-310-15isk
NamespaceName: default
PodName: nginx
Labels: run=nginx
ContainerName: nginx
ContainerID: 2455eecdfe6f80c7647c7e39340635a38198751e29db6863faab8b1c6ef37ec2
ContainerImage: docker.io/library/nginx:latest@sha256:be51ee4ca05e6aaee1dd95bec50efdd5aed33390fbb21e7c29931ef5c8e1309a
Type: ContainerLog
Source: /usr/sbin/nginx -g daemon off;
Operation: Syscall
Data: syscall=SYS_SETGID userid=0
Result: Passed
HostPID: 131059
HostPPID: 131052
Owner: map[Name:nginx Namespace:default Ref:Pod]
PID: 1
PPID: 131052
ProcessName: /usr/sbin/nginx
```

<!--

The PR title message must follow convention:
`<type>(<scope>): <subject>`.

Where: <br />
- `type` is to define what type of PR is this.
  Most common types are:
    - `feat`      - for new features, not a new feature for build script
    - `fix`       - for bug fixes or improvements, not a fix for build script
    - `chore`     - changes not related to production code
    - `docs`      - changes related to documentation
    - `style`     - formatting, missing semi colons, linting fix etc; no significant production code changes
    - `test`      - adding missing tests, refactoring tests; no production code change
    - `refactor`  - refactoring production code, eg. renaming a variable or function name, there should not be any significant production code changes

- `scope` is a single word that best describes where the changes fit.
    - feature(`monitor`,`enforcer`)
    - test(`tests`, `bdd`)
    - chore(`build`)
- `subject` is a single line brief description of the changes made in the pull request.

-->