### PR TITLE
feat: Add support for microshift

### DIFF
--- a/getting-started/support_matrix.md
+++ b/getting-started/support_matrix.md
@@ -25,6 +25,7 @@ KubeArmor supports following types of workloads:
 | AWS        | [Graviton] | Amazon Linux 2 | ARM | :heavy_check_mark: | :heavy_check_mark: | :x: | :heavy_check_mark: | SELinux |
 | RedHat     | [OpenShift] | [RHEL] <=8.4 | x86_64 | :heavy_check_mark: | :heavy_check_mark: | :x:  | :heavy_check_mark: | SELinux |
 | RedHat     | [OpenShift] | [RHEL] >=8.5 | x86_64 | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | [BPFLSM] |
+| RedHat     | [MicroShift] | [RHEL] >=9.2 | x86_64 | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | [BPFLSM] |
 | Rancher    | [RKE] | [SUSE] | x86_64 | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | [BPFLSM], AppArmor |
 | Rancher    | [K3S] | [Distros] | x86_64 | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | [BPFLSM], AppArmor |
 | Oracle     | [Ampere] | [UEK] | ARM | :heavy_check_mark: | :heavy_check_mark: | :x: | :heavy_check_mark: | SELinux | [1084] |
@@ -41,6 +42,7 @@ KubeArmor supports following types of workloads:
 [GKE-REL]: https://cloud.google.com/kubernetes-engine/docs/concepts/release-channels
 [bottlerocket]: https://github.com/bottlerocket-os/bottlerocket#bottlerocket-os
 [OPENSHIFT]: https://www.redhat.com/en/technologies/cloud-computing/openshift
+[MicroShift]: https://microshift.io/
 [SUSE]: https://www.suse.com/
 [RHEL]: https://www.redhat.com/en/technologies/linux-platforms/enterprise-linux
 [RKE]: https://rancher.com/docs/rke/latest/en/

--- a/pkg/KubeArmorController/handlers/pod_mutation.go
+++ b/pkg/KubeArmorController/handlers/pod_mutation.go
@@ -58,9 +58,7 @@ func (a *PodAnnotator) Handle(ctx context.Context, req admission.Request) admiss
 
 	// == LSM == //
 
-	if a.Enforcer == "" || a.Enforcer == "SELinux" {
-		pod.Annotations["kubearmor-policy"] = "audited"
-	} else if a.Enforcer == "AppArmor" {
+	if a.Enforcer == "AppArmor" {
 		appArmorAnnotator(pod)
 	}
 


### PR DESCRIPTION
**Purpose of PR?**:

Fixes #1325 

**Does this PR introduce a breaking change?**

**If the changes in this PR are manually verified, list down the scenarios covered:**:
- **Using kArmor cli**
<img width="1800" alt="1 1" src="https://github.com/kubearmor/KubeArmor/assets/94977678/f63e3504-1ac9-4c32-bc7f-85db94e1f868">

<img width="1096" alt="1 2" src="https://github.com/kubearmor/KubeArmor/assets/94977678/984a533f-40dd-45fa-b1fd-184d25d0e1ba">

---

- **Using the KubeArmor operator with an additional `REDHAT_CERTIFIED_OP` env variable.**
<img width="1800" alt="Screenshot 2023-10-19 at 12 20 12" src="https://github.com/kubearmor/KubeArmor/assets/94977678/5784c9d0-5356-408b-9966-446cdf8270ec">

<img width="1096" alt="2 2" src="https://github.com/kubearmor/KubeArmor/assets/94977678/19f402b8-e996-4b89-a76a-1cd142f6ddfa">

**Additional information for reviewer?** :
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [ ] Bug fix. Fixes #<issue number>
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Commit has unit tests
- [ ] Commit has integration tests

### Tasks specific to MicroShift

- [x]  Check if policy enforcement, observability, audit rules, network segmentation is supported
- [x] Get output of karmor probe
- [x] Update [kubearmor support matrix](https://github.com/kubearmor/KubeArmor/blob/main/getting-started/support_matrix.md)
- [x] Provide and attach karmor sysdump [microshift-sysdump.zip](https://github.com/kubearmor/KubeArmor/files/13039386/microshift-sysdump.zip)
- [x] Also get Kernel information details by getting access to the host and using following command: [PR](https://github.com/nyrahul/linux-kernel-configs/pull/10)

```shell
curl -s https://raw.githubusercontent.com/nyrahul/linux-kernel-configs/main/lk-config-get.sh | bash -s
```

<!--

The PR title message must follow convention:
`<type>(<scope>): <subject>`.

Where: <br />
- `type` is to define what type of PR is this.
  Most common types are:
    - `feat`      - for new features, not a new feature for build script
    - `fix`       - for bug fixes or improvements, not a fix for build script
    - `chore`     - changes not related to production code
    - `docs`      - changes related to documentation
    - `style`     - formatting, missing semi colons, linting fix etc; no significant production code changes
    - `test`      - adding missing tests, refactoring tests; no production code change
    - `refactor`  - refactoring production code, eg. renaming a variable or function name, there should not be any significant production code changes

- `scope` is a single word that best describes where the changes fit.
    - feature(`monitor`,`enforcer`)
    - test(`tests`, `bdd`)
    - chore(`build`)
- `subject` is a single line brief description of the changes made in the pull request.

-->