### PR TITLE
docs: fix typos, grammar, style, etc in `differentiation.md`

### DIFF
--- a/getting-started/differentiation.md
+++ b/getting-started/differentiation.md
@@ -4,36 +4,43 @@
 
 ## Significance of Inline Mitigation
 
-KubeArmor supports prevention of attacks, not just observability and monitoring. More importantly, the prevention is handled inline i.e, for e.g, even before a process is spawned, the rule can deny execution of that process. Most of the other systems typically employ something called as post-attack mitigation that kills the process/pod after the malicious intent is observed, allowing the attacker to execute its code in the target environment. Essentially KubeArmor uses inline mitigation to reduce the attack surface of pod/container/VM. KubeArmor leverages best of breed Linux Security Modules (LSMs) such as AppArmor, BPF-LSM, and SELinux (only for host protection) for inline mitigation. LSMs have several advantages over any other technique:
-* KubeArmor does not change anything with the pod/container.
-* KubeArmor does not require and change at the host level or at the CRI (Container Runtime Interface) level to enforce blocking rules. KubeArmor deploys as a non-privileged daemonset with certain capabilities that allows it to monitor other pods/containers and host.
-* A given cluster can multiple nodes utilizing different LSMs. KubeArmor abstracts away the complexities of the LSMs and provides an easy way for policy enforcement. KubeArmor manages the complexity of the LSMs under-the-hood.
+KubeArmor supports attack prevention, not just observability and monitoring.
+More importantly, the prevention is handled inline: even before a process is spawned, a rule can deny execution of a process.
+Most other systems typically employ "post-attack mitigation" that kills a process/pod after malicious intent is observed, allowing an attacker to execute code on the target environment.
+Essentially KubeArmor uses inline mitigation to reduce the attack surface of a pod/container/VM.
+KubeArmor leverages best of breed Linux Security Modules (LSMs) such as AppArmor, BPF-LSM, and SELinux (only for host protection) for inline mitigation.
+LSMs have several advantages over other techniques:
 
-### Post-Attack Mitigation and it flaws
+* KubeArmor does not change anything with the pod/container.
+* KubeArmor does not require any changes at the host level or at the CRI (Container Runtime Interface) level to enforce blocking rules. KubeArmor deploys as a non-privileged DaemonSet with certain capabilities that allows it to monitor other pods/containers and the host.
+* A given cluster can have multiple nodes utilizing different LSMs. KubeArmor abstracts away complexities of LSMs and provides an easy way to enforce policies. KubeArmor manages complexity of LSMs under-the-hood.
+
+### Post-Attack Mitigation and its flaws
 
 <img src="../.gitbook/assets/post-attack-mitigation.png" width="400" class="center" alt="Post Attack Mitigation">
 
