### PR TITLE
chore(deployment): remove kubearmor-controller resource limits

### DIFF
--- a/deployments/get/objects.go
+++ b/deployments/get/objects.go
@@ -565,13 +565,9 @@ func GetKubeArmorControllerDeployment(namespace string) *appsv1.Deployment {
 								PeriodSeconds:       int32(10),
 							},
 							Resources: corev1.ResourceRequirements{
-								Limits: corev1.ResourceList{
-									corev1.ResourceCPU:    resource.MustParse("100m"),
-									corev1.ResourceMemory: resource.MustParse("30Mi"),
-								},
 								Requests: corev1.ResourceList{
-									corev1.ResourceCPU:    resource.MustParse("100m"),
-									corev1.ResourceMemory: resource.MustParse("20Mi"),
+									corev1.ResourceCPU:    resource.MustParse("10m"),
+									corev1.ResourceMemory: resource.MustParse("64Mi"),
 								},
 							},
 						},

--- a/deployments/helm/templates/deployment.yaml
+++ b/deployments/helm/templates/deployment.yaml
@@ -78,9 +78,6 @@ spec:
           initialDelaySeconds: 5
           periodSeconds: 10
         resources:
-          limits:
-            cpu: 500m
-            memory: 128Mi
           requests:
             cpu: 10m
             memory: 64Mi

--- a/deployments/helm/values.yaml
+++ b/deployments/helm/values.yaml
@@ -520,7 +520,6 @@ kubearmor:
     - hostPath:
         path: /lib/modules
         type: Directory
-        type: DirectoryOrCreate
       name: lib-modules-path
     - hostPath:
         path: /sys/fs/bpf


### PR DESCRIPTION
**Purpose of PR?**:

Resource usage of kubearmor-controller is relative to the cluster size(no. of nodes, pods), to improve the reliability we're removing the resource limits for kubearmor-controller deployment.

**Does this PR introduce a breaking change?**
No
**If the changes in this PR are manually verified, list down the scenarios covered:**:

**Additional information for reviewer?** :
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [ ] Bug fix. Fixes #<issue number>
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Commit has unit tests
- [ ] Commit has integration tests

<!--

The PR title message must follow convention:
`<type>(<scope>): <subject>`.

Where: <br />
- `type` is to define what type of PR is this.
  Most common types are:
    - `feat`      - for new features, not a new feature for build script
    - `fix`       - for bug fixes or improvements, not a fix for build script
    - `chore`     - changes not related to production code
    - `docs`      - changes related to documentation
    - `style`     - formatting, missing semi colons, linting fix etc; no significant production code changes
    - `test`      - adding missing tests, refactoring tests; no production code change
    - `refactor`  - refactoring production code, eg. renaming a variable or function name, there should not be any significant production code changes

- `scope` is a single word that best describes where the changes fit.
    - feature(`monitor`,`enforcer`)
    - test(`tests`, `bdd`)
    - chore(`build`)
- `subject` is a single line brief description of the changes made in the pull request.

-->