### PR TITLE
test(syscalls): Add an annotation to Pod for syscalls test

### DIFF
--- a/tests/syscalls/manifests/ubuntu-deployment.yaml
+++ b/tests/syscalls/manifests/ubuntu-deployment.yaml
@@ -10,6 +10,8 @@ metadata:
   namespace: syscalls
   labels:
     deployment: ubuntu-1
+  annotations:
+    kubearmor-policy: enabled
 spec:
   replicas: 1
   selector:
@@ -19,6 +21,8 @@ spec:
     metadata:
       labels:
         container: ubuntu-1
+      annotations:
+        kubearmor-policy: enabled
     spec:
       containers:
       - name: ubuntu-1-container


### PR DESCRIPTION
When we run `ginkgo -r` in the `KubeArmor/tests/syscalls` directory on the local environment, we get a Pod not found error even though the Pod for testing is running, as shown below. Note that the error message is excerpted.

```bash
------------------------------
• [FAILED] [61.257 seconds]
Syscalls [BeforeEach] Match syscalls can detect unlink syscall
  [BeforeEach] /home/ec2-user/KubeArmor/tests/syscalls/syscalls_test.go:49
  [It] /home/ec2-user/KubeArmor/tests/syscalls/syscalls_test.go:59

  [FAILED] Expected
      <*errors.errorString | 0xc0006dc1e0>:
      pod not found
      {s: "pod not found"}
  to be nil
  In [BeforeEach] at: /home/ec2-user/KubeArmor/tests/syscalls/syscalls_test.go:40 @ 07/02/23 06:31:59.513
------------------------------
```

This is an error in `K8sGetPods()` in `syscalls_test.go` because the Pod deployed by `ubuntu-deployment.yaml` in the `KubeArmor/tests/syscalls/manifests` directory was not found. The current implementation of the test is not working.

The current implementation of the test uses the pod name prefix and namespace and annotation to find the Pod that will execute the test commands. In the implementation in s`yscalls_test.go`, the `prefix`, `namespace` and `annotation` are "ubuntu-1-deployment-", "syscalls", "kubearmor-policy: enabled".

The Pod being searched for is not annotated, and the test will not run because it cannot find the Pod even though it is running, resulting in the error described above.

Therefore, this commit modifies `ubuntu-deployment.yaml` to annotate the Pod so that the test will work correctly.

**Purpose of PR?**:

Fixes #

I haven't created an issue. 

**Does this PR introduce a breaking change?**

No.

I added annotations to `ubuntu-deployment.yaml` in the `KubeArmor/tests/syscalls/manifests` directory.

**If the changes in this PR are manually verified, list down the scenarios covered:**:

This pull request modifies `ubuntu-deployment.yaml` to annotate the Pod  so that the test will work correctly without the Pod not found error.

**Additional information for reviewer?** :
_Mention if this PR is part of any design or a continuation of previous PRs_

Please let me know if there are other appropriate ways to implement this.

**Checklist:**
- [x] Bug fix. Fixes #<issue number>
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Commit has unit tests
- [ ] Commit has integration tests

<!--

The PR title message must follow convention:
`<type>(<scope>): <subject>`.

Where: <br />
- `type` is to define what type of PR is this.
  Most common types are:
    - `feat`      - for new features, not a new feature for build script
    - `fix`       - for bug fixes or improvements, not a fix for build script
    - `chore`     - changes not related to production code
    - `docs`      - changes related to documentation
    - `style`     - formatting, missing semi colons, linting fix etc; no significant production code changes
    - `test`      - adding missing tests, refactoring tests; no production code change
    - `refactor`  - refactoring production code, eg. renaming a variable or function name, there should not be any significant production code changes

- `scope` is a single word that best describes where the changes fit.
    - feature(`monitor`,`enforcer`)
    - test(`tests`, `bdd`)
    - chore(`build`)
- `subject` is a single line brief description of the changes made in the pull request.

-->