### PR TITLE
feat(config): add untracked ns as a configurable option

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ COPY . .
 WORKDIR /usr/src/KubeArmor/KubeArmor
 
 RUN go install github.com/golang/protobuf/protoc-gen-go@latest
+RUN go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
 RUN make
 
 ### Make executable image

--- a/KubeArmor/config/config.go
+++ b/KubeArmor/config/config.go
@@ -43,81 +43,41 @@ type KubearmorConfig struct {
 
 	CoverageTest bool // Enable/Disable Coverage Test
 
-	LsmOrder  []string // LSM order
-	BPFFsPath string   // path to the BPF filesystem
+	ConfigUntrackedNs []string // untracked namespaces
+	LsmOrder          []string // LSM order
+	BPFFsPath         string   // path to the BPF filesystem
 }
-
-// PolicyDir policy dir path for host policies backup
-const PolicyDir string = "/opt/kubearmor/policies/"
-
-// PIDFilePath for pid file path
-const PIDFilePath string = "/opt/kubearmor/kubearmor.pid"
 
 // GlobalCfg Global configuration for Kubearmor
 var GlobalCfg KubearmorConfig
 
-// ConfigCluster Cluster name key
-const ConfigCluster string = "cluster"
-
-// ConfigHost Host name key
-const ConfigHost string = "host"
-
-// ConfigGRPC GRPC Port key
-const ConfigGRPC string = "gRPC"
-
-// ConfigLogPath Log Path key
-const ConfigLogPath string = "logPath"
-
-// ConfigSELinuxProfileDir SELinux Profile Directory key
-const ConfigSELinuxProfileDir string = "seLinuxProfileDir"
-
-// ConfigCRISocket key
-const ConfigCRISocket string = "criSocket"
-
-// ConfigVisibility Container visibility key
-const ConfigVisibility string = "visibility"
-
-// ConfigHostVisibility Host visibility key
-const ConfigHostVisibility string = "hostVisibility"
-
-// ConfigKubearmorPolicy Kubearmor policy key
-const ConfigKubearmorPolicy string = "enableKubeArmorPolicy"
-
-// ConfigKubearmorHostPolicy Kubearmor host policy key
-const ConfigKubearmorHostPolicy string = "enableKubeArmorHostPolicy"
-
-// ConfigKubearmorVM Kubearmor VM key
-const ConfigKubearmorVM string = "enableKubeArmorVm"
-
-// ConfigDefaultFilePosture KubeArmor Default Global File Posture key
-const ConfigDefaultFilePosture string = "defaultFilePosture"
-
-// ConfigDefaultNetworkPosture KubeArmor Default Global Network Posture key
-const ConfigDefaultNetworkPosture string = "defaultNetworkPosture"
-
-// ConfigDefaultCapabilitiesPosture KubeArmor Default Global Capabilities Posture key
-const ConfigDefaultCapabilitiesPosture string = "defaultCapabilitiesPosture"
-
-// ConfigHostDefaultFilePosture KubeArmor Default Global File Posture key
-const ConfigHostDefaultFilePosture string = "hostDefaultFilePosture"
-
-// ConfigHostDefaultNetworkPosture KubeArmor Default Global Network Posture key
-const ConfigHostDefaultNetworkPosture string = "hostDefaultNetworkPosture"
-
-// ConfigHostDefaultCapabilitiesPosture KubeArmor Default Global Capabilities Posture key
-const ConfigHostDefaultCapabilitiesPosture string = "hostDefaultCapabilitiesPosture"
-
-// ConfigCoverageTest Coverage Test key
-const ConfigCoverageTest string = "coverageTest"
-
-// ConfigK8sEnv VM key
-const ConfigK8sEnv string = "k8s"
-
-// LsmOrder Preference order of the LSMs
-const LsmOrder string = "lsm"
-
-// BPFFsPath key
-const BPFFsPath string = "bpfFsPath"
+// Config const
+const (
+	PolicyDir                            string = "/opt/kubearmor/policies/"
+	PIDFilePath                          string = "/opt/kubearmor/kubearmor.pid"
+	ConfigCluster                        string = "cluster"
+	ConfigHost                           string = "host"
+	ConfigGRPC                           string = "gRPC"
+	ConfigLogPath                        string = "logPath"
+	ConfigSELinuxProfileDir              string = "seLinuxProfileDir"
+	ConfigCRISocket                      string = "criSocket"
+	ConfigVisibility                     string = "visibility"
+	ConfigHostVisibility                 string = "hostVisibility"
+	ConfigKubearmorPolicy                string = "enableKubeArmorPolicy"
+	ConfigKubearmorHostPolicy            string = "enableKubeArmorHostPolicy"
+	ConfigKubearmorVM                    string = "enableKubeArmorVm"
+	ConfigDefaultFilePosture             string = "defaultFilePosture"
+	ConfigDefaultNetworkPosture          string = "defaultNetworkPosture"
+	ConfigDefaultCapabilitiesPosture     string = "defaultCapabilitiesPosture"
+	ConfigHostDefaultFilePosture         string = "hostDefaultFilePosture"
+	ConfigHostDefaultNetworkPosture      string = "hostDefaultNetworkPosture"
+	ConfigHostDefaultCapabilitiesPosture string = "hostDefaultCapabilitiesPosture"
+	ConfigCoverageTest                   string = "coverageTest"
+	ConfigK8sEnv                         string = "k8s"
+	ConfigUntrackedNs                    string = "untrackedNs"
+	LsmOrder                             string = "lsm"
+	BPFFsPath                            string = "bpfFsPath"
+)
 
 func readCmdLineParams() {
 	hostname, _ := os.Hostname()
@@ -146,6 +106,8 @@ func readCmdLineParams() {
 	hostDefaultCapabilitiesPosture := flag.String(ConfigHostDefaultCapabilitiesPosture, "audit", "configuring default enforcement action in global capability context {allow|audit|block}")
 
 	coverageTestB := flag.Bool(ConfigCoverageTest, false, "enabling CoverageTest")
+
+	untrackedNs := flag.String(ConfigUntrackedNs, "kube-system,kubearmor", "Namespaces which are not being tracked, default untracked:[kube-system, kubearmor]")
 
 	lsmOrder := flag.String(LsmOrder, "bpf,apparmor,selinux", "lsm preference order to use, available lsms [bpf, apparmor, selinux]")
 
@@ -185,6 +147,8 @@ func readCmdLineParams() {
 	viper.SetDefault(ConfigHostDefaultCapabilitiesPosture, *hostDefaultCapabilitiesPosture)
 
 	viper.SetDefault(ConfigCoverageTest, *coverageTestB)
+
+	viper.SetDefault(ConfigUntrackedNs, *untrackedNs)
 
 	viper.SetDefault(LsmOrder, *lsmOrder)
 
@@ -262,6 +226,8 @@ func LoadConfig() error {
 	}
 
 	GlobalCfg.CoverageTest = viper.GetBool(ConfigCoverageTest)
+
+	GlobalCfg.ConfigUntrackedNs = strings.Split(viper.GetString(ConfigUntrackedNs), ",")
 
 	GlobalCfg.LsmOrder = strings.Split(viper.GetString(LsmOrder), ",")
 


### PR DESCRIPTION
**Purpose of PR?**:
Previously, the namespaces to be ignored from system monitor were hard coded, this PR makes it configurable.

**Does this PR introduce a breaking change?**
No

**If the changes in this PR are manually verified, list down the scenarios covered:**:
Tested locally on k3s. Cases tested:
- [x] Default namespaces are being ignored
- [x] ns supplied as an env variable is working fine

**Checklist:**
- [x] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`

<!--

The PR title message must follow convention:
`<type>(<scope>): <subject>`.

Where: <br />
- `type` is to define what type of PR is this.
  Most common types are:
    - `feat`      - for new features, not a new feature for build script
    - `fix`       - for bug fixes or improvements, not a fix for build script
    - `chore`     - changes not related to production code
    - `docs`      - changes related to documentation
    - `style`     - formatting, missing semi colons, linting fix etc; no significant production code changes
    - `test`      - adding missing tests, refactoring tests; no production code change
    - `refactor`  - refactoring production code, eg. renaming a variable or function name, there should not be any significant production code changes

- `scope` is a single word that best describes where the changes fit.
    - feature(`monitor`,`enforcer`)
    - test(`tests`, `bdd`)
    - chore(`build`)
- `subject` is a single line brief description of the changes made in the pull request.

-->