### PR TITLE
fix(core): handle containers in CRI agnostic way

### DIFF
--- a/KubeArmor/core/kubeArmor.go
+++ b/KubeArmor/core/kubeArmor.go
@@ -512,15 +512,15 @@ func KubeArmor() {
 			}
 
 			// monitor containers
-			if strings.Contains(dm.Node.ContainerRuntimeVersion, "docker") {
+			if strings.Contains(dm.Node.ContainerRuntimeVersion, "docker") || strings.Contains(cfg.GlobalCfg.CRISocket, "docker") {
 				// update already deployed containers
 				dm.GetAlreadyDeployedDockerContainers()
 				// monitor docker events
 				go dm.MonitorDockerEvents()
-			} else if strings.Contains(dm.Node.ContainerRuntimeVersion, "containerd") {
+			} else if strings.Contains(dm.Node.ContainerRuntimeVersion, "containerd") || strings.Contains(cfg.GlobalCfg.CRISocket, "containerd") {
 				// monitor containerd events
 				go dm.MonitorContainerdEvents()
-			} else if strings.Contains(dm.Node.ContainerRuntimeVersion, "cri-o") {
+			} else if strings.Contains(dm.Node.ContainerRuntimeVersion, "cri-o") || strings.Contains(cfg.GlobalCfg.CRISocket, "cri-o") {
 				// monitor crio events
 				go dm.MonitorCrioEvents()
 			} else {

--- a/KubeArmor/core/kubeUpdate.go
+++ b/KubeArmor/core/kubeUpdate.go
@@ -583,16 +583,9 @@ func (dm *KubeArmorDaemon) WatchK8sPods() {
 				pod.ContainerImages = map[string]string{}
 				for _, container := range event.Object.Status.ContainerStatuses {
 					if len(container.ContainerID) > 0 {
-						if strings.HasPrefix(container.ContainerID, "docker://") {
-							containerID := strings.TrimPrefix(container.ContainerID, "docker://")
-							pod.Containers[containerID] = container.Name
-							pod.ContainerImages[containerID] = container.Image + kl.GetSHA256ofImage(container.ImageID)
-						} else if strings.HasPrefix(container.ContainerID, "containerd://") {
-							containerID := strings.TrimPrefix(container.ContainerID, "containerd://")
-							pod.Containers[containerID] = container.Name
-							pod.ContainerImages[containerID] = container.Image + kl.GetSHA256ofImage(container.ImageID)
-						} else if strings.HasPrefix(container.ContainerID, "cri-o://") {
-							containerID := strings.TrimPrefix(container.ContainerID, "cri-o://")
+						cid := strings.Split(container.ContainerID, "://")
+						if len(cid) == 2 { // always true because k8s spec defines format as '<type>://<container_id>'
+							containerID := cid[1]
 							pod.Containers[containerID] = container.Name
 							pod.ContainerImages[containerID] = container.Image + kl.GetSHA256ofImage(container.ImageID)
 						}


### PR DESCRIPTION
It is possible that runtime itself uses an arbitrary runtime names. Example robin platform uses robin as Container Runtime Version, in which case we depend on the CRISocket passed to KubeArmor for determining the CRI Version

there are CRI providers out there which use different CRI name such as robin instead of docker,containerd or crio

**Purpose of PR?**:

Fixes Deployment on Robin

**Does this PR introduce a breaking change?**

**If the changes in this PR are manually verified, list down the scenarios covered:**:
tested on robin platform

**Additional information for reviewer?** :
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [x] Bug fix. 

<!--

The PR title message must follow convention:
`<type>(<scope>): <subject>`.

Where: <br />
- `type` is to define what type of PR is this.
  Most common types are:
    - `feat`      - for new features, not a new feature for build script
    - `fix`       - for bug fixes or improvements, not a fix for build script
    - `chore`     - changes not related to production code
    - `docs`      - changes related to documentation
    - `style`     - formatting, missing semi colons, linting fix etc; no significant production code changes
    - `test`      - adding missing tests, refactoring tests; no production code change
    - `refactor`  - refactoring production code, eg. renaming a variable or function name, there should not be any significant production code changes

- `scope` is a single word that best describes where the changes fit.
    - feature(`monitor`,`enforcer`)
    - test(`tests`, `bdd`)
    - chore(`build`)
- `subject` is a single line brief description of the changes made in the pull request.

-->