### PR TITLE
feat(monitor): monitor the chroot systemcall

### DIFF
--- a/KubeArmor/BPF/system_monitor.c
+++ b/KubeArmor/BPF/system_monitor.c
@@ -123,6 +123,7 @@ enum
     _SYS_SETGID = 106,
     _SYS_MOUNT = 165,
     _SYS_UMOUNT = 166,
+    _SYS_CHROOT = 161,
 
     // network
     _SYS_SOCKET = 41,
@@ -150,6 +151,7 @@ enum
     _SYS_SETGID = 144,
     _SYS_MOUNT = 165,
     _SYS_UMOUNT = 166,
+    _SYS_CHROOT = 51,
 
     // network
     _SYS_SOCKET = 198,
@@ -1067,6 +1069,14 @@ int kprobe__security_path_rmdir(struct pt_regs *ctx)
     return security_path__dir_path_args(ctx);
 }
 
+SEC("kprobe/security_path_chroot")
+int kprobe__security_path_chroot(struct pt_regs *ctx)
+{
+    if (skip_syscall())
+        return 0;
+    return security_path__dir_path_args(ctx);
+}
+
 SEC("kprobe/security_ptrace_access_check")
 int kprobe__security_ptrace_access_check(struct pt_regs *ctx)
 {
@@ -1710,6 +1720,21 @@ SEC("kretprobe/__x64_sys_umount")
 int kretprobe__umount(struct pt_regs *ctx)
 {
     return trace_ret_generic(_SYS_UMOUNT, ctx, ARG_TYPE0(STR_T) | ARG_TYPE1(UMOUNT_FLAG_T), _CAPS_PROBE);
+}
+
+SEC("kprobe/__x64_sys_chroot")
+int kprobe__chroot(struct pt_regs *ctx)
+{
+    if (skip_syscall())
+        return 0;
+
+    return save_args(_SYS_CHROOT, ctx);
+}
+
+SEC("kretprobe/__x64_sys_chroot")
+int kretprobe__chroot(struct pt_regs *ctx)
+{
+    return trace_ret_generic(_SYS_CHROOT, ctx, ARG_TYPE0(FILE_TYPE_T), _FILE_PROBE);
 }
 
 struct tracepoint_syscalls_sys_exit_t

--- a/KubeArmor/monitor/logUpdate.go
+++ b/KubeArmor/monitor/logUpdate.go
@@ -274,6 +274,20 @@ func (mon *SystemMonitor) UpdateLogs() {
 				log.Resource = fileName
 				log.Data = "syscall=" + GetSyscallName(int32(msg.ContextSys.EventID)) + " userid=" + strconv.Itoa(uid) + " group=" + strconv.Itoa(guid) + " mode=" + strconv.Itoa(mode)
 
+			case SysChroot:
+				if len(msg.ContextArgs) != 1 {
+					continue
+				}
+
+				var fileName string
+				if val, ok := msg.ContextArgs[0].(string); ok {
+					fileName = val
+				}
+
+				log.Operation = "Syscall"
+				log.Resource = fileName
+				log.Data = "syscall=" + GetSyscallName(int32(msg.ContextSys.EventID))
+
 			case SysSetuid, SysSetgid:
 				if len(msg.ContextArgs) != 1 {
 					continue

--- a/KubeArmor/monitor/syscallParser.go
+++ b/KubeArmor/monitor/syscallParser.go
@@ -932,6 +932,7 @@ var auditedSyscalls = map[int]string{
 	101: "ptrace",
 	165: "mount",
 	166: "umount",
+	161: "chroot",
 }
 
 func isAuditedSyscall(syscallID int32) bool {

--- a/KubeArmor/monitor/syscalls_amd64.go
+++ b/KubeArmor/monitor/syscalls_amd64.go
@@ -16,6 +16,7 @@ const (
 	SysRmdir    = 84
 	SysChown    = 92
 	SysFChownAt = 260
+	SysChroot   = 161
 
 	SysSetuid = 105
 	SysSetgid = 106

--- a/KubeArmor/monitor/syscalls_arm64.go
+++ b/KubeArmor/monitor/syscalls_arm64.go
@@ -19,6 +19,7 @@ const (
 	SysClose    = 57
 	SysUnlinkAt = 35
 	SysFChownAt = 54
+	SysChroot   = 51
 
 	SysSetuid = 146
 	SysSetgid = 144

--- a/KubeArmor/monitor/systemMonitor.go
+++ b/KubeArmor/monitor/systemMonitor.go
@@ -416,10 +416,10 @@ func (mon *SystemMonitor) InitBPF() error {
 	mon.Logger.Print("Initialized the eBPF system monitor")
 
 	// sysPrefix := bcc.GetSyscallPrefix()
-	systemCalls := []string{"open", "openat", "execve", "execveat", "socket", "connect", "accept", "bind", "listen", "unlink", "unlinkat", "rmdir", "ptrace", "chown", "setuid", "setgid", "fchownat", "mount", "umount"}
+	systemCalls := []string{"open", "openat", "execve", "execveat", "socket", "connect", "accept", "bind", "listen", "unlink", "unlinkat", "rmdir", "ptrace", "chown", "setuid", "setgid", "fchownat", "mount", "umount", "chroot"}
 	// {category, event}
 	sysTracepoints := [][2]string{{"syscalls", "sys_exit_openat"}}
-	sysKprobes := []string{"do_exit", "security_bprm_check", "security_file_open", "security_path_mknod", "security_path_unlink", "security_path_rmdir", "security_ptrace_access_check"}
+	sysKprobes := []string{"do_exit", "security_bprm_check", "security_file_open", "security_path_mknod", "security_path_unlink", "security_path_rmdir", "security_path_chroot", "security_ptrace_access_check"}
 	netSyscalls := []string{"tcp_connect"}
 	netRetSyscalls := []string{"inet_csk_accept"}
 
@@ -481,7 +481,6 @@ func (mon *SystemMonitor) InitBPF() error {
 
 // DestroySystemMonitor Function
 func (mon *SystemMonitor) DestroySystemMonitor() error {
-
 	(*mon.MonitorLock).Lock()
 	defer (*mon.MonitorLock).Unlock()
 
@@ -666,6 +665,10 @@ func (mon *SystemMonitor) TraceSyscall() {
 				}
 			} else if ctx.EventID == SysFChownAt {
 				if len(args) != 5 {
+					continue
+				}
+			} else if ctx.EventID == SysChroot {
+				if len(args) != 1 {
 					continue
 				}
 			} else if ctx.EventID == SysSetuid {

--- a/tests/k8s_env/Makefile
+++ b/tests/k8s_env/Makefile
@@ -6,7 +6,7 @@ build:
 	@go mod tidy
 	# run in two steps as syscall suite fails if run at the very end
 	# see - https://github.com/kubearmor/KubeArmor/issues/1269
-	@ginkgo --vv --flake-attempts=10 --timeout=30m syscalls/
+	@ginkgo --vv --flake-attempts=10 --timeout=60m syscalls/
 	@ginkgo -r --vv --flake-attempts=10 --timeout=30m --skip-package "syscalls"
 .PHONY: test
 test:

--- a/tests/k8s_env/Makefile
+++ b/tests/k8s_env/Makefile
@@ -6,7 +6,7 @@ build:
 	@go mod tidy
 	# run in two steps as syscall suite fails if run at the very end
 	# see - https://github.com/kubearmor/KubeArmor/issues/1269
-	@ginkgo --vv --flake-attempts=10 --timeout=10m syscalls/
+	@ginkgo --vv --flake-attempts=10 --timeout=30m syscalls/
 	@ginkgo -r --vv --flake-attempts=10 --timeout=30m --skip-package "syscalls"
 .PHONY: test
 test:

--- a/tests/k8s_env/syscalls/manifests/matchsyscalls/chroot.yaml
+++ b/tests/k8s_env/syscalls/manifests/matchsyscalls/chroot.yaml
@@ -1,0 +1,16 @@
+apiVersion: security.kubearmor.com/v1
+kind: KubeArmorPolicy
+metadata:
+  name: audit-all-chroot
+  namespace: syscalls
+spec:
+  severity: 3
+  selector:
+    matchLabels:
+      container: ubuntu-1
+  syscalls:
+    matchSyscalls:
+    - syscall:
+      - chroot
+  action:
+    Audit

--- a/tests/k8s_env/syscalls/syscalls_test.go
+++ b/tests/k8s_env/syscalls/syscalls_test.go
@@ -160,6 +160,27 @@ var _ = Describe("Syscalls", func() {
 
 		})
 
+		It("can detect chroot syscall", func() {
+			// Apply policy
+			err := K8sApply([]string{"manifests/matchsyscalls/chroot.yaml"})
+			Expect(err).To(BeNil())
+
+			// Start Kubearmor Logs
+			err = KarmorLogStart("policy", "syscalls", "Syscall", ubuntu)
+			Expect(err).To(BeNil())
+
+			_, _, err = K8sExecInPod(ubuntu, "syscalls", []string{"bash", "-c", "chroot /"})
+			Expect(err).To(BeNil())
+
+			// check policy alert
+			_, alerts, err := KarmorGetLogs(5*time.Second, 1)
+			Expect(err).To(BeNil())
+			Expect(len(alerts)).To(BeNumerically(">=", 1))
+			Expect(alerts[0].PolicyName).To(Equal("audit-all-chroot"))
+			Expect(alerts[0].Severity).To(Equal("3"))
+
+		})
+
 	})
 
 	Describe("Match paths", func() {

--- a/tests/util/kartutil.go
+++ b/tests/util/kartutil.go
@@ -306,13 +306,15 @@ func K8sExecInPod(pod string, ns string, cmd []string) (string, string, error) {
 	if err != nil {
 		return "", "", err
 	}
-	buf := &bytes.Buffer{}
+	stdinBuf := &bytes.Buffer{}
+	stdoutBuf := &bytes.Buffer{}
 	errBuf := &bytes.Buffer{}
 	exec.Stream(remotecommand.StreamOptions{
-		Stdout: buf,
+		Stdin:  stdinBuf,
+		Stdout: stdoutBuf,
 		Stderr: errBuf,
 	})
-	return buf.String(), errBuf.String(), nil
+	return stdoutBuf.String(), errBuf.String(), nil
 }
 
 // K8sExecInPodWithContainer Exec into the pod. Output: stdout, stderr, err


### PR DESCRIPTION
Currently, KubeArmor does not have the feature to monitor the chroot
system call.

On the other hand, there is a future request in Issue #1070 to support
audit for security sensitive system calls.

  - Issue #1070 

Therefore, this commit implements a new feature to monitor the chroot
system call.

This commit also includes a corresponding fix to allow standard input to
be used in the `K8sExecInPod function` in `kartutil.go` to run ginkgo test for
the chroot system call and so on.

**Purpose of PR?**:

Fixes #1070 

**Does this PR introduce a breaking change?**

No

**If the changes in this PR are manually verified, list down the scenarios covered:**:

The `chroot` system call can be monitored

**Additional information for reviewer?** :
_Mention if this PR is part of any design or a continuation of previous PRs_

- Result of `karmor logs --json` confirming that the `chroot` system call has been executed

```json
{
  "Timestamp": 1689491852,
  "UpdatedTime": "2023-07-16T07:17:32.077185Z",
  "ClusterName": "default",
  "HostName": "ip-172-31-36-15",
  "NamespaceName": "syscalls",
  "Owner": {
    "Ref": "Deployment",
    "Name": "ubuntu-1-deployment",
    "Namespace": "syscalls"
  },
  "PodName": "ubuntu-1-deployment-9c9dbdb8-mpkzg",
  "Labels": "container=ubuntu-1",
  "ContainerID": "fc231ca71c13188feb32aaf7c41f6357d2576411dba14a8a913119a2e70c3ea8",
  "ContainerName": "ubuntu-1-container",
  "ContainerImage": "kubearmor/ubuntu-w-utils:0.1@sha256:b4693b003ed1fbf7f5ef2c8b9b3f96fd853c30e1b39549cf98bd772fbd99e260",
  "HostPPID": 3392448,
  "HostPID": 3392770,
  "PPID": 3392448,
  "PID": 96,
  "ParentProcessName": "/usr/bin/containerd-shim",
  "ProcessName": "/bin/sh",
  "PolicyName": "audit-all-chroot",
  "Severity": "3",
  "Type": "MatchedPolicy",
  "Source": "/bin/sh -i",
  "Operation": "Syscall",
  "Resource": "/",
  "Data": "syscall=SYS_CHROOT",
  "Action": "Audit",
  "Result": "Passed"
}
```

- Results of tests by `Ginkgo`

The newly created scenario passed.

```bash
Created a gRPC client (localhost:32767)
Checked the liveness of the gRPC server
Started to watch alerts
releasing grpc client
Stopped WatchAlerts
•
```

**Checklist:**
- [ ] Bug fix. Fixes #<issue number>
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Commit has unit tests
- [ ] Commit has integration tests

<!--

The PR title message must follow convention:
`<type>(<scope>): <subject>`.

Where: <br />
- `type` is to define what type of PR is this.
  Most common types are:
    - `feat`      - for new features, not a new feature for build script
    - `fix`       - for bug fixes or improvements, not a fix for build script
    - `chore`     - changes not related to production code
    - `docs`      - changes related to documentation
    - `style`     - formatting, missing semi colons, linting fix etc; no significant production code changes
    - `test`      - adding missing tests, refactoring tests; no production code change
    - `refactor`  - refactoring production code, eg. renaming a variable or function name, there should not be any significant production code changes

- `scope` is a single word that best describes where the changes fit.
    - feature(`monitor`,`enforcer`)
    - test(`tests`, `bdd`)
    - chore(`build`)
- `subject` is a single line brief description of the changes made in the pull request.

-->