### PR TITLE
fix (killercoda): fix kubearmor installation script

### DIFF
--- a/contribution/Killercoda-Kubearmor/kubearmor-installation-view.sh
+++ b/contribution/Killercoda-Kubearmor/kubearmor-installation-view.sh
@@ -3,15 +3,12 @@
 # Copyright 2023 Authors of KubeArmor
 
 namespace="kubearmor"
-
-echo "Waiting for all pods in namespace '$namespace' to be in the 'Running' state"
-
-kubectl wait --for=condition=ready --timeout=5m -n kubearmor pod -l kubearmor-app=kubearmor-operator
-kubectl get po -n $namespace
-kubectl wait -n kubearmor --timeout=5m --for=jsonpath='{.status.phase}'=Running kubearmorconfigs/kubearmor-default
-kubectl wait --timeout=5m --for=condition=ready pod -l kubearmor-app,kubearmor-app!=kubearmor-snitch -n kubearmor
-kubectl wait --timeout=5m --for=condition=ready pod -l kubearmor-app=kubearmor,kubearmor-app!=kubearmor-snitch -n kubearmor
-
-echo "All pods in namespace '$namespace' are now in the 'Running' state"
-
-kubectl get po -n $namespace
+duration=120
+watch -n 1 "kubectl get po -n $namespace" &
+watch_pid=$!
+sleep $duration
+while kubectl get po -n $namespace | tail -n +2 | awk '{print $3}' | grep -q -v "Running"; do
+  sleep 8
+done
+kill $watch_pid
+echo "All pods are in the 'Running' state. Exiting..."


### PR DESCRIPTION
**Purpose of PR?**:

fix breaking changes introduced in https://github.com/kubearmor/KubeArmor/issues/1493

**Additional information for reviewer?** :
The issue with the PR #1493 was that in the kubearmor installation script the kubectl wait command was waiting for the snitch to be completed (which takes around 300sec) thus blocking the next deployment. 
This PR uses a different method for checking the deployment status

Note: This PR needs to be revisited later with the `kubectl wait` fixes.

<!--

The PR title message must follow convention:
`<type>(<scope>): <subject>`.

Where: <br />
- `type` is to define what type of PR is this.
  Most common types are:
    - `feat`      - for new features, not a new feature for build script
    - `fix`       - for bug fixes or improvements, not a fix for build script
    - `chore`     - changes not related to production code
    - `docs`      - changes related to documentation
    - `style`     - formatting, missing semi colons, linting fix etc; no significant production code changes
    - `test`      - adding missing tests, refactoring tests; no production code change
    - `refactor`  - refactoring production code, eg. renaming a variable or function name, there should not be any significant production code changes

- `scope` is a single word that best describes where the changes fit.
    - feature(`monitor`,`enforcer`)
    - test(`tests`, `bdd`)
    - chore(`build`)
- `subject` is a single line brief description of the changes made in the pull request.

-->