### PR TITLE
fix(operaor): handle apparmor and security fs mounts

### DIFF
--- a/pkg/KubeArmorOperator/cmd/snitch-cmd/main.go
+++ b/pkg/KubeArmorOperator/cmd/snitch-cmd/main.go
@@ -126,6 +126,8 @@ func snitch() {
 	patchNode.Metadata.Labels[common.EnforcerLabel] = nodeEnforcer
 	patchNode.Metadata.Labels[common.RandLabel] = rand.String(4)
 	patchNode.Metadata.Labels[common.BTFLabel] = btfPresent
+	patchNode.Metadata.Labels[common.ApparmorFsLabel] = enforcer.CheckIfApparmorFsPresent(PathPrefix, *Logger)
+	patchNode.Metadata.Labels[common.SecurityFsLabel] = enforcer.CheckIfSecurityFsPresent(PathPrefix, *Logger)
 	patch, err := json.Marshal(patchNode)
 
 	if err != nil {

--- a/pkg/KubeArmorOperator/common/defaults.go
+++ b/pkg/KubeArmorOperator/common/defaults.go
@@ -41,13 +41,20 @@ const (
 var OperatorConfigCrd *opv1.KubeArmorConfig
 
 var (
-	EnforcerLabel           string = "kubearmor.io/enforcer"
-	RuntimeLabel            string = "kubearmor.io/runtime"
-	SocketLabel             string = "kubearmor.io/socket"
-	RandLabel               string = "kubearmor.io/rand"
-	OsLabel                 string = "kubernetes.io/os"
-	ArchLabel               string = "kubernetes.io/arch"
-	BTFLabel                string = "kubearmor.io/btf"
+	// node labels
+	EnforcerLabel   string = "kubearmor.io/enforcer"
+	RuntimeLabel    string = "kubearmor.io/runtime"
+	SocketLabel     string = "kubearmor.io/socket"
+	RandLabel       string = "kubearmor.io/rand"
+	OsLabel         string = "kubernetes.io/os"
+	ArchLabel       string = "kubernetes.io/arch"
+	BTFLabel        string = "kubearmor.io/btf"
+	ApparmorFsLabel string = "kubearmor.io/apparmorfs"
+	SecurityFsLabel string = "kubearmor.io/securityfs"
+
+	// if any node with securityfs/lsm present
+	IfNodeWithSecurtiyFs bool = false
+
 	DeleteAction            string = "DELETE"
 	AddAction               string = "ADD"
 	Namespace               string = "kubearmor"

--- a/pkg/KubeArmorOperator/enforcer/enforcer.go
+++ b/pkg/KubeArmorOperator/enforcer/enforcer.go
@@ -27,7 +27,25 @@ func CheckBtfSupport(PathPrefix string, log zap.SugaredLogger) string {
 	return "no"
 }
 
-// DetectEnforcer: detect the enforcer on the node
+// CheckIfApparmorFsPresent checks if BTF is present
+func CheckIfApparmorFsPresent(PathPrefix string, log zap.SugaredLogger) string {
+	path := PathPrefix + "/etc/apparmor.d"
+	if _, err := os.Stat(filepath.Clean(path)); err == nil {
+		return "yes"
+	}
+	return "no"
+}
+
+// CheckIfSecurityFsPresent checks if Security filesystem is present
+func CheckIfSecurityFsPresent(PathPrefix string, log zap.SugaredLogger) string {
+	path := PathPrefix + "/sys/kernel/security"
+	if _, err := os.Stat(filepath.Clean(path)); err == nil {
+		return "yes"
+	}
+	return "no"
+}
+
+// DetectEnforcer detect the enforcer on the node
 func DetectEnforcer(lsmOrder []string, PathPrefix string, log zap.SugaredLogger) string {
 	supportedLsms := []string{}
 	lsm := []byte{}

--- a/pkg/KubeArmorOperator/internal/controller/resources.go
+++ b/pkg/KubeArmorOperator/internal/controller/resources.go
@@ -23,8 +23,12 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func generateDaemonset(name, enforcer, runtime, socket, btfPresent string) *appsv1.DaemonSet {
-	enforcerVolumes, enforcerVolumeMounts := genEnforcerVolumes(enforcer)
+func generateDaemonset(name, enforcer, runtime, socket, btfPresent, apparmorfs string) *appsv1.DaemonSet {
+	enforcerVolumes := []corev1.Volume{}
+	enforcerVolumeMounts := []corev1.VolumeMount{}
+	if !(enforcer == "apparmor" && apparmorfs == "no") {
+		enforcerVolumes, enforcerVolumeMounts = genEnforcerVolumes(enforcer)
+	}
 	runtimeVolumes, runtimeVolumeMounts := genRuntimeVolumes(runtime, socket)
 	vols := []corev1.Volume{}
 	volMnts := []corev1.VolumeMount{}
@@ -321,11 +325,66 @@ func (clusterWatcher *ClusterWatcher) AreAllNodesProcessed() bool {
 	if !(len(nodes.Items) == processedNodes) {
 		return false
 	}
+
+	// check if there's any node with securityfs/lsm exists
+	common.IfNodeWithSecurtiyFs = false
+	for _, node := range nodes.Items {
+		if val, ok := node.Labels[common.SecurityFsLabel]; ok {
+			switch val {
+			case "yes":
+				common.IfNodeWithSecurtiyFs = true
+			}
+		}
+	}
+
 	kaPodsList, err := clusterWatcher.Client.CoreV1().Pods(common.Namespace).List(context.Background(), metav1.ListOptions{
 		LabelSelector: "kubearmor-app=kubearmor",
 	})
 	return len(kaPodsList.Items) == dsCount
 
+}
+
+func (clusterWatcher *ClusterWatcher) deployControllerDeployment(deployment *appsv1.Deployment) error {
+	if common.IfNodeWithSecurtiyFs {
+		deployment.Spec.Template.Spec.NodeSelector = map[string]string{
+			common.SecurityFsLabel: "yes",
+		}
+		deployment.Spec.Template.Spec.Containers = deployments.GetKubeArmorControllerDeployment(common.Namespace).Spec.Template.Spec.Containers
+	} else {
+		deployment.Spec.Template.Spec.NodeSelector = nil
+		for i, container := range deployment.Spec.Template.Spec.Containers {
+			if container.Name == "manager" {
+				for j, mount := range container.VolumeMounts {
+					if mount.MountPath == "/sys/kernel/security" {
+						deployment.Spec.Template.Spec.Containers[i].VolumeMounts = append(deployment.Spec.Template.Spec.Containers[i].VolumeMounts[:j],
+							deployment.Spec.Template.Spec.Containers[i].VolumeMounts[j+1:]...)
+					}
+				}
+			}
+		}
+	}
+	controller, err := clusterWatcher.Client.AppsV1().Deployments(common.Namespace).Get(context.Background(), deployment.Name, metav1.GetOptions{})
+	if isNotfound(err) {
+		clusterWatcher.Log.Infof("Creating deployment %s", deployment.Name)
+		_, err = clusterWatcher.Client.AppsV1().Deployments(common.Namespace).Create(context.Background(), deployment, metav1.CreateOptions{})
+		if err != nil {
+			clusterWatcher.Log.Warnf("Cannot create deployment %s, error=%s", deployment.Name, err.Error())
+			return err
+		}
+	} else {
+		if (common.IfNodeWithSecurtiyFs && controller.Spec.Template.Spec.NodeSelector == nil) ||
+			(!common.IfNodeWithSecurtiyFs && controller.Spec.Template.Spec.NodeSelector != nil) {
+			clusterWatcher.Log.Infof("Updating deployment %s", controller.Name)
+			controller.Spec.Template.Spec.NodeSelector = deployment.Spec.Template.Spec.NodeSelector
+			controller.Spec.Template.Spec.Containers = deployment.Spec.Template.Spec.Containers
+			_, err = clusterWatcher.Client.AppsV1().Deployments(common.Namespace).Update(context.Background(), controller, metav1.UpdateOptions{})
+			if err != nil {
+				clusterWatcher.Log.Warnf("Cannot update deployment %s, error=%s", deployment.Name, err.Error())
+				return err
+			}
+		}
+	}
+	return nil
 }
 
 func (clusterWatcher *ClusterWatcher) WatchRequiredResources() {
@@ -397,7 +456,6 @@ func (clusterWatcher *ClusterWatcher) WatchRequiredResources() {
 	relayServer.Spec.Template.Spec.Containers[0].Image = common.GetApplicationImage(common.KubeArmorRelayName)
 	relayServer.Spec.Template.Spec.Containers[0].ImagePullPolicy = corev1.PullPolicy(common.KubeArmorRelayImagePullPolicy)
 	deploys := []*appsv1.Deployment{
-		addOwnership(controller).(*appsv1.Deployment),
 		addOwnership(relayServer).(*appsv1.Deployment),
 	}
 
@@ -537,6 +595,13 @@ func (clusterWatcher *ClusterWatcher) WatchRequiredResources() {
 			}
 		}
 
+		areAllNodeProcessed := clusterWatcher.AreAllNodesProcessed()
+
+		// deploy controller
+		if err := clusterWatcher.deployControllerDeployment(controller); err != nil {
+			installErr = err
+		}
+
 		//mutation webhook
 		hook, err := clusterWatcher.Client.AdmissionregistrationV1().MutatingWebhookConfigurations().Get(context.Background(), mutationhook.Name, metav1.GetOptions{})
 		if isNotfound(err) {
@@ -564,7 +629,7 @@ func (clusterWatcher *ClusterWatcher) WatchRequiredResources() {
 			if installErr != nil {
 				installErr = nil
 				go clusterWatcher.UpdateCrdStatus(common.OperatorConfigCrd.Name, common.ERROR, common.INSTALLATION_ERR_MSG)
-			} else if clusterWatcher.AreAllNodesProcessed() {
+			} else if areAllNodeProcessed {
 				go clusterWatcher.UpdateCrdStatus(common.OperatorConfigCrd.Name, common.RUNNING, common.RUNNING_MSG)
 			} else {
 				go clusterWatcher.UpdateCrdStatus(common.OperatorConfigCrd.Name, common.PENDING, common.PENDING_MSG)


### PR DESCRIPTION
**Purpose of PR?**:
This PR handles the cases:
- `/etc/apparmor.d` is not present on host to be mounted with `KubeArmor daemonset` when apparmor enforcer is being used.
- `/sys/kernel/security` is not present to be mounted with `kubearmor-controller`. 

when the operator is used to deploy the KubeArmor. In both the cases, if required path is not present, kubearmor darmonset or controller will be deployed without the mount. 

Fixes #

**Does this PR introduce a breaking change?**
No
**If the changes in this PR are manually verified, list down the scenarios covered:**:

**Additional information for reviewer?** :
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [ ] Bug fix. Fixes #<issue number>
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Commit has unit tests
- [ ] Commit has integration tests

<!--

The PR title message must follow convention:
`<type>(<scope>): <subject>`.

Where: <br />
- `type` is to define what type of PR is this.
  Most common types are:
    - `feat`      - for new features, not a new feature for build script
    - `fix`       - for bug fixes or improvements, not a fix for build script
    - `chore`     - changes not related to production code
    - `docs`      - changes related to documentation
    - `style`     - formatting, missing semi colons, linting fix etc; no significant production code changes
    - `test`      - adding missing tests, refactoring tests; no production code change
    - `refactor`  - refactoring production code, eg. renaming a variable or function name, there should not be any significant production code changes

- `scope` is a single word that best describes where the changes fit.
    - feature(`monitor`,`enforcer`)
    - test(`tests`, `bdd`)
    - chore(`build`)
- `subject` is a single line brief description of the changes made in the pull request.

-->