### PR TITLE
docs: removed network microsegmentation use-case

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -12,7 +12,6 @@
 
 * [Harden Infrastructure](getting-started/hardening_guide.md)
 * [Least Permissive Access](getting-started/least_permissive_access.md)
-* [Network Segmentation](getting-started/network_segmentation.md)
 * [Application Behavior](getting-started/workload_visibility.md)
 * [Use-Cases](getting-started/use-cases.md)
 

--- a/getting-started/hardening_guide.md
+++ b/getting-started/hardening_guide.md
@@ -193,6 +193,6 @@ output report in out/report.txt ...
 
 Key highlights:
 1. The hardening policies are available by default in the `out` folder separated out in directories based on deployment names.
-2. Get an HTML report by using the option `--report report.html` with `karmor recommend`. [Sample HTML Report](https://githtmlpreview.netlify.app/?https://github.com/kubearmor/KubeArmor/blob/main/getting-started/hardening-report.html).
+2. Get an HTML report by using the option `--report report.html` with `karmor recommend`.
 3. Get hardening policies in context to specific compliance by specifying `--tag <CIS/MITRE/...>` option.
 


### PR DESCRIPTION
**Purpose of PR?**:
Network segmentation use-case depends on an external tooling called discovery engine. Intention is to remove dependency on external tooling. 

**Does this PR introduce a breaking change?**
No

**Checklist:**
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
