### PR TITLE
fix: Remove CRI Storage volume and volume mounts

### DIFF
--- a/deployments/get/defaults.go
+++ b/deployments/get/defaults.go
@@ -46,7 +46,6 @@ var hostPathDirectory = corev1.HostPathDirectory
 var hostPathDirectoryOrCreate = corev1.HostPathDirectoryOrCreate
 var hostPathFile = corev1.HostPathFile
 var hostPathSocket = corev1.HostPathSocket
-var hostContainerStorageMountPropagation = corev1.MountPropagationHostToContainer
 
 var gkeHostUsrVolMnt = corev1.VolumeMount{
 	Name:      "usr-src-path", // /usr -> /media/root/usr (read-only) check issue #579 for details
@@ -126,18 +125,6 @@ var defaultConfigs = map[string]DaemonSetConfig{
 				MountPath: "/var/run/containerd/containerd.sock",
 				ReadOnly:  true,
 			},
-			{
-				Name:             "containerd-storage-path", // containerd storage
-				MountPath:        "/run/containerd",
-				MountPropagation: &hostContainerStorageMountPropagation,
-				ReadOnly:         true,
-			},
-			{
-				Name:             "docker-storage-path", // docker storage
-				MountPath:        "/var/lib/docker",
-				MountPropagation: &hostContainerStorageMountPropagation,
-				ReadOnly:         true,
-			},
 		},
 		Volumes: []corev1.Volume{
 			apparmorVol,
@@ -147,24 +134,6 @@ var defaultConfigs = map[string]DaemonSetConfig{
 					HostPath: &corev1.HostPathVolumeSource{
 						Path: "/var/run/containerd/containerd.sock",
 						Type: &hostPathSocket,
-					},
-				},
-			},
-			{
-				Name: "containerd-storage-path",
-				VolumeSource: corev1.VolumeSource{
-					HostPath: &corev1.HostPathVolumeSource{
-						Path: "/run/containerd",
-						Type: &hostPathDirectoryOrCreate,
-					},
-				},
-			},
-			{
-				Name: "docker-storage-path",
-				VolumeSource: corev1.VolumeSource{
-					HostPath: &corev1.HostPathVolumeSource{
-						Path: "/var/lib/docker",
-						Type: &hostPathDirectoryOrCreate,
 					},
 				},
 			},
@@ -180,12 +149,6 @@ var defaultConfigs = map[string]DaemonSetConfig{
 				MountPath: "/var/run/crio/crio.sock",
 				ReadOnly:  true,
 			},
-			{
-				Name:             "crio-storage-path", // crio storage - stores all of its data, including containers images, in this directory.
-				MountPath:        "/var/lib/containers/storage",
-				MountPropagation: &hostContainerStorageMountPropagation,
-				ReadOnly:         true,
-			},
 		},
 		Volumes: []corev1.Volume{
 			apparmorVol,
@@ -195,15 +158,6 @@ var defaultConfigs = map[string]DaemonSetConfig{
 					HostPath: &corev1.HostPathVolumeSource{
 						Path: "/var/run/crio/crio.sock",
 						Type: &hostPathSocket,
-					},
-				},
-			},
-			{
-				Name: "crio-storage-path",
-				VolumeSource: corev1.VolumeSource{
-					HostPath: &corev1.HostPathVolumeSource{
-						Path: "/var/lib/containers/storage",
-						Type: &hostPathDirectoryOrCreate,
 					},
 				},
 			},
@@ -219,12 +173,6 @@ var defaultConfigs = map[string]DaemonSetConfig{
 				MountPath: "/var/run/docker.sock",
 				ReadOnly:  true,
 			},
