### PR TITLE
fix(core): fix so that it can be restricted to matched paths and dire…

### DIFF
--- a/KubeArmor/core/kubeUpdate.go
+++ b/KubeArmor/core/kubeUpdate.go
@@ -1612,7 +1612,9 @@ func (dm *KubeArmorDaemon) ParseAndUpdateHostSecurityPolicy(event tp.K8sKubeArmo
 				}
 			}
 		}
-	} else if len(secPolicy.Spec.File.MatchDirectories) > 0 {
+	}
+
+	if len(secPolicy.Spec.File.MatchDirectories) > 0 {
 		for idx, dir := range secPolicy.Spec.File.MatchDirectories {
 			if dir.Severity == 0 {
 				if secPolicy.Spec.File.Severity != 0 {
@@ -1646,7 +1648,9 @@ func (dm *KubeArmorDaemon) ParseAndUpdateHostSecurityPolicy(event tp.K8sKubeArmo
 				}
 			}
 		}
-	} else if len(secPolicy.Spec.File.MatchPatterns) > 0 {
+	}
+
+	if len(secPolicy.Spec.File.MatchPatterns) > 0 {
 		for idx, pat := range secPolicy.Spec.File.MatchPatterns {
 			if pat.Severity == 0 {
 				if secPolicy.Spec.File.Severity != 0 {


### PR DESCRIPTION
…ctories in systemd mode

When running KubeArmor in systemd mode, there is an issue where restrictions on the directories specified in sepc.file.matchDirectories are not enforced when matchPaths and matchDirectories are applied to spec.file in HostPolicy as shown below.

  ```
  apiVersion: security.kubearmor.com/v1
  kind: KubeArmorHostPolicy
  metadata:
    name: host-policy
  spec:
    file:
      matchPaths:
      - path: /home/ubuntu/.bashrc
      matchDirectories:
      - dir: /etc/cron.weekly/
        recursive: true
    action:
      Block
  ```

This issue is reported in issue/#1436.

In the current implementation, it is possible to check files under "/etc/cron.weekly/" directory even if this Policy is applied.

Therefore, in this fix, the implementation was made to fix this issue.

**Purpose of PR?**:

Fixes #1436 

**Does this PR introduce a breaking change?**

No

**If the changes in this PR are manually verified, list down the scenarios covered:**:

I have confirmed that `scenario_1.sh` is used to restrict processing corresponding to MatchPaths and MatchDirectories.

<details><summary> Details of scenario_1.sh </summary>
<p>

```bash
ubuntu ~/KubeArmor/KubeArmor/haytok [fix-to-restrict-matched-paths-and-directories-in-systemd-mode]
> cat scenario_1.sh
POLICY_NAME="host_policy.yaml"
BACKUP_POLICY_NAME="host-policy.yaml"

echo "Start ...";

echo foo > /home/ubuntu/foo
echo 'print("Hello")' > /home/ubuntu/main.py
touch /home/ubuntu/main.go
touch /home/ubuntu/main.c

cat <<EOF > $POLICY_NAME
apiVersion: security.kubearmor.com/v1
kind: KubeArmorHostPolicy
metadata:
  name: host-policy
spec:
  file:
    matchPaths:
    - path: /etc/cron.weekly/man-db
    - path: /home/master/.bash_profile
    - path: /home/ubuntu/foo
    matchDirectories:
    - dir: /etc/cron.weekly/
      recursive: true
    - dir: /etc/cron.monthly/
      recursive: true
    - dir: /etc/cron.daily/
      recursive: true
    - dir: /etc/cron.hourly/
      recursive: true
    matchPatterns:
    - pattern: /home/ubuntu/main.*
  action:
    Block
EOF

echo "-+-+-+-+-+-+-+-+-+-+";
./karmor version

echo "-+-+-+-+-+-+-+-+-+-+";
echo "Add $POLICY_NAME";
./karmor vm policy add $POLICY_NAME
sleep 1

echo "-+-+-+-+-+-+-+-+-+-+";
echo "Run Test commands";

echo "---";
echo "RUN cat /home/ubuntu/foo";
cat /home/ubuntu/foo

echo "---";
echo "RUN ls /etc/cron.weekly/";
ls /etc/cron.weekly/

echo "---";
echo "RUN ls /etc/cron.monthly/";
ls /etc/cron.monthly/

echo "---";
echo "RUN ls /etc/cron.daily/";
ls /etc/cron.daily/

echo "---";
echo "RUN ls /etc/cron.hourly/";
ls /etc/cron.hourly/

echo "---";
echo "RUN cat /home/ubuntu/main.py";
cat /home/ubuntu/main.py

echo "End ...";
```

</p>
</details> 

Results of running `scenario_1.sh` when `not` applying this fix

<details><summary> Details </summary>
<p>

```bash
ubuntu ~/KubeArmor/KubeArmor/haytok [fix-to-restrict-matched-paths-and-directories-in-systemd-mode]
> ./scenario_1.sh
Start ...
-+-+-+-+-+-+-+-+-+-+
karmor version 4507cc0 linux/amd64 BuildDate=2023-10-07T15:40:56Z
-+-+-+-+-+-+-+-+-+-+
Add host_policy.yaml
Policy Applied
-+-+-+-+-+-+-+-+-+-+
Run Test commands
---
RUN cat /home/ubuntu/foo
cat: /home/ubuntu/foo: Permission denied
---
RUN ls /etc/cron.weekly/
man-db	update-notifier-common
---
RUN ls /etc/cron.monthly/
---
RUN ls /etc/cron.daily/
apport	apt-compat  bsdmainutils  dpkg	logrotate  man-db  popularity-contest  update-notifier-common
---
RUN ls /etc/cron.hourly/
---
RUN cat /home/ubuntu/main.py
print("Hello")
End ...
```

</p>
</details> 

Results of running `scenario_1.sh` when applying this fix

<details><summary>Details</summary>
<p>

```bash
ubuntu ~/KubeArmor/KubeArmor/haytok [fix-to-restrict-matched-paths-and-directories-in-systemd-mode]
> ./scenario_1.sh
Start ...
-+-+-+-+-+-+-+-+-+-+
karmor version 4507cc0 linux/amd64 BuildDate=2023-10-07T15:40:56Z
-+-+-+-+-+-+-+-+-+-+
Add host_policy.yaml
Policy Applied
-+-+-+-+-+-+-+-+-+-+
Run Test commands
---
RUN cat /home/ubuntu/foo
cat: /home/ubuntu/foo: Permission denied
---
RUN ls /etc/cron.weekly/
ls: cannot open directory '/etc/cron.weekly/': Permission denied
---
RUN ls /etc/cron.monthly/
ls: cannot open directory '/etc/cron.monthly/': Permission denied
---
RUN ls /etc/cron.daily/
ls: cannot open directory '/etc/cron.daily/': Permission denied
---
RUN ls /etc/cron.hourly/
ls: cannot open directory '/etc/cron.hourly/': Permission denied
---
RUN cat /home/ubuntu/main.py
cat: /home/ubuntu/main.py: Permission denied
End ...
```

</p>
</details> 

<!-- この結果から、matchDirectories で指定したパスに対する制限を課すことができるようになりました。 -->

From these results, it is now possible to impose restrictions on paths specified in `matchPaths` and `matchDirectories`.

**Additional information for reviewer?** :
_Mention if this PR is part of any design or a continuation of previous PRs_

N/A

**Checklist:**
- [x] Bug fix. Fixes #1436 
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Commit has unit tests
- [ ] Commit has integration tests

<!--

The PR title message must follow convention:
`<type>(<scope>): <subject>`.

Where: <br />
- `type` is to define what type of PR is this.
  Most common types are:
    - `feat`      - for new features, not a new feature for build script
    - `fix`       - for bug fixes or improvements, not a fix for build script
    - `chore`     - changes not related to production code
    - `docs`      - changes related to documentation
    - `style`     - formatting, missing semi colons, linting fix etc; no significant production code changes
    - `test`      - adding missing tests, refactoring tests; no production code change
    - `refactor`  - refactoring production code, eg. renaming a variable or function name, there should not be any significant production code changes

- `scope` is a single word that best describes where the changes fit.
    - feature(`monitor`,`enforcer`)
    - test(`tests`, `bdd`)
    - chore(`build`)
- `subject` is a single line brief description of the changes made in the pull request.

-->