### PR TITLE
fix(CI): use tagged image upon tag creation trigger in latest release workflow

### DIFF
--- a/.github/workflows/ci-latest-release.yml
+++ b/.github/workflows/ci-latest-release.yml
@@ -55,9 +55,12 @@ jobs:
         run: |
           helm upgrade --install kubearmor ./deployments/helm \
           --values ./KubeArmor/build/kubearmor-helm-test-values.yaml \
+          --set kubearmor.image.tag=${{ steps.vars.outputs.tag }} \
+          --set kubearmorInit.image.tag=${{ steps.vars.outputs.tag }} \
           -n kube-system;
 
           kubectl wait --for=condition=ready --timeout=5m -n kube-system pod -l kubearmor-app
+          kubectl get pods -A
 
       - name: Test KubeArmor using Ginkgo
         run: |


### PR DESCRIPTION
Tested on fork:
On push: https://github.com/DelusionalOptimist/KubeArmor/actions/runs/5390509068/jobs/9785951544
On tag creation: https://github.com/DelusionalOptimist/KubeArmor/actions/runs/5390516161/jobs/9785969213