-			{
-				Name:             "docker-storage-path", // docker storage
-				MountPath:        "/var/lib/docker",
-				MountPropagation: &hostContainerStorageMountPropagation,
-				ReadOnly:         true,
-			},
 		},
 		Volumes: []corev1.Volume{
 			apparmorVol,
@@ -234,15 +182,6 @@ var defaultConfigs = map[string]DaemonSetConfig{
 					HostPath: &corev1.HostPathVolumeSource{
 						Path: "/var/run/docker.sock",
 						Type: &hostPathSocket,
-					},
-				},
-			},
-			{
-				Name: "docker-storage-path",
-				VolumeSource: corev1.VolumeSource{
-					HostPath: &corev1.HostPathVolumeSource{
-						Path: "/var/lib/docker",
-						Type: &hostPathDirectoryOrCreate,
 					},
 				},
 			},
@@ -258,12 +197,6 @@ var defaultConfigs = map[string]DaemonSetConfig{
 				MountPath: "/var/run/docker.sock",
 				ReadOnly:  true,
 			},
-			{
-				Name:             "docker-storage-path", // docker storage
-				MountPath:        "/var/lib/docker",
-				MountPropagation: &hostContainerStorageMountPropagation,
-				ReadOnly:         true,
-			},
 		},
 		Volumes: []corev1.Volume{
 			apparmorVol,
@@ -273,15 +206,6 @@ var defaultConfigs = map[string]DaemonSetConfig{
 					HostPath: &corev1.HostPathVolumeSource{
 						Path: "/var/run/docker.sock",
 						Type: &hostPathSocket,
-					},
-				},
-			},
-			{
-				Name: "docker-storage-path",
-				VolumeSource: corev1.VolumeSource{
-					HostPath: &corev1.HostPathVolumeSource{
-						Path: "/var/lib/docker",
-						Type: &hostPathDirectoryOrCreate,
 					},
 				},
 			},
@@ -297,12 +221,6 @@ var defaultConfigs = map[string]DaemonSetConfig{
 				MountPath: "/var/snap/microk8s/common/run/containerd.sock",
 				ReadOnly:  true,
 			},
-			{
-				Name:             "containerd-storage-path", // containerd storage
-				MountPath:        "/run/containerd",
-				MountPropagation: &hostContainerStorageMountPropagation,
-				ReadOnly:         true,
-			},
 		},
 		Volumes: []corev1.Volume{
 			apparmorVol,
@@ -312,15 +230,6 @@ var defaultConfigs = map[string]DaemonSetConfig{
 					HostPath: &corev1.HostPathVolumeSource{
 						Path: "/var/snap/microk8s/common/run/containerd.sock",
 						Type: &hostPathSocket,
-					},
-				},
-			},
-			{
-				Name: "containerd-storage-path",
-				VolumeSource: corev1.VolumeSource{
-					HostPath: &corev1.HostPathVolumeSource{
-						Path: "/var/snap/microk8s/common/run/containerd",
-						Type: &hostPathDirectoryOrCreate,
 					},
 				},
 			},
@@ -336,11 +245,6 @@ var defaultConfigs = map[string]DaemonSetConfig{
 				MountPath: "/var/run/containerd/containerd.sock",
 				ReadOnly:  true,
 			},
-			{
-				Name:             "containerd-storage-path",
-				MountPath:        "/run/containerd",
-				MountPropagation: &hostContainerStorageMountPropagation,
-			},
 		},
 		Volumes: []corev1.Volume{
 			apparmorVol,
@@ -350,15 +254,6 @@ var defaultConfigs = map[string]DaemonSetConfig{
 					HostPath: &corev1.HostPathVolumeSource{
 						Path: "/run/k0s/containerd.sock",
 						Type: &hostPathSocket,
-					},
-				},
-			},
-			{
-				Name: "containerd-storage-path",
-				VolumeSource: corev1.VolumeSource{
-					HostPath: &corev1.HostPathVolumeSource{
-						Path: "/run/k0s/containerd",
-						Type: &hostPathDirectory,
 					},
 				},
 			},
