### PR TITLE
fixes(killercoda): fix breaking changes introduced in #1493

### DIFF
--- a/contribution/Killercoda-Kubearmor/k3s_installation_killercoda.sh
+++ b/contribution/Killercoda-Kubearmor/k3s_installation_killercoda.sh
@@ -48,10 +48,9 @@ else
     echo "export KUBECONFIG=$KUBECONFIG" | tee -a ~/.bashrc
 fi
 
+sleep 30
 echo "Waiting for all pods in kube-system to be in the 'Running' state"
-
-kubectl wait --for=condition=Ready pod --all --namespace=kube-system --timeout=120s
-
+kubectl wait --for=condition=Ready pod --all --namespace=kube-system --timeout=300s
 kubectl get pods -A
 
 echo "All pods in kube-system are now in the 'Running' state"

--- a/contribution/Killercoda-Kubearmor/kubearmor-installation-view.sh
+++ b/contribution/Killercoda-Kubearmor/kubearmor-installation-view.sh
@@ -10,7 +10,7 @@ kubectl wait --for=condition=ready --timeout=5m -n kubearmor pod -l kubearmor-ap
 kubectl get po -n $namespace
 kubectl wait -n kubearmor --timeout=5m --for=jsonpath='{.status.phase}'=Running kubearmorconfigs/kubearmor-default
 kubectl wait --timeout=5m --for=condition=ready pod -l kubearmor-app,kubearmor-app!=kubearmor-snitch -n kubearmor
-kubectl wait --timeout=5m --for=condition=ready pod -l kubearmor-app=kubearmor -n kubearmor
+kubectl wait --timeout=5m --for=condition=ready pod -l kubearmor-app=kubearmor,kubearmor-app!=kubearmor-snitch -n kubearmor
 
 echo "All pods in namespace '$namespace' are now in the 'Running' state"
 


### PR DESCRIPTION
**Purpose of PR?**:

Fixes #1493 

**Does this PR introduce a breaking change?**
No

**If the changes in this PR are manually verified, list down the scenarios covered:**:
Manually tested the k3s installation on Killercoda

**Additional information for reviewer?** :
We were seeing some unwanted warnings in #1493 for kubearmor installation - `kube-system` resources were not ready and hence the `kubectl wait` was terminating. 
Also in the kubearmor_installation script, we weren't ignoring the snitch pod (as it will be terminated later) so the `kubectl wait` was stuck on listening to that.

**Checklist:**
- [x] Bug fix. Fixes #1493
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`

<!--

The PR title message must follow convention:
`<type>(<scope>): <subject>`.

Where: <br />
- `type` is to define what type of PR is this.
  Most common types are:
    - `feat`      - for new features, not a new feature for build script
    - `fix`       - for bug fixes or improvements, not a fix for build script
    - `chore`     - changes not related to production code
    - `docs`      - changes related to documentation
    - `style`     - formatting, missing semi colons, linting fix etc; no significant production code changes
    - `test`      - adding missing tests, refactoring tests; no production code change
    - `refactor`  - refactoring production code, eg. renaming a variable or function name, there should not be any significant production code changes

- `scope` is a single word that best describes where the changes fit.
    - feature(`monitor`,`enforcer`)
    - test(`tests`, `bdd`)
    - chore(`build`)
- `subject` is a single line brief description of the changes made in the pull request.

-->