### PR TITLE
docs: updated FAQ for kind cluster support on apparmor

### DIFF
--- a/getting-started/FAQ.md
+++ b/getting-started/FAQ.md
@@ -257,7 +257,7 @@ This will enable the `KubeArmorHostPolicy` and host based visibility for the k8s
 
 </details>
 
-<details><summary><h4>Unable to get KubeArmor policy enforcement with Kind clusters</h4></summary>
+<details><summary><h4>Using KubeArmor with Kind clusters</h4></summary>
 
 KubeArmor works out of the box with Kind clusters supporting BPF-LSM. However, with AppArmor only mode, Kind cluster needs additional provisional steps. You can check if BPF-LSM is supported/enabled on your host (on which the kind cluster is to be deployed) by using following:
 ```
@@ -280,11 +280,15 @@ EOF
 
 ## 2. Exec into kind node & install apparmor util
 ```sh
-docker exec -it kind-control-plane bash
-apt update && apt install apparmor-utils -y && systemctl restart containerd
+docker exec -it kind-control-plane bash -c "apt update && apt install apparmor-utils -y && systemctl restart containerd"
 ```
 
 After this, exit out of the node shell and follow the [getting-started guide](https://github.com/kubearmor/KubeArmor/blob/main/getting-started/deployment_guide.md).
+
+If the `kubearmor-relay` pod goes into CrashLoopBackOff, apply the following patch:
+```sh
+kubectl patch deploy -n $(kubectl get deploy -l kubearmor-app=kubearmor-relay -A -o custom-columns=:'{.metadata.namespace}',:'{.metadata.name}') --type=json -p='[{"op": "add", "path": "/spec/template/metadata/annotations/container.apparmor.security.beta.kubernetes.io~1kubearmor-relay-server", "value": "unconfined"}]'
+```
 
 </details>
 


### PR DESCRIPTION
Kind clusters with distributions supporting only AppArmor needs special instructions specified as part of this FAQ update.

**Root cause**: Kind [recommends disabling AppArmor](https://kind.sigs.k8s.io/docs/user/known-issues/#apparmor) by default because of [known issues](https://github.com/moby/moby/issues/7512#issuecomment-51845976). However, KubeArmor requires AppArmor for policy enforcement in cases where BPF-LSM is not available. For slightly-old Ubuntu/Debian based distros, BPF-LSM is not available and thus the engine has to rely on AppArmor. KubeArmor injects a default apparmor profile for every workload and that overrides the default apparmor behavior and thus in general gets everything else working. However, KubeArmor does not apply default apparmor policies for the `kube-system` namespace and hence kubearmor-relay ends up using the default `cri.d.apparmor.d` apparmor policy that results in `socket: permission denied` for its grpc server bind socket call.

Ref: moby/moby#7512

**Checklist:**
- [x] Bug fix.
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [x] Commit has unit tests
- [x] Commit has integration tests

<!--

The PR title message must follow convention:
`<type>(<scope>): <subject>`.

Where: <br />
- `type` is to define what type of PR is this.
  Most common types are:
    - `feat`      - for new features, not a new feature for build script
    - `fix`       - for bug fixes or improvements, not a fix for build script
    - `chore`     - changes not related to production code
    - `docs`      - changes related to documentation
    - `style`     - formatting, missing semi colons, linting fix etc; no significant production code changes
    - `test`      - adding missing tests, refactoring tests; no production code change
    - `refactor`  - refactoring production code, eg. renaming a variable or function name, there should not be any significant production code changes

- `scope` is a single word that best describes where the changes fit.
    - feature(`monitor`,`enforcer`)
    - test(`tests`, `bdd`)
    - chore(`build`)
- `subject` is a single line brief description of the changes made in the pull request.

-->