@@ -374,12 +269,6 @@ var defaultConfigs = map[string]DaemonSetConfig{
 				MountPath: "/var/run/containerd/containerd.sock",
 				ReadOnly:  true,
 			},
-			{
-				Name:             "containerd-storage-path", // containerd storage
-				MountPath:        "/run/containerd",
-				MountPropagation: &hostContainerStorageMountPropagation,
-				ReadOnly:         true,
-			},
 		},
 		Volumes: []corev1.Volume{
 			apparmorVol,
@@ -389,15 +278,6 @@ var defaultConfigs = map[string]DaemonSetConfig{
 					HostPath: &corev1.HostPathVolumeSource{
 						Path: "/run/k3s/containerd/containerd.sock",
 						Type: &hostPathSocket,
-					},
-				},
-			},
-			{
-				Name: "containerd-storage-path",
-				VolumeSource: corev1.VolumeSource{
-					HostPath: &corev1.HostPathVolumeSource{
-						Path: "/run/k3s/containerd",
-						Type: &hostPathDirectoryOrCreate,
 					},
 				},
 			},
@@ -413,18 +293,6 @@ var defaultConfigs = map[string]DaemonSetConfig{
 				MountPath: "/var/run/containerd/containerd.sock",
 				ReadOnly:  true,
 			},
-			{
-				Name:             "containerd-storage-path", // containerd storage
-				MountPath:        "/run/containerd",
-				MountPropagation: &hostContainerStorageMountPropagation,
-				ReadOnly:         true,
-			},
-			{
-				Name:             "docker-storage-path", // docker storage
-				MountPath:        "/var/lib/docker",
-				MountPropagation: &hostContainerStorageMountPropagation,
-				ReadOnly:         true,
-			},
 		},
 		Volumes: []corev1.Volume{
 			apparmorVol,
@@ -434,24 +302,6 @@ var defaultConfigs = map[string]DaemonSetConfig{
 					HostPath: &corev1.HostPathVolumeSource{
 						Path: "/var/run/containerd/containerd.sock",
 						Type: &hostPathSocket,
-					},
-				},
-			},
-			{
-				Name: "containerd-storage-path",
-				VolumeSource: corev1.VolumeSource{
-					HostPath: &corev1.HostPathVolumeSource{
-						Path: "/run/containerd",
-						Type: &hostPathDirectoryOrCreate,
-					},
-				},
-			},
-			{
-				Name: "docker-storage-path",
-				VolumeSource: corev1.VolumeSource{
-					HostPath: &corev1.HostPathVolumeSource{
-						Path: "/var/lib/docker",
-						Type: &hostPathDirectoryOrCreate,
 					},
 				},
 			},
@@ -467,18 +317,6 @@ var defaultConfigs = map[string]DaemonSetConfig{
 				MountPath: "/var/run/containerd/containerd.sock",
 				ReadOnly:  true,
 			},
-			{
-				Name:             "containerd-storage-path", // containerd storage
-				MountPath:        "/run/containerd",
-				MountPropagation: &hostContainerStorageMountPropagation,
-				ReadOnly:         true,
-			},
-			{
-				Name:             "docker-storage-path", // docker storage
-				MountPath:        "/var/lib/docker",
-				MountPropagation: &hostContainerStorageMountPropagation,
-				ReadOnly:         true,
-			},
 		},
 		Volumes: []corev1.Volume{
 			apparmorVol,
@@ -488,24 +326,6 @@ var defaultConfigs = map[string]DaemonSetConfig{
 					HostPath: &corev1.HostPathVolumeSource{
 						Path: "/var/run/containerd/containerd.sock",
 						Type: &hostPathSocket,
-					},
-				},
-			},
-			{
-				Name: "containerd-storage-path",
-				VolumeSource: corev1.VolumeSource{
-					HostPath: &corev1.HostPathVolumeSource{
-						Path: "/run/containerd",
-						Type: &hostPathDirectoryOrCreate,
-					},
-				},
-			},
-			{
-				Name: "docker-storage-path",
-				VolumeSource: corev1.VolumeSource{
-					HostPath: &corev1.HostPathVolumeSource{
-						Path: "/var/lib/docker",
-						Type: &hostPathDirectoryOrCreate,
 					},
 				},
 			},
