### PR TITLE
fix(operator): Fix containerd socket and storage volumemounts

### DIFF
--- a/pkg/KubeArmorOperator/common/defaults.go
+++ b/pkg/KubeArmorOperator/common/defaults.go
@@ -181,6 +181,12 @@ var RuntimeStorageLocation = map[string]string{
 	"cri-o":      "/var/lib/containers/storage",
 }
 
+var RuntimeSocketLocation = map[string]string{
+	"docker":     "/var/run/docker.sock",
+	"containerd": "/var/run/containerd/containerd.sock",
+	"cri-o":      "/var/run/crio/crio.sock",
+}
+
 func ShortSHA(s string) string {
 	sBytes := []byte(s)
 

--- a/pkg/KubeArmorOperator/internal/controller/resources.go
+++ b/pkg/KubeArmorOperator/internal/controller/resources.go
@@ -70,7 +70,6 @@ func generateDaemonset(name, enforcer, runtime, socket, runtimeStorage, btfPrese
 	daemonset.Spec.Template.Spec.Volumes = vols
 	daemonset.Spec.Template.Spec.InitContainers[0].VolumeMounts = commonVolMnts
 	daemonset.Spec.Template.Spec.Containers[0].VolumeMounts = volMnts
-	daemonset.Spec.Template.Spec.Containers[0].Args = append(daemonset.Spec.Template.Spec.Containers[0].Args, "-criSocket=unix:///"+strings.ReplaceAll(socket, "_", "/"))
 	// update images
 	daemonset.Spec.Template.Spec.Containers[0].Image = common.GetApplicationImage(common.KubeArmorName)
 	daemonset.Spec.Template.Spec.Containers[0].ImagePullPolicy = corev1.PullPolicy(common.KubeArmorImagePullPolicy)
@@ -106,6 +105,8 @@ func genRuntimeVolumes(runtime, runtimeSocket, runtimeStorage string) (vol []cor
 					},
 				},
 			})
+
+			socket = common.RuntimeSocketLocation[runtime]
 			volMnt = append(volMnt, corev1.VolumeMount{
 				Name:      runtime + "-socket",
 				MountPath: socket,


### PR DESCRIPTION
**Purpose of PR?**:

After [k0s support](https://github.com/kubearmor/KubeArmor/pull/1399) was added, the CI started failing due to differences between the containerd socket and volumemounts. This PR disguises these volumemounts, which resolves the CI failures.

Fixes #
Fixes the CI failure introduced by the k0s support https://github.com/kubearmor/KubeArmor/actions/runs/6258134856/job/16991588030.

**Does this PR introduce a breaking change?**

**If the changes in this PR are manually verified, list down the scenarios covered:**:

**Additional information for reviewer?** :
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [x] Bug fix. Fixes #<issue number>
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Commit has unit tests
- [ ] Commit has integration tests

<!--

The PR title message must follow convention:
`<type>(<scope>): <subject>`.

Where: <br />
- `type` is to define what type of PR is this.
  Most common types are:
    - `feat`      - for new features, not a new feature for build script
    - `fix`       - for bug fixes or improvements, not a fix for build script
    - `chore`     - changes not related to production code
    - `docs`      - changes related to documentation
    - `style`     - formatting, missing semi colons, linting fix etc; no significant production code changes
    - `test`      - adding missing tests, refactoring tests; no production code change
    - `refactor`  - refactoring production code, eg. renaming a variable or function name, there should not be any significant production code changes

- `scope` is a single word that best describes where the changes fit.
    - feature(`monitor`,`enforcer`)
    - test(`tests`, `bdd`)
    - chore(`build`)
- `subject` is a single line brief description of the changes made in the pull request.

-->