### PR TITLE
fix(CI): add the job to run go test on the KubeArmor/KubeArmor directory

### DIFF
--- a/.github/workflows/ci-test-go.yml
+++ b/.github/workflows/ci-test-go.yml
@@ -61,6 +61,19 @@ jobs:
         run: make gosec
         working-directory: KubeArmor
 
+  go-test:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-go@v3
+        with:
+          go-version: "v1.20"
+
+      - name: Run go test on the KubeArmor/KubeArmor directory
+        run: go test ./...
+        working-directory: KubeArmor
+
   license:
     runs-on: ubuntu-20.04
     steps:

--- a/KubeArmor/core/karmorprobedata.go
+++ b/KubeArmor/core/karmorprobedata.go
@@ -58,7 +58,7 @@ func (dm *KubeArmorDaemon) SetKarmorData() {
 	kd.HostVisibility = dm.Node.Annotations["kubearmor-visibility"]
 	err := kl.WriteToFile(kd, "/tmp/karmorProbeData.cfg")
 	if err != nil {
-		dm.Logger.Errf("Error writing karmor config data", err)
+		dm.Logger.Errf("Error writing karmor config data (%s)", err.Error())
 	}
 
 }


### PR DESCRIPTION
The current implementation does not have a job in CI to run tests for golang programs under the KubeArmor/KubeArmor directory.

Therefore, this commit will add the job to ci-test-go.yml to run tests for golang programs under the KubeArmor/KubeArmor directory.

**Purpose of PR?**:

Fixes #

I haven't created an issue. However, in the pull request #1264 , we were advised to add a CI to run tests of golang programs under KubeArmor/KubeArmor directory. Specifically, [this part](https://github.com/kubearmor/KubeArmor/pull/1264#issuecomment-1588526055) is applicable.

**Does this PR introduce a breaking change?**

No.
I added a job to `ci-test-go.yml` with this commit.

**If the changes in this PR are manually verified, list down the scenarios covered:**:

In the CI job, tests of golang programs can be run in the KubeArmor/KubeArmor directory.

**Additional information for reviewer?** :
_Mention if this PR is part of any design or a continuation of previous PRs_

Attached below is a screenshot of running the job I added in my verification environment.

<img width="1120" alt="image" src="https://github.com/kubearmor/KubeArmor/assets/44946173/ce284310-6c23-492f-bb40-42299b045839">

Note that at the moment, the test fails at the process in `KubeArmor/KubeArmor/core/karmorprobedata.go:61:17` as shown in the image. I will try to fix this in another pull request.

**Checklist:**
- [ ] Bug fix. Fixes #<issue number>
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Commit has unit tests
- [ ] Commit has integration tests

<!--

The PR title message must follow convention:
`<type>(<scope>): <subject>`.

Where: <br />
- `type` is to define what type of PR is this.
  Most common types are:
    - `feat`      - for new features, not a new feature for build script
    - `fix`       - for bug fixes or improvements, not a fix for build script
    - `chore`     - changes not related to production code
    - `docs`      - changes related to documentation
    - `style`     - formatting, missing semi colons, linting fix etc; no significant production code changes
    - `test`      - adding missing tests, refactoring tests; no production code change
    - `refactor`  - refactoring production code, eg. renaming a variable or function name, there should not be any significant production code changes

- `scope` is a single word that best describes where the changes fit.
    - feature(`monitor`,`enforcer`)
    - test(`tests`, `bdd`)
    - chore(`build`)
- `subject` is a single line brief description of the changes made in the pull request.

-->