@@ -523,18 +343,6 @@ var defaultConfigs = map[string]DaemonSetConfig{
 				MountPath: "/run/dockershim.sock",
 				ReadOnly:  true,
 			},
-			{
-				Name:             "containerd-storage-path", // containerd storage
-				MountPath:        "/run/containerd",
-				MountPropagation: &hostContainerStorageMountPropagation,
-				ReadOnly:         true,
-			},
-			{
-				Name:             "docker-storage-path", // docker storage
-				MountPath:        "/var/lib/docker",
-				MountPropagation: &hostContainerStorageMountPropagation,
-				ReadOnly:         true,
-			},
 		},
 		Volumes: []corev1.Volume{
 			apparmorVol,
@@ -544,24 +352,6 @@ var defaultConfigs = map[string]DaemonSetConfig{
 					HostPath: &corev1.HostPathVolumeSource{
 						Path: "/run/dockershim.sock",
 						Type: &hostPathSocket,
-					},
-				},
-			},
-			{
-				Name: "containerd-storage-path",
-				VolumeSource: corev1.VolumeSource{
-					HostPath: &corev1.HostPathVolumeSource{
-						Path: "/run/containerd",
-						Type: &hostPathDirectoryOrCreate,
-					},
-				},
-			},
-			{
-				Name: "docker-storage-path",
-				VolumeSource: corev1.VolumeSource{
-					HostPath: &corev1.HostPathVolumeSource{
-						Path: "/var/lib/docker",
-						Type: &hostPathDirectoryOrCreate,
 					},
 				},
 			},
@@ -577,18 +367,6 @@ var defaultConfigs = map[string]DaemonSetConfig{
 				MountPath: "/var/run/containerd/containerd.sock",
 				ReadOnly:  true,
 			},
-			{
-				Name:             "containerd-storage-path", // containerd storage
-				MountPath:        "/run/containerd",
-				MountPropagation: &hostContainerStorageMountPropagation,
-				ReadOnly:         true,
-			},
-			{
-				Name:             "docker-storage-path", // docker storage
-				MountPath:        "/var/lib/docker",
-				MountPropagation: &hostContainerStorageMountPropagation,
-				ReadOnly:         true,
-			},
 		},
 		Volumes: []corev1.Volume{
 			apparmorVol,
@@ -598,24 +376,6 @@ var defaultConfigs = map[string]DaemonSetConfig{
 					HostPath: &corev1.HostPathVolumeSource{
 						Path: "/var/run/containerd/containerd.sock",
 						Type: &hostPathSocket,
-					},
-				},
-			},
-			{
-				Name: "containerd-storage-path",
-				VolumeSource: corev1.VolumeSource{
-					HostPath: &corev1.HostPathVolumeSource{
-						Path: "/run/containerd",
-						Type: &hostPathDirectoryOrCreate,
-					},
-				},
-			},
-			{
-				Name: "docker-storage-path",
-				VolumeSource: corev1.VolumeSource{
-					HostPath: &corev1.HostPathVolumeSource{
-						Path: "/var/lib/docker",
-						Type: &hostPathDirectoryOrCreate,
 					},
 				},
 			},

--- a/deployments/helm/KubeArmor/values.yaml
+++ b/deployments/helm/KubeArmor/values.yaml
@@ -136,14 +136,6 @@ kubearmor:
     - mountPath: /var/run/containerd/containerd.sock
       name: containerd-sock-path
       readOnly: true
-    - mountPath: /run/containerd
-      mountPropagation: HostToContainer
-      name: containerd-storage-path
-      readOnly: true
-    - mountPath: /var/lib/docker
-      mountPropagation: HostToContainer
-      name: docker-storage-path
-      readOnly: true
 
   volumeMountsDocker:
     - mountPath: /usr/src
