### PR TITLE
ensuring PPID to be 0 when HOSTPPID is assigned to PPID

### DIFF
--- a/KubeArmor/monitor/systemMonitor.go
+++ b/KubeArmor/monitor/systemMonitor.go
@@ -641,6 +641,9 @@ func (mon *SystemMonitor) TraceSyscall() {
 			if err != nil {
 				continue
 			}
+			if ctx.PPID == ctx.HostPPID {
+				ctx.PPID = 0
+			}
 			args, err := GetArgs(dataBuff, ctx.Argnum)
 			if err != nil {
 				continue

--- a/protobuf/Makefile
+++ b/protobuf/Makefile
@@ -15,6 +15,7 @@ go.sum: go.mod
 %.pb.go: %.proto
 	go mod tidy
 	protoc --go_out=. --go_opt=paths=source_relative --go-grpc_out=. --go-grpc_opt=paths=source_relative,require_unimplemented_servers=false $<
+	sed -i -e 's/\bPPID,omitempty\b/PPID,/' -e 's/\bUID,omitempty\b/UID,/' kubearmor.pb.go
 
 .PHONY: clean
 clean:

--- a/protobuf/kubearmor.pb.go
+++ b/protobuf/kubearmor.pb.go
@@ -255,9 +255,9 @@ type Alert struct {
 	ContainerImage    string    `protobuf:"bytes,24,opt,name=ContainerImage,proto3" json:"ContainerImage,omitempty"`
 	HostPPID          int32     `protobuf:"varint,27,opt,name=HostPPID,proto3" json:"HostPPID,omitempty"`
 	HostPID           int32     `protobuf:"varint,9,opt,name=HostPID,proto3" json:"HostPID,omitempty"`
-	PPID              int32     `protobuf:"varint,10,opt,name=PPID,proto3" json:"PPID,omitempty"`
+	PPID              int32     `protobuf:"varint,10,opt,name=PPID,proto3" json:"PPID,"`
 	PID               int32     `protobuf:"varint,11,opt,name=PID,proto3" json:"PID,omitempty"`
-	UID               int32     `protobuf:"varint,12,opt,name=UID,proto3" json:"UID,omitempty"`
+	UID               int32     `protobuf:"varint,12,opt,name=UID,proto3" json:"UID,"`
 	ParentProcessName string    `protobuf:"bytes,25,opt,name=ParentProcessName,proto3" json:"ParentProcessName,omitempty"`
 	ProcessName       string    `protobuf:"bytes,26,opt,name=ProcessName,proto3" json:"ProcessName,omitempty"`
 	PolicyName        string    `protobuf:"bytes,13,opt,name=PolicyName,proto3" json:"PolicyName,omitempty"`
@@ -545,9 +545,9 @@ type Log struct {
 	ProcessName       string    `protobuf:"bytes,21,opt,name=ProcessName,proto3" json:"ProcessName,omitempty"`
 	HostPPID          int32     `protobuf:"varint,22,opt,name=HostPPID,proto3" json:"HostPPID,omitempty"`
 	HostPID           int32     `protobuf:"varint,9,opt,name=HostPID,proto3" json:"HostPID,omitempty"`
-	PPID              int32     `protobuf:"varint,10,opt,name=PPID,proto3" json:"PPID,omitempty"`
+	PPID              int32     `protobuf:"varint,10,opt,name=PPID,proto3" json:"PPID,"`
 	PID               int32     `protobuf:"varint,11,opt,name=PID,proto3" json:"PID,omitempty"`
-	UID               int32     `protobuf:"varint,12,opt,name=UID,proto3" json:"UID,omitempty"`
+	UID               int32     `protobuf:"varint,12,opt,name=UID,proto3" json:"UID,"`
 	Type              string    `protobuf:"bytes,13,opt,name=Type,proto3" json:"Type,omitempty"`
 	Source            string    `protobuf:"bytes,14,opt,name=Source,proto3" json:"Source,omitempty"`
 	Operation         string    `protobuf:"bytes,15,opt,name=Operation,proto3" json:"Operation,omitempty"`


### PR DESCRIPTION
**Purpose of PR?**:
`PPID` inside the container takes `PPID` of runc during `kubectl exec` therefore we add a check when `PPID == HOSTPPID` we make `PPID = 0`

Fixes #1388 

**Does this PR introduce a breaking change?**
No

**If the changes in this PR are manually verified, list down the scenarios covered:**:
tested locally, during kubectl exec `PPID` is 0 and for other process like `ls`, `PPID` has its original value
log for kubectl exec:
```
== Log / 2023-09-13 08:49:05.195945 ==
ClusterName: default
HostName: prateek-lenovo-ideapad-310-15isk
NamespaceName: default
PodName: nginx-86c557dcf4-fs26c
ContainerName: 09c3cbf01faacf6e6e3246200a8341138b2e6aea9ed7876d05f0144092bdc8c1
ContainerID: 09c3cbf01faacf6e6e3246200a8341138b2e6aea9ed7876d05f0144092bdc8c1
Type: ContainerLog
Source: /usr/bin/bash
Operation: Syscall
Data: syscall=SYS_SETUID userid=0
Result: Passed
HostPID: 274313
HostPPID: 274308
PID: 452
PPID: 0
ProcessName: /usr/bin/bash
UID: 0
```

**Additional information for reviewer?** :
1. during `json.Marshal`, due to `omitempty` tag `PPID` with value 0 was not shown in the logs therefore added `sed` command to remove the omitempty tag from the `.pb.go` file.
2. After this PR is merged we also need to update protobuf in kubearmor-client

**Checklist:**
- [ ] Bug fix. Fixes #<issue number>
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Commit has unit tests
- [ ] Commit has integration tests

<!--

The PR title message must follow convention:
`<type>(<scope>): <subject>`.

Where: <br />
- `type` is to define what type of PR is this.
  Most common types are:
    - `feat`      - for new features, not a new feature for build script
    - `fix`       - for bug fixes or improvements, not a fix for build script
    - `chore`     - changes not related to production code
    - `docs`      - changes related to documentation
    - `style`     - formatting, missing semi colons, linting fix etc; no significant production code changes
    - `test`      - adding missing tests, refactoring tests; no production code change
    - `refactor`  - refactoring production code, eg. renaming a variable or function name, there should not be any significant production code changes

- `scope` is a single word that best describes where the changes fit.
    - feature(`monitor`,`enforcer`)
    - test(`tests`, `bdd`)
    - chore(`build`)
- `subject` is a single line brief description of the changes made in the pull request.

-->