### PR TITLE
chore(CI): Increase ci latest-release workflow timeout

### DIFF
--- a/.github/workflows/ci-latest-release.yml
+++ b/.github/workflows/ci-latest-release.yml
@@ -44,7 +44,7 @@ jobs:
     runs-on: ubuntu-20.04
     permissions:
       id-token: write 
-    timeout-minutes: 60
+    timeout-minutes: 120
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
**Purpose of PR?**: 

latest release workflow in the CI pipeline is failing due to current timeout limit of `60 minutes` which is not sufficient to build and push multi-platform container images for `kubearmor` and `kubearmor-init`. with this PR this timeout will be increase to `120 minutes`. 

**Does this PR introduce a breaking change?**
No

**Checklist:**
- [x] Bug fix. Fixes #<issue number> **(No opened issue)**
- [x] New feature (non-breaking change which adds functionality) **(Not applicable)**
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected) **(Not applicable)**
- [x] This change requires a documentation update **(Not applicable)**
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [x] Commit has unit tests **(Not applicable)**
- [x] Commit has integration tests **(Not applicable)**

<!--

The PR title message must follow convention:
`<type>(<scope>): <subject>`.

Where: <br />
- `type` is to define what type of PR is this.
  Most common types are:
    - `feat`      - for new features, not a new feature for build script
    - `fix`       - for bug fixes or improvements, not a fix for build script
    - `chore`     - changes not related to production code
    - `docs`      - changes related to documentation
    - `style`     - formatting, missing semi colons, linting fix etc; no significant production code changes
    - `test`      - adding missing tests, refactoring tests; no production code change
    - `refactor`  - refactoring production code, eg. renaming a variable or function name, there should not be any significant production code changes

- `scope` is a single word that best describes where the changes fit.
    - feature(`monitor`,`enforcer`)
    - test(`tests`, `bdd`)
    - chore(`build`)
- `subject` is a single line brief description of the changes made in the pull request.

-->