@@ -165,10 +157,6 @@ kubearmor:
       name: etc-apparmor-d-path
     - mountPath: /var/run/docker.sock
       name: docker-sock-path
-      readOnly: true
-    - mountPath: /var/lib/docker
-      mountPropagation: HostToContainer
-      name: docker-storage-path
       readOnly: true
 
   volumeMountsCRIO:
@@ -192,10 +180,6 @@ kubearmor:
     - mountPath: /var/run/crio/crio.sock
       name: crio-sock-path
       readOnly: true
-    - mountPath: /var/lib/containers/storage
-      mountPropagation: HostToContainer
-      name: crio-storage-path
-      readOnly: true
 
   volumeMountsMicroK8s:
     - mountPath: /usr/src
@@ -217,10 +201,6 @@ kubearmor:
       name: etc-apparmor-d-path
     - mountPath: /var/snap/microk8s/common/run/containerd.sock
       name: containerd-sock-path
-      readOnly: true
-    - mountPath: /run/containerd
-      mountPropagation: HostToContainer
-      name: containerd-storage-path
       readOnly: true
 
   volumeMountsK0s:
@@ -244,9 +224,6 @@ kubearmor:
     - mountPath: /var/run/containerd/containerd.sock
       name: containerd-sock-path
       readOnly: true
-    - mountPath: /run/containerd
-      mountPropagation: HostToContainer
-      name: containerd-storage-path
 
   volumeMountsK3s:
     - mountPath: /usr/src
@@ -268,10 +245,6 @@ kubearmor:
       name: etc-apparmor-d-path
     - mountPath: /var/run/containerd/containerd.sock
       name: containerd-sock-path
-      readOnly: true
-    - mountPath: /run/containerd
-      mountPropagation: HostToContainer
-      name: containerd-storage-path
       readOnly: true
 
   volumeMountsMinikube:
@@ -316,14 +289,6 @@ kubearmor:
     - mountPath: /var/run/containerd/containerd.sock
       name: containerd-sock-path
       readOnly: true
-    - mountPath: /run/containerd
-      mountPropagation: HostToContainer
-      name: containerd-storage-path
-      readOnly: true
-    - mountPath: /var/lib/docker
-      mountPropagation: HostToContainer
-      name: docker-storage-path
-      readOnly: true
 
   volumeMountsBottleRocket:
     - mountPath: /lib/modules
@@ -346,14 +311,6 @@ kubearmor:
     - mountPath: /run/dockershim.sock
       name: containerd-sock-path
       readOnly: true
-    - mountPath: /run/containerd
-      mountPropagation: HostToContainer
-      name: containerd-storage-path
-      readOnly: true
-    - mountPath: /var/lib/docker
-      mountPropagation: HostToContainer
-      name: docker-storage-path
-      readOnly: true
 
   volumeMountsEKS:
     - mountPath: /lib/modules
@@ -375,14 +332,6 @@ kubearmor:
       name: etc-apparmor-d-path
     - mountPath: /var/run/containerd/containerd.sock
       name: containerd-sock-path
-      readOnly: true
-    - mountPath: /run/containerd
-      mountPropagation: HostToContainer
-      name: containerd-storage-path
-      readOnly: true
-    - mountPath: /var/lib/docker
-      mountPropagation: HostToContainer
-      name: docker-storage-path
       readOnly: true
 
   volumesGeneric:
@@ -418,14 +367,6 @@ kubearmor:
         path: /var/run/containerd/containerd.sock
         type: Socket
       name: containerd-sock-path
-    - hostPath:
-        path: /run/containerd
-        type: DirectoryOrCreate
-      name: containerd-storage-path
-    - hostPath:
-        path: /var/lib/docker
-        type: DirectoryOrCreate
-      name: docker-storage-path
 
   volumesDocker:
     - hostPath:
