### PR TITLE
feat(ksp):  Adding protected pods to KSP

### DIFF
--- a/KubeArmor/config/config.go
+++ b/KubeArmor/config/config.go
@@ -33,6 +33,8 @@ type KubearmorConfig struct {
 	KVMAgent   bool // Enable/Disable KVM Agent
 	K8sEnv     bool // Is k8s env ?
 
+	ProtectedPods bool //To enable/disable showing protected pods in KSP
+
 	DefaultFilePosture         string // Default Enforcement Action in Global File Context
 	DefaultNetworkPosture      string // Default Enforcement Action in Global Network Context
 	DefaultCapabilitiesPosture string // Default Enforcement Action in Global Capabilities Context
@@ -79,6 +81,9 @@ const ConfigVisibility string = "visibility"
 
 // ConfigHostVisibility Host visibility key
 const ConfigHostVisibility string = "hostVisibility"
+
+// ConfigProtectedPods Protected Pods key
+const ConfigProtectedPods string = "enableProtectedPods"
 
 // ConfigKubearmorPolicy Kubearmor policy key
 const ConfigKubearmorPolicy string = "enableKubeArmorPolicy"
@@ -133,6 +138,7 @@ func readCmdLineParams() {
 	hostVisStr := flag.String(ConfigHostVisibility, "default", "Host Visibility to use [process,file,network,capabilities,none] (default \"none\" for k8s, \"process,file,network,capabilities\" for VM)")
 
 	policyB := flag.Bool(ConfigKubearmorPolicy, true, "enabling KubeArmorPolicy")
+	protectedPodsB := flag.Bool(ConfigProtectedPods, false, "enabling ProtectedPods KSP")
 	hostPolicyB := flag.Bool(ConfigKubearmorHostPolicy, false, "enabling KubeArmorHostPolicy")
 	kvmAgentB := flag.Bool(ConfigKubearmorVM, false, "enabling KubeArmorVM")
 	k8sEnvB := flag.Bool(ConfigK8sEnv, true, "is k8s env?")
@@ -162,6 +168,8 @@ func readCmdLineParams() {
 
 	viper.SetDefault(ConfigCluster, *clusterStr)
 	viper.SetDefault(ConfigHost, *hostStr)
+
+	viper.SetDefault(ConfigProtectedPods, *protectedPodsB)
 
 	viper.SetDefault(ConfigGRPC, *grpcStr)
 	viper.SetDefault(ConfigLogPath, *logStr)
@@ -232,6 +240,8 @@ func LoadConfig() error {
 
 	GlobalCfg.Visibility = viper.GetString(ConfigVisibility)
 	GlobalCfg.HostVisibility = viper.GetString(ConfigHostVisibility)
+
+	GlobalCfg.ProtectedPods = viper.GetBool(ConfigProtectedPods)
 
 	GlobalCfg.Policy = viper.GetBool(ConfigKubearmorPolicy)
 	GlobalCfg.HostPolicy = viper.GetBool(ConfigKubearmorHostPolicy)

--- a/KubeArmor/types/types.go
+++ b/KubeArmor/types/types.go
@@ -137,7 +137,8 @@ type K8sPodEvent struct {
 
 // K8sPolicyStatus Structure
 type K8sPolicyStatus struct {
-	Status string `json:"status,omitempty"`
+	Status        string   `json:"status,omitempty"`
+	ProtectedPods []string `json:"protectedpods,omitempty"`
 }
 
 // K8sKubeArmorPolicyEvent Structure

--- a/KubeArmor/types/types.go
+++ b/KubeArmor/types/types.go
@@ -487,13 +487,11 @@ type SecuritySpec struct {
 	Network      NetworkType      `json:"network,omitempty"`
 	Capabilities CapabilitiesType `json:"capabilities,omitempty"`
 	Syscalls     SyscallsType     `json:"syscalls,omitempty"`
-
-	AppArmor string `json:"apparmor,omitempty"`
-
-	Severity int      `json:"severity"`
-	Tags     []string `json:"tags,omitempty"`
-	Message  string   `json:"message,omitempty"`
-	Action   string   `json:"action"`
+	AppArmor     string           `json:"apparmor,omitempty"`
+	Severity     int              `json:"severity"`
+	Tags         []string         `json:"tags,omitempty"`
+	Message      string           `json:"message,omitempty"`
+	Action       string           `json:"action"`
 }
 
 // SecurityPolicy Structure

--- a/KubeArmor/types/types.go
+++ b/KubeArmor/types/types.go
@@ -499,6 +499,7 @@ type SecuritySpec struct {
 type SecurityPolicy struct {
 	Metadata map[string]string `json:"metadata"`
 	Spec     SecuritySpec      `json:"spec"`
+	Status   K8sPolicyStatus   `json:"status,omitempty"`
 }
 
 // ========================== //

--- a/deployments/CRD/KubeArmorPolicy.yaml
+++ b/deployments/CRD/KubeArmorPolicy.yaml
@@ -38,10 +38,6 @@ spec:
           spec:
             description: KubeArmorPolicySpec defines the desired state of KubeArmorPolicy
             properties:
-              protectedPods:
-                items:
-                  type: string
-                type: array
               action:
                 enum:
                 - Allow
@@ -1161,6 +1157,10 @@ spec:
             properties:
               status:
                 type: string
+              protectedPods:
+                items:
+                  type: string
+                type: array
             type: object
         type: object
     served: true

--- a/deployments/CRD/KubeArmorPolicy.yaml
+++ b/deployments/CRD/KubeArmorPolicy.yaml
@@ -38,6 +38,10 @@ spec:
           spec:
             description: KubeArmorPolicySpec defines the desired state of KubeArmorPolicy
             properties:
+              protectedPods:
+                items:
+                  type: string
+                type: array
               action:
                 enum:
                 - Allow

--- a/pkg/KubeArmorController/api/security.kubearmor.com/v1/kubearmorpolicy_types.go
+++ b/pkg/KubeArmorController/api/security.kubearmor.com/v1/kubearmorpolicy_types.go
@@ -57,6 +57,8 @@ type KubeArmorPolicySpec struct {
 	// +kubebuilder:validation:optional
 	Severity SeverityType `json:"severity,omitempty"`
 	// +kubebuilder:validation:optional
+	ProtectedPods []string `json:"protected_pods,omitempty"`
+	// +kubebuilder:validation:optional
 	Tags []string `json:"tags,omitempty"`
 	// +kubebuilder:validation:optional
 	Message string `json:"message,omitempty"`
@@ -69,6 +71,11 @@ type KubeArmorPolicyStatus struct {
 	PolicyStatus string `json:"status,omitempty"`
 }
 
+// KubeArmorPolicyStatus defines the observed state of KubeArmorPolicy
+type KubeArmorProtectedPods struct {
+	ProtectedPods []string `json:"protected_pods,omitempty"`
+}
+
 // +kubebuilder:object:root=true
 
 // KubeArmorPolicy is the Schema for the kubearmorpolicies API
@@ -79,8 +86,9 @@ type KubeArmorPolicy struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	Spec   KubeArmorPolicySpec   `json:"spec,omitempty"`
-	Status KubeArmorPolicyStatus `json:"status,omitempty"`
+	Spec          KubeArmorPolicySpec    `json:"spec,omitempty"`
+	Status        KubeArmorPolicyStatus  `json:"status,omitempty"`
+	ProtectedPods KubeArmorProtectedPods `json:"protected_pods,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/pkg/KubeArmorController/api/security.kubearmor.com/v1/kubearmorpolicy_types.go
+++ b/pkg/KubeArmorController/api/security.kubearmor.com/v1/kubearmorpolicy_types.go
@@ -68,12 +68,8 @@ type KubeArmorPolicySpec struct {
 
 // KubeArmorPolicyStatus defines the observed state of KubeArmorPolicy
 type KubeArmorPolicyStatus struct {
-	PolicyStatus string `json:"status,omitempty"`
-}
-
-// KubeArmorPolicyStatus defines the observed state of KubeArmorPolicy
-type KubeArmorProtectedPods struct {
-	ProtectedPods []string `json:"protected_pods,omitempty"`
+	PolicyStatus  string   `json:"status,omitempty"`
+	ProtectedPods []string `json:"protectedPods,omitempty"`
 }
 
 // +kubebuilder:object:root=true
@@ -86,9 +82,8 @@ type KubeArmorPolicy struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	Spec          KubeArmorPolicySpec    `json:"spec,omitempty"`
-	Status        KubeArmorPolicyStatus  `json:"status,omitempty"`
-	ProtectedPods KubeArmorProtectedPods `json:"protected_pods,omitempty"`
+	Spec   KubeArmorPolicySpec   `json:"spec,omitempty"`
+	Status KubeArmorPolicyStatus `json:"status,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/pkg/KubeArmorController/config/webhook/manifests.yaml
+++ b/pkg/KubeArmorController/config/webhook/manifests.yaml
@@ -26,7 +26,3 @@ webhooks:
     resources:
     - pods
   sideEffects: NoneOnDryRun
-  objectSelector:
-    matchExpressions:
-    - key: "kubearmor-app"
-      operator: DoesNotExist

--- a/pkg/KubeArmorController/crd/KubeArmorPolicy.yaml
+++ b/pkg/KubeArmorController/crd/KubeArmorPolicy.yaml
@@ -38,6 +38,8 @@ spec:
           spec:
             description: KubeArmorPolicySpec defines the desired state of KubeArmorPolicy
             properties:
+              protectedPods:
+                type: string
               action:
                 enum:
                 - Allow

--- a/pkg/KubeArmorController/crd/KubeArmorPolicy.yaml
+++ b/pkg/KubeArmorController/crd/KubeArmorPolicy.yaml
@@ -38,8 +38,6 @@ spec:
           spec:
             description: KubeArmorPolicySpec defines the desired state of KubeArmorPolicy
             properties:
-              protectedPods:
-                type: string
               action:
                 enum:
                 - Allow
@@ -1159,6 +1157,10 @@ spec:
             properties:
               status:
                 type: string
+              protectedPods:
+                items:
+                  type: string
+                type: array
             type: object
         type: object
     served: true


### PR DESCRIPTION
**Purpose of PR?**:

Kubearmor always has maintained a list of protected pods and their respective policies, this PR adds a patch to show protected pods for the ksp.
Fixes #1393 

**Does this PR introduce a breaking change?**
No

**Additional information for reviewer?** :
Below are the list of action items that needs to be done before merging:
- [x] Change ProtectedPods from Spec to the Status field of CRD
- [x] Find a way to use the function in `WatchK8sPod`
- [ ] Add test cases for this 

**Checklist:**
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Commit has unit tests
- [ ] Commit has integration tests

<!--

The PR title message must follow convention:
`<type>(<scope>): <subject>`.

Where: <br />
- `type` is to define what type of PR is this.
  Most common types are:
    - `feat`      - for new features, not a new feature for build script
    - `fix`       - for bug fixes or improvements, not a fix for build script
    - `chore`     - changes not related to production code
    - `docs`      - changes related to documentation
    - `style`     - formatting, missing semi colons, linting fix etc; no significant production code changes
    - `test`      - adding missing tests, refactoring tests; no production code change
    - `refactor`  - refactoring production code, eg. renaming a variable or function name, there should not be any significant production code changes

- `scope` is a single word that best describes where the changes fit.
    - feature(`monitor`,`enforcer`)
    - test(`tests`, `bdd`)
    - chore(`build`)
- `subject` is a single line brief description of the changes made in the pull request.

-->