### PR TITLE
[enhancement] helm values for kubearmor relay stdout env

### DIFF
--- a/deployments/get/objects.go
+++ b/deployments/get/objects.go
@@ -119,6 +119,20 @@ var replicas = int32(1)
 var relayDeploymentLabels = map[string]string{
 	"kubearmor-app": "kubearmor-relay",
 }
+var envVars = []corev1.EnvVar{
+	{
+		Name:  "ENABLE_STDOUT_LOGS",
+		Value: "false",
+	},
+	{
+		Name:  "ENABLE_STDOUT_ALERTS",
+		Value: "false",
+	},
+	{
+		Name:  "ENABLE_STDOUT_MSGS",
+		Value: "false",
+	},
+}
 
 // GetRelayDeployment Function
 func GetRelayDeployment(namespace string) *appsv1.Deployment {
@@ -159,6 +173,7 @@ func GetRelayDeployment(namespace string) *appsv1.Deployment {
 									ContainerPort: port,
 								},
 							},
+							Env: envVars,
 						},
 					},
 				},

--- a/deployments/helm/KubeArmor/templates/deployment.yaml
+++ b/deployments/helm/KubeArmor/templates/deployment.yaml
@@ -22,6 +22,13 @@ spec:
       - image: {{printf "%s:%s" .Values.kubearmorRelay.image.repository .Values.kubearmorRelay.image.tag}}
         imagePullPolicy: {{ .Values.kubearmorRelay.imagePullPolicy }}
         name: kubearmor-relay-server
+        env:
+        - name: ENABLE_STDOUT_LOGS
+          value: {{ quote .Values.kubearmorRelay.enableStdoutLogs }}
+        - name: ENABLE_STDOUT_ALERTS
+          value: {{ quote .Values.kubearmorRelay.enableStdoutAlerts }}
+        - name: ENABLE_STDOUT_MSGS
+          value: {{ quote .Values.kubearmorRelay.enableStdoutMsg }}
         ports:
         - containerPort: 32767
       nodeSelector:

--- a/deployments/helm/KubeArmor/values.yaml
+++ b/deployments/helm/KubeArmor/values.yaml
@@ -15,6 +15,10 @@ kubearmorRelay:
     tag: latest
   # kubearmor-init imagePullPolicy
   imagePullPolicy: Always
+  # Add environment variables for STDOUT logging
+  enableStdoutLogs: "false"
+  enableStdoutAlerts: "false"
+  enableStdoutMsg: "false"
 
 kubearmorInit:
   image:

--- a/deployments/helm/KubeArmorOperator/README.md
+++ b/deployments/helm/KubeArmorOperator/README.md
@@ -49,6 +49,10 @@ spec:
     defaultFilePosture: audit|block                            # DEFAULT - audit
     defaultNetworkPosture: audit|block                         # DEFAULT - audit
 
+    enableStdOutLogs: [show stdout logs for relay server]      # DEFAULT - false
+    enableStdOutAlerts: [show stdout alerts for relay server]  # DEFAULT - false
+    enableStdOutMsgs: [show stdout messages for relay server]  # DEFAULT - false 
+
     # default visibility configuration
     defaultVisibility: [comma separated: process|file|network] # DEFAULT - process,network
 
@@ -117,5 +121,5 @@ job.batch/kubearmor-snitch-lglbd   1/1           3s         11m
 Uninstalling the Operator will also uninstall KubeArmor from all your nodes. To uninstall, just run:
 
 ```bash
-helm uninstall kubearmor -n kubearmor
+helm uninstall kubearmor-operator -n kubearmor
 ```

--- a/deployments/helm/KubeArmorOperator/crds/operator.kubearmor.com_kubearmorconfigs.yaml
+++ b/deployments/helm/KubeArmorOperator/crds/operator.kubearmor.com_kubearmorconfigs.yaml
@@ -57,6 +57,12 @@ spec:
                 type: string
               defaultVisibility:
                 type: string
+              enableStdOutAlerts:
+                type: boolean
+              enableStdOutLogs:
+                type: boolean
+              enableStdOutMsgs:
+                type: boolean
               kubeRbacProxyImage:
                 description: ImageSpec defines the image specifications
                 properties:

--- a/deployments/helm/KubeArmorOperator/values.yaml
+++ b/deployments/helm/KubeArmorOperator/values.yaml
@@ -6,9 +6,12 @@ kubearmorOperator:
     repository: kubearmor/kubearmor-operator
     tag: latest
   imagePullPolicy: IfNotPresent
-  
+
 kubearmorConfig:
   defaultCapabilitiesPosture: audit
   defaultFilePosture: audit
   defaultNetworkPosture: audit
   defaultVisibility: process,network
+  enableStdOutLogs: false
+  enableStdOutAlerts: false
+  enableStdOutMsgs: false

--- a/deployments/operator/operator.yaml
+++ b/deployments/operator/operator.yaml
@@ -55,6 +55,12 @@ spec:
                 type: string
               defaultVisibility:
                 type: string
+              enableStdOutAlerts:
+                type: boolean
+              enableStdOutLogs:
+                type: boolean
+              enableStdOutMsgs:
+                type: boolean
               kubeRbacProxyImage:
                 description: ImageSpec defines the image specifications
                 properties:

--- a/pkg/KubeArmorOperator/api/operator.kubearmor.com/v1/kubearmorconfig_types.go
+++ b/pkg/KubeArmorOperator/api/operator.kubearmor.com/v1/kubearmorconfig_types.go
@@ -43,6 +43,12 @@ type KubeArmorConfigSpec struct {
 	KubeArmorControllerImage ImageSpec `json:"kubearmorControllerImage,omitempty"`
 	// +kubebuilder:validation:optional
 	KubeRbacProxyImage ImageSpec `json:"kubeRbacProxyImage,omitempty"`
+	// +kubebuilder:validation:optional
+	EnableStdOutLogs bool `json:"enableStdOutLogs,omitempty"`
+	// +kubebuilder:validation:optional
+	EnableStdOutAlerts bool `json:"enableStdOutAlerts,omitempty"`
+	// +kubebuilder:validation:optional
+	EnableStdOutMsgs bool `json:"enableStdOutMsgs,omitempty"`
 }
 
 // KubeArmorConfigStatus defines the observed state of KubeArmorConfig

--- a/pkg/KubeArmorOperator/common/defaults.go
+++ b/pkg/KubeArmorOperator/common/defaults.go
@@ -69,6 +69,12 @@ var (
 	ConfigDefaultCapabilitiesPosture string = "defaultCapabilitiesPosture"
 	ConfigDefaultNetworkPosture      string = "defaultNetworkPosture"
 
+	//KubearmorRelayEnvVariables
+
+	EnableStdOutAlerts string = "enableStdOutAlerts"
+	EnableStdOutLogs   string = "enableStdOutLogs"
+	EnableStdOutMsgs   string = "enableStdOutMsgs"
+
 	// Images
 	KubeArmorName                      string = "kubearmor"
 	KubeArmorImage                     string = "kubearmor/kubearmor:stable"
@@ -94,6 +100,12 @@ var ConfigMapData = map[string]string{
 	ConfigDefaultCapabilitiesPosture: "audit",
 	ConfigDefaultNetworkPosture:      "audit",
 	ConfigVisibility:                 "process,network,capabilities",
+}
+
+var KubearmorRelayEnvMap = map[string]string{
+	EnableStdOutAlerts: "false",
+	EnableStdOutLogs:   "false",
+	EnableStdOutMsgs:   "false",
 }
 
 var ContainerRuntimeSocketMap = map[string][]string{

--- a/pkg/KubeArmorOperator/config/crd/bases/operator.kubearmor.com_kubearmorconfigs.yaml
+++ b/pkg/KubeArmorOperator/config/crd/bases/operator.kubearmor.com_kubearmorconfigs.yaml
@@ -57,6 +57,12 @@ spec:
                 type: string
               defaultVisibility:
                 type: string
+              enableStdOutAlerts:
+                type: boolean
+              enableStdOutLogs:
+                type: boolean
+              enableStdOutMsgs:
+                type: boolean
               kubeRbacProxyImage:
                 description: ImageSpec defines the image specifications
                 properties:

--- a/pkg/KubeArmorOperator/config/samples/sample-config.yml
+++ b/pkg/KubeArmorOperator/config/samples/sample-config.yml
@@ -14,6 +14,9 @@ spec:
   defaultFilePosture: audit
   defaultNetworkPosture: audit
   defaultVisibility: process,network
+  enableStdOutLogs: false
+  enableStdOutAlerts: false
+  enableStdOutMsgs: false
   kubearmorImage:
     image: kubearmor/kubearmor:stable
     imagePullPolicy: Always


### PR DESCRIPTION
**Purpose of PR?**:

Fixes #1469 

**Does this PR introduce a breaking change?**
NA

**If the changes in this PR are manually verified, list down the scenarios covered:**:
Updated the helm chart values.yaml and deployment.yaml to include the required env variables automatically in the karmor relay server deployment.

**Additional information for reviewer?** :
_Mention if this PR is part of any design or a continuation of previous PRs_
NA


**Checklist:**
- [x] Bug fix. Fixes #1469 
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected): NA
- [x] This change requires a documentation update:  NA
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`: NA
- [x] Commit has unit tests: NA
- [x] Commit has integration tests: NA

<!--

The PR title message must follow convention:
`<type>(<scope>): <subject>`.

Where: <br />
- `type` is to define what type of PR is this.
  Most common types are:
    - `feat`      - for new features, not a new feature for build script
    - `fix`       - for bug fixes or improvements, not a fix for build script
    - `chore`     - changes not related to production code
    - `docs`      - changes related to documentation
    - `style`     - formatting, missing semi colons, linting fix etc; no significant production code changes
    - `test`      - adding missing tests, refactoring tests; no production code change
    - `refactor`  - refactoring production code, eg. renaming a variable or function name, there should not be any significant production code changes

- `scope` is a single word that best describes where the changes fit.
    - feature(`monitor`,`enforcer`)
    - test(`tests`, `bdd`)
    - chore(`build`)
- `subject` is a single line brief description of the changes made in the pull request.

-->