@@ -460,10 +401,6 @@ kubearmor:
         path: /var/run/docker.sock
         type: Socket
       name: docker-sock-path
-    - hostPath:
-        path: /var/lib/docker
-        type: DirectoryOrCreate
-      name: docker-storage-path
 
   volumesCRIO:
     - hostPath:
@@ -498,10 +435,6 @@ kubearmor:
         path: /var/run/crio/crio.sock
         type: Socket
       name: crio-sock-path
-    - hostPath:
-        path: /var/lib/containers/storage
-        type: DirectoryOrCreate
-      name: crio-storage-path
 
   volumesMicroK8s:
     - hostPath:
@@ -536,10 +469,6 @@ kubearmor:
         path: /var/snap/microk8s/common/run/containerd.sock
         type: Socket
       name: containerd-sock-path
-    - hostPath:
-        path: /var/snap/microk8s/common/run/containerd
-        type: DirectoryOrCreate
-      name: containerd-storage-path
 
   volumesK0s:
     - hostPath:
@@ -574,10 +503,6 @@ kubearmor:
         path: /run/k0s/containerd.sock
         type: Socket
       name: containerd-sock-path
-    - hostPath:
-        path: /run/k0s/containerd
-        type: Directory
-      name: containerd-storage-path
 
   volumesK3s:
     - hostPath:
@@ -612,10 +537,6 @@ kubearmor:
         path: /run/k3s/containerd/containerd.sock
         type: Socket
       name: containerd-sock-path
-    - hostPath:
-        path: /run/k3s/containerd
-        type: DirectoryOrCreate
-      name: containerd-storage-path
 
   volumesMinikube:
     - hostPath:
@@ -650,10 +571,6 @@ kubearmor:
         path: /var/run/docker.sock
         type: Socket
       name: docker-sock-path
-    - hostPath:
-        path: /var/lib/docker
-        type: DirectoryOrCreate
-      name: docker-storage-path
 
   volumesGKE:
     - hostPath:
@@ -688,14 +605,6 @@ kubearmor:
         path: /var/run/containerd/containerd.sock
         type: Socket
       name: containerd-sock-path
-    - hostPath:
-        path: /run/containerd
-        type: DirectoryOrCreate
-      name: containerd-storage-path
-    - hostPath:
-        path: /var/lib/docker
-        type: DirectoryOrCreate
-      name: docker-storage-path
 
   volumesBottleRocket:
     - hostPath:
@@ -730,14 +639,6 @@ kubearmor:
         path: /run/dockershim.sock
         type: Socket
       name: containerd-sock-path
-    - hostPath:
-        path: /run/containerd
-        type: DirectoryOrCreate
-      name: containerd-storage-path
-    - hostPath:
-        path: /var/lib/docker
-        type: DirectoryOrCreate
-      name: docker-storage-path
 
   volumesEKS:
     - hostPath:
@@ -772,11 +673,3 @@ kubearmor:
         path: /var/run/containerd/containerd.sock
         type: Socket
       name: containerd-sock-path
-    - hostPath:
-        path: /run/containerd
-        type: DirectoryOrCreate
-      name: containerd-storage-path
-    - hostPath:
-        path: /var/lib/docker
-        type: DirectoryOrCreate
-      name: docker-storage-path

--- a/deployments/helm/KubeArmorOperator/README.md
+++ b/deployments/helm/KubeArmorOperator/README.md
@@ -100,7 +100,7 @@ service/kubearmor-controller-metrics-service   ClusterIP   10.43.241.84    <none
 service/kubearmor                              ClusterIP   10.43.216.156   <none>        32767/TCP   2m53s
 
 NAME                                        DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE   NODE SELECTOR                                                                                                                                                                       AGE
