### PR TITLE
fix(systemmonitor):deleting untraced file access entries in file_map

### DIFF
--- a/KubeArmor/BPF/system_monitor.c
+++ b/KubeArmor/BPF/system_monitor.c
@@ -1326,6 +1326,11 @@ int kprobe__do_exit(struct pt_regs *ctx)
     if (skip_syscall())
         return 0;
 
+    u64 tgid = bpf_get_current_pid_tgid();
+
+    // delete entry for file access which are not successful and are not deleted from file_map since kretprobe/__x64_sys_openat hook is not triggered
+    bpf_map_delete_elem(&file_map, &tgid);
+
     sys_context_t context = {};
 
     const long code = PT_REGS_PARM1(ctx);


### PR DESCRIPTION
**Purpose of PR?**:
issue - Currently, we delete the entries from the `file_map` whenever the `kretprobe/__x64_sys_open` hook is triggered.
But there are some cases in which `kretprobe/__x64_sys_open` is not triggered. In this case, the entries remain forever in the `file_map`. Once the max limit of `file_map` entries is reached it won't add further entries and we will miss the coming entries, which is the cause for the issue.

Solution - we use the `kprobe/do_exit` hook to delete the entries. `kprobe/do_exit` is always triggered after process execution. Adding delete implementation here will delete the entries that are not deleted during the `kretprobe/__x64_sys_open` hook execution.

Result - Not all the entries will be deleted by this, but the majority will be. `file_map` will still have entries and it might get filled up again. Although the entries' incoming rate is slower now. So now `file_map` would take more time to fill up.

Fixes #1370 

**Does this PR introduce a breaking change?**

**If the changes in this PR are manually verified, list down the scenarios covered:**:
yes, tested for `touch /proc/1/ns`

**Additional information for reviewer?** :
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [x] Bug fix. Fixes #<issue number>
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Commit has unit tests
- [ ] Commit has integration tests

<!--

The PR title message must follow convention:
`<type>(<scope>): <subject>`.

Where: <br />
- `type` is to define what type of PR is this.
  Most common types are:
    - `feat`      - for new features, not a new feature for build script
    - `fix`       - for bug fixes or improvements, not a fix for build script
    - `chore`     - changes not related to production code
    - `docs`      - changes related to documentation
    - `style`     - formatting, missing semi colons, linting fix etc; no significant production code changes
    - `test`      - adding missing tests, refactoring tests; no production code change
    - `refactor`  - refactoring production code, eg. renaming a variable or function name, there should not be any significant production code changes

- `scope` is a single word that best describes where the changes fit.
    - feature(`monitor`,`enforcer`)
    - test(`tests`, `bdd`)
    - chore(`build`)
- `subject` is a single line brief description of the changes made in the pull request.

-->