-* Post-exploit Mitigation works by killing the suspicious process in response to an alert indicating malicious intent.
-* Attacker is allowed to executes its binary. Attacker could possibly disable the security controls, access logs, etc to circumvent the attack detection.
-* By the time, the malicious process is killed, it might have already deleted, encrypted, or transmitted the sensitive contents.
+* Post-exploit Mitigation works by killing a suspicious process in response to an alert indicating malicious intent.
+* Attacker is allowed to execute a binary. Attacker could disable security controls, access logs, etc to circumvent attack detection.
+* By the time a malicious process is killed, sensitive contents could have already been deleted, encrypted, or transmitted.
 * [Quoting Grsecurity](https://grsecurity.net/tetragone_a_lesson_in_security_fundamentals), “post-exploitation detection/mitigation is at the mercy of an exploit writer putting little to no effort into avoiding tripping these detection mechanisms.”
-
-[Here](https://grsecurity.net/tetragone_a_lesson_in_security_fundamentals) is the reference on why Post-Attack Mitigation is a flawed technique.
 
 ## Problems with k8s native Pod Security Context
 
-[Pod Security Context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) allows one to specify [native apparmor](https://kubernetes.io/docs/tutorials/security/apparmor/) or native selinux policy.
+[Pod Security Context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) allows one to specify [native AppArmor](https://kubernetes.io/docs/tutorials/security/apparmor/) or [native SELinux](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#assign-selinux-labels-to-a-container) policies.
 
 <img src="../.gitbook/assets/pod security context.png" width="512" class="center" alt="Pod Security Context">
 
 This approach has multiple problems:
+
 1. It is often difficult to predict which LSM (AppArmor or SELinux) would be available on the target node.
 2. BPF-LSM is not supported by Pod Security Context.
-3. It is difficult to manually specify the apparmor or selinux policy. Changing default apparmor or selinux policies might result in more security holes since it is difficult to decipher the implications of the changes and can be counter-productive.
+3. It is difficult to manually specify an AppArmor or SELinux policy. Changing default AppArmor or SELinux policies might result in more security holes since it is difficult to decipher the implications of the changes and can be counter-productive.
 
-### Problems with multicloud deployment
+### Problems with multi-cloud deployment
 
-Different managed cloud providers use different default distributions. Google GKE COS uses AppArmor by default, AWS Bottlerocket uses BPF-LSM and SElinux, and AWS Amazon Linux 2 uses only SElinux by default. Thus it becomes challenging to use pod security context in multi cloud deployments.
+Different managed cloud providers use different default distributions.
+Google GKE COS uses AppArmor by default, AWS Bottlerocket uses BPF-LSM and SELinux, and AWS Amazon Linux 2 uses only SELinux by default.
+Thus it is challenging to use Pod Security Context in multi-cloud deployments.
 
 <img src="../.gitbook/assets/multi-cloud.png" width="784" class="center" alt="Multi Cloud issues with LSMs">
 
@@ -42,5 +49,6 @@ Different managed cloud providers use different default distributions. Google GK
 <img src="../.gitbook/assets/bpf-lsm.png" width="512" class="center" alt="BPF-LSM with KubeArmor">
 
 References:
+
 * [Armoring Cloud Native Workloads with BPF-LSM](https://www.youtube.com/watch?v=uYVaiIX7QC0&ab_channel=CNCF%5BCloudNativeComputingFoundation%5D)
 * [Securing Bottlerocket deployments on Amazon EKS with KubeArmor](https://aws.amazon.com/blogs/containers/secure-bottlerocket-deployments-on-amazon-eks-with-kubearmor/)


### PR DESCRIPTION
**Purpose of PR?**:

## Summary

Fix various typos & grammar, as well as moderately improve style in `differentiation.md`

## Details

- add a link to SELinux k8s docs

#### style improvements:
  - capitalize proper nouns consistently
    - DaemonSet, per [k8s style guide](https://kubernetes.io/docs/contribute/style/style-guide/#use-upper-camel-case-for-api-objects)
    - consistently use capital "AppArmor", capital "SELinux", and capital "Pod Security Context"
      - these were sometimes lower-cased or just inconsistently capitalized
  - consistently use "multi-cloud" (instead of "multicloud" or "multi cloud")
  - consistently have a newline before and after lists, per `markdownlint`
  - consistently have 1 sentence per line in prose
    - instead of some very long lines
  - remove duplicate post-attack mitigation link
    - links should also have context and not use "here", per [k8s style guide](https://kubernetes.io/docs/contribute/style/style-guide/#links)
  - use simpler and more direct language, per [k8s style guide](https://kubernetes.io/docs/contribute/style/style-guide/#use-simple-and-direct-language)
    - shortens a few sentences, removes unnecessary phrases, makes it clearer and more concise
  - use present tense where possible, per [k8s style guide](https://kubernetes.io/docs/contribute/style/style-guide/#use-present-tense)
    - "it becomes" -> "it is"
  - avoid Latin phrases, per [k8s style guide](https://kubernetes.io/docs/contribute/style/style-guide/#avoid-latin-phrases)
    - heavily simplify the one sentence that used two Latin phrases almost immediately after each other

#### grammar fixes:
  - fix tense issues:
    - "capabilities [...] allows it" -> "[...] allow it"
    - "easy way for policy enforcement" -> "easy way to enforce policies" -- missing verb entirely
    - "allowed to executes" -> "allowed to execute"
  - fix various issues with articles and plurality:
    - consistently use "the host" -- there is only one host in context (a process only has one host)
    - consistently use "a process", "a pod", "a rule", etc -- it can be any process and is not a specific process
    - consistently use "LSMs" with no article
    - consistently don't use articles in "Attacker" line (as this is a brief hypothetical)
      - "its binary" -> "a binary" -- binary is necessarily possessed by the attacker
      - "the sensitive contents" -> "sensitive contents" -- we're not referring to a specific set of contents, just any set
  - no comma after "By the time" as the pause is later after the verb

#### typos:
  - "and changes" -> "any changes"
  - "can multiple" -> "can have multiple"
  - "it flaws" -> "its flaws"
  
 <hr>

**Does this PR introduce a breaking change?**

no

**If the changes in this PR are manually verified, list down the scenarios covered:**:

n/a, pure docs change

**Additional information for reviewer?** :
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [n/a] Bug fix. Fixes #<issue number>
- [n/a] New feature (non-breaking change which adds functionality)
- [n/a] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [n/a] Commit has unit tests
- [n/a] Commit has integration tests

<!--

The PR title message must follow convention:
`<type>(<scope>): <subject>`.

Where: <br />
- `type` is to define what type of PR is this.
  Most common types are:
    - `feat`      - for new features, not a new feature for build script
    - `fix`       - for bug fixes or improvements, not a fix for build script
    - `chore`     - changes not related to production code
    - `docs`      - changes related to documentation
    - `style`     - formatting, missing semi colons, linting fix etc; no significant production code changes
    - `test`      - adding missing tests, refactoring tests; no production code change
    - `refactor`  - refactoring production code, eg. renaming a variable or function name, there should not be any significant production code changes

- `scope` is a single word that best describes where the changes fit.
    - feature(`monitor`,`enforcer`)
    - test(`tests`, `bdd`)
    - chore(`build`)
- `subject` is a single line brief description of the changes made in the pull request.

-->