-daemonset.apps/kubearmor-bpf-docker-d4651   1         1         1       1            1           kubearmor.io/btf=yes,kubearmor.io/enforcer=bpf,kubearmor.io/runtime-storage=var_lib_docker,kubearmor.io/runtime=docker,kubearmor.io/socket=run_docker.sock,kubernetes.io/os=linux   30s
+daemonset.apps/kubearmor-bpf-docker-d4651   1         1         1       1            1           kubearmor.io/btf=yes,kubearmor.io/enforcer=bpf,kubearmor.io/runtime=docker,kubearmor.io/socket=run_docker.sock,kubernetes.io/os=linux   30s
 
 NAME                                   READY   UP-TO-DATE   AVAILABLE   AGE
 deployment.apps/kubearmor-operator     1/1     1            1           11m

--- a/pkg/KubeArmorOperator/cmd/snitch-cmd/main.go
+++ b/pkg/KubeArmorOperator/cmd/snitch-cmd/main.go
@@ -114,13 +114,6 @@ func snitch() {
 		Logger.Errorf("Not able to detect runtime")
 		os.Exit(1)
 	}
-	runtimeStorage := runtimepkg.DetectRuntimeStorage(PathPrefix, runtime, *Logger)
-	if runtimeStorage != "NA" {
-		Logger.Infof("Detected runtime storage location %s", runtimeStorage)
-	} else {
-		Logger.Errorf("Not able to detect runtime storage location")
-		os.Exit(1)
-	}
 
 	// Check BTF support
 	btfPresent := enforcer.CheckBtfSupport(PathPrefix, *Logger)
@@ -131,7 +124,6 @@ func snitch() {
 	patchNode.Metadata.Labels[common.RuntimeLabel] = runtime
 	patchNode.Metadata.Labels[common.SocketLabel] = strings.ReplaceAll(socket[1:], "/", "_")
 	patchNode.Metadata.Labels[common.EnforcerLabel] = nodeEnforcer
-	patchNode.Metadata.Labels[common.RuntimeStorageLabel] = strings.ReplaceAll(runtimeStorage[1:], "/", "_")
 	patchNode.Metadata.Labels[common.RandLabel] = rand.String(4)
 	patchNode.Metadata.Labels[common.BTFLabel] = btfPresent
 	patch, err := json.Marshal(patchNode)

--- a/pkg/KubeArmorOperator/common/defaults.go
+++ b/pkg/KubeArmorOperator/common/defaults.go
@@ -43,7 +43,6 @@ var OperatorConfigCrd *opv1.KubeArmorConfig
 var (
 	EnforcerLabel           string = "kubearmor.io/enforcer"
 	RuntimeLabel            string = "kubearmor.io/runtime"
-	RuntimeStorageLabel     string = "kubearmor.io/runtime-storage"
 	SocketLabel             string = "kubearmor.io/socket"
 	RandLabel               string = "kubearmor.io/rand"
 	OsLabel                 string = "kubernetes.io/os"
@@ -130,7 +129,6 @@ var ContainerRuntimeSocketMap = map[string][]string{
 var HostPathDirectory = corev1.HostPathDirectory
 var HostPathSocket = corev1.HostPathSocket
 var HostPathFile = corev1.HostPathFile
-var HostToContainerMountPropagation = corev1.MountPropagationHostToContainer
 
 var EnforcerVolumesMounts = map[string][]corev1.VolumeMount{
 	"apparmor": {
@@ -171,26 +169,6 @@ var EnforcerVolumes = map[string][]corev1.Volume{
 			},
 		},
 	},
-}
-
-var RuntimeStorageVolumes = map[string][]string{
-	"docker": {
-		"/var/lib/docker",
-	},
-	"cri-o": {
-		"/var/lib/containers/storage",
-	},
-	"containerd": {
-		"/run/k0s/containerd",
-		"/run/k3s/containerd",
-		"/run/containerd",
-	},
-}
-
-var RuntimeStorageLocation = map[string]string{
-	"docker":     "/var/lib/docker",
-	"containerd": "/run/containerd",
-	"cri-o":      "/var/lib/containers/storage",
 }
 
 var RuntimeSocketLocation = map[string]string{

--- a/pkg/KubeArmorOperator/runtime/runtime.go
+++ b/pkg/KubeArmorOperator/runtime/runtime.go
@@ -34,13 +34,3 @@ func DetectRuntimeViaMap(pathPrefix string, k8sRuntime string, log zap.SugaredLo
 	log.Warn("Couldn't detect runtime")
 	return "NA", "NA"
 }
-
-func DetectRuntimeStorage(pathPrefix, runtime string, log zap.SugaredLogger) string {
-
-	for _, storageLocation := range common.RuntimeStorageVolumes[runtime] {
-		if _, err := os.Stat(pathPrefix + storageLocation); err == nil {
-			return storageLocation
-		}
-	}
-	return "NA"
-}

--- a/tests/k8s_env/ksp/ksp_test.go
+++ b/tests/k8s_env/ksp/ksp_test.go
@@ -851,13 +851,6 @@ var _ = Describe("Ksp", func() {
 
 		It("it can audit accessing a file owner only from source path", func() {
 
-			if strings.Contains(K8sCRIRuntime(), "cri-o") {
-				// We have issues with audit policy matching with owner related logs due to inconsistent storage mounts
-				// Please check issue for more details : https://github.com/kubearmor/KubeArmor/issues/1178
-				// We will revert the skip after the issue is handled
-				Skip("Skipping due to issue with policy matcher in context of owner only alerts")
-			}
-
 			// Apply Policy
 			err := K8sApplyFile("multiubuntu/ksp-group-2-audit-file-path-owner-from-source-path.yaml")
 			Expect(err).To(BeNil())

--- a/tests/util/kartutil.go
+++ b/tests/util/kartutil.go
@@ -581,17 +581,6 @@ func RandString(n int) string {
 	return string(b)
 }
 
-// K8sCRIRuntime extracts Container Runtime from the Kubernetes API
-func K8sCRIRuntime() string {
-	nodes, _ := k8sClient.K8sClientset.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
-	if len(nodes.Items) <= 0 {
-		return ""
-	}
-
-	containerRuntime := nodes.Items[0].Status.NodeInfo.ContainerRuntimeVersion
-	return containerRuntime
-}
-
 // K8sRuntimeEnforcer extracts Runtime Enforcer from the Node Labels
 func K8sRuntimeEnforcer() string {
 	nodes, _ := k8sClient.K8sClientset.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})


### PR DESCRIPTION
**Purpose of PR?**:
Since we removed the CRI storage dependency in [PR](https://github.com/kubearmor/KubeArmor/pull/1491) this PR is follow-up, removing the CRI storage volume and mounts from deploygen and operator.

Fixes #

**Does this PR introduce a breaking change?**

**If the changes in this PR are manually verified, list down the scenarios covered:**:

**Additional information for reviewer?** :
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [ ] Bug fix. Fixes #<issue number>
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Commit has unit tests
- [ ] Commit has integration tests

<!--

The PR title message must follow convention:
`<type>(<scope>): <subject>`.

Where: <br />
- `type` is to define what type of PR is this.
  Most common types are:
    - `feat`      - for new features, not a new feature for build script
    - `fix`       - for bug fixes or improvements, not a fix for build script
    - `chore`     - changes not related to production code
    - `docs`      - changes related to documentation
    - `style`     - formatting, missing semi colons, linting fix etc; no significant production code changes
    - `test`      - adding missing tests, refactoring tests; no production code change
    - `refactor`  - refactoring production code, eg. renaming a variable or function name, there should not be any significant production code changes

- `scope` is a single word that best describes where the changes fit.
    - feature(`monitor`,`enforcer`)
    - test(`tests`, `bdd`)
    - chore(`build`)
- `subject` is a single line brief description of the changes made in the pull request.

-->