### PR TITLE
fix(core,monitor,feeder): fix telemetry missing data and configurable debug stdout logs

### DIFF
--- a/KubeArmor/Makefile
+++ b/KubeArmor/Makefile
@@ -50,7 +50,7 @@ run: build
 	cd $(CURDIR); sudo rm -f /tmp/kubearmor.log
 	cd $(CURDIR)/BPF; make clean
 	cd $(CURDIR)/BPF; make
-	cd $(CURDIR); sudo -E ./kubearmor -logPath=/tmp/kubearmor.log -enableKubeArmorPolicy -enableKubeArmorHostPolicy -hostVisibility=process,file,network,capabilities -defaultFilePosture block -defaultCapabilitiesPosture block -defaultNetworkPosture block -hostDefaultFilePosture block -hostDefaultCapabilitiesPosture block -hostDefaultNetworkPosture block
+	cd $(CURDIR); DEBUG=true sudo -E ./kubearmor -logPath=/tmp/kubearmor.log -enableKubeArmorPolicy -enableKubeArmorHostPolicy -hostVisibility=process,file,network,capabilities -defaultFilePosture block -defaultCapabilitiesPosture block -defaultNetworkPosture block -hostDefaultFilePosture block -hostDefaultCapabilitiesPosture block -hostDefaultNetworkPosture block
 
 .PHONY: run-container
 run-container: build

--- a/KubeArmor/config/config.go
+++ b/KubeArmor/config/config.go
@@ -102,7 +102,7 @@ func readCmdLineParams() {
 	kvmAgentB := flag.Bool(ConfigKubearmorVM, false, "enabling KubeArmorVM")
 	k8sEnvB := flag.Bool(ConfigK8sEnv, true, "is k8s env?")
 
-	debugB := flag.Bool(ConfigDebug, false, "Enable/Disable KubeArmor debug mode")
+	debugB := flag.Bool(ConfigDebug, false, "Enable/Disable pushing KubeArmor debug logs over gRPC. NOTE: Set environment DEBUG=true to configure stdout debug logging")
 
 	defaultFilePosture := flag.String(ConfigDefaultFilePosture, "audit", "configuring default enforcement action in global file context {allow|audit|block}")
 	defaultNetworkPosture := flag.String(ConfigDefaultNetworkPosture, "audit", "configuring default enforcement action in global network context {allow|audit|block}")

--- a/KubeArmor/core/kubeUpdate.go
+++ b/KubeArmor/core/kubeUpdate.go
@@ -575,7 +575,7 @@ func (dm *KubeArmorDaemon) WatchK8sPods() {
 
 				controllerName, controller, namespace, err := getTopLevelOwner(event.Object.ObjectMeta, event.Object.Namespace, event.Object.Kind)
 				if err != nil {
-					dm.Logger.Errf("Failed to get ownerRef (%s, %s)", event.Object.ObjectMeta.Name, err.Error())
+					dm.Logger.Warnf("Failed to get ownerRef (%s, %s)", event.Object.ObjectMeta.Name, err.Error())
 
 				}
 

--- a/KubeArmor/feeder/feeder.go
+++ b/KubeArmor/feeder/feeder.go
@@ -595,7 +595,8 @@ func (fd *Feeder) PushLog(log tp.Log) {
 	}
 
 	if log.Source == "" {
-		if log.Type == "HostLog" {
+		// even if a log doesn't have a source, it must have a type
+		if log.Type == "" {
 			return
 		}
 		fd.Debug("Pushing Telemetry without source")

--- a/KubeArmor/feeder/policyMatcher.go
+++ b/KubeArmor/feeder/policyMatcher.go
@@ -915,16 +915,19 @@ func setLogFields(log *tp.Log, existAllowPolicy bool, defaultPosture string, vis
 	}
 
 	if containerEvent {
+		// return here as container events are dropped in kernel space
 		(*log).Type = "ContainerLog"
 		return true
-	}
-
-	if visibility {
+	} else {
+		// host events are dropped in userspace
 		(*log).Type = "HostLog"
-		return true
 	}
 
-	return false
+
+	// handles host visibility
+	// return true if visibility enabled
+	// return false otherwise so that log is skipped
+	return visibility
 }
 
 // ==================== //

--- a/KubeArmor/log/logger.go
+++ b/KubeArmor/log/logger.go
@@ -6,6 +6,7 @@ package log
 
 import (
 	"encoding/json"
+	"os"
 	"time"
 
 	"go.uber.org/zap"
@@ -32,7 +33,7 @@ func customTimeEncoder(t time.Time, enc zapcore.PrimitiveArrayEncoder) {
 // initLogger Function
 func initLogger() {
 	defaultConfig := []byte(`{
-		"level": "debug",
+		"level": "info",
 		"encoding": "console",
 		"outputPaths": ["stdout"],
 		"encoderConfig": {
@@ -59,7 +60,11 @@ func initLogger() {
 	}
 
 	config.EncoderConfig.EncodeTime = customTimeEncoder
-	config.Level.SetLevel(zap.DebugLevel) // if we need to set log level
+
+	// this is not read from config/viper as logger is initialized before config
+	if val, ok := os.LookupEnv("DEBUG"); ok && val == "true" {
+		config.Level.SetLevel(zap.DebugLevel) // set to enable debug logging
+	}
 
 	logger, err := config.Build()
 	if err != nil {

--- a/KubeArmor/monitor/processTree.go
+++ b/KubeArmor/monitor/processTree.go
@@ -226,8 +226,10 @@ func (mon *SystemMonitor) GetParentExecPath(containerID string, hostPid uint32, 
 		// just in case that it couldn't still get the full path
 		if data, err := os.Readlink("/proc/" + strconv.FormatUint(uint64(hostPid), 10) + "/exe"); err == nil && data != "" && data != "/" {
 			return data
-		} else {
+		} else if err != nil {
 			mon.Logger.Debugf("Could not read path from procfs due to %s", err.Error())
+		} else {
+			mon.Logger.Debugf("Could not read path from procfs due to unknown error")
 		}
 	}
 
@@ -258,8 +260,10 @@ func (mon *SystemMonitor) GetExecPath(containerID string, hostPid uint32, readli
 		// just in case that it couldn't still get the full path
 		if data, err := os.Readlink("/proc/" + strconv.FormatUint(uint64(hostPid), 10) + "/exe"); err == nil && data != "" && data != "/" {
 			return data
-		} else {
+		} else if err != nil {
 			mon.Logger.Debugf("Could not read path from procfs due to %s", err.Error())
+		} else {
+			mon.Logger.Debugf("Could not read path from procfs due to an unknown error")
 		}
 	}
 
@@ -288,8 +292,10 @@ func (mon *SystemMonitor) GetCommand(containerID string, hostPid uint32, readlin
 		// just in case that it couldn't still get the full path
 		if data, err := os.Readlink("/proc/" + strconv.FormatUint(uint64(hostPid), 10) + "/exe"); err == nil && data != "" && data != "/" {
 			return data
-		} else {
+		} else if err != nil {
 			mon.Logger.Debugf("Could not read path from procfs due to %s", err.Error())
+		} else {
+			mon.Logger.Debugf("Could not read path from procfs due to an unknown error")
 		}
 	}
 


### PR DESCRIPTION
**Purpose of PR?**:
Fixes
- Telemetry logs without data and only having cluster and hostname.
It was happening because of the recent removal of condition where we skip a log when `source` is empty. Which led to two things:
	- Visibility based dropping of host events, which happens in userspace, didn't work as intended. We intentionally leave the log empty if visibility of host is not enabled and this condition [here](https://github.com/kubearmor/KubeArmor/blob/719ae8563da75f877966f7d2cd675ed9187f1100/KubeArmor/feeder/feeder.go#L719) doesn't take into consideration empty `log.Type`. Thus, it ends up pushing a log which only has cluster and hostname taken from Node data. Also, the existing check for early return on empty source if `log.Type == HostLog` didn't work because HostLog type was only set if visibility was enabled.
	- Events, regardless of container or host, were skipped from sending over gRPC if they didn't have source. However, logs might be dropped based on visibility configuration, thus they'll have no log fields. So we put in a check for log.Type and if a log doesn't have a type, up until the point where we check it in `PushLog`, we skip sending it. This is safe to do as `log.Type` is not written over in any check after this point.

- Removes `DEBUG` logs from stdout. Need to use the environment var `DEBUG=true` to set this.
	NOTE: the flag `-debug` won't affect this as logger is initialized before config.

- Fixes panics at some places.

Fixes #

**Does this PR introduce a breaking change?**

**If the changes in this PR are manually verified, list down the scenarios covered:**:

**Additional information for reviewer?** :
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [x] Bug fix. Fixes #<issue number>
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Commit has unit tests
- [ ] Commit has integration tests

<!--

The PR title message must follow convention:
`<type>(<scope>): <subject>`.

Where: <br />
- `type` is to define what type of PR is this.
  Most common types are:
    - `feat`      - for new features, not a new feature for build script
    - `fix`       - for bug fixes or improvements, not a fix for build script
    - `chore`     - changes not related to production code
    - `docs`      - changes related to documentation
    - `style`     - formatting, missing semi colons, linting fix etc; no significant production code changes
    - `test`      - adding missing tests, refactoring tests; no production code change
    - `refactor`  - refactoring production code, eg. renaming a variable or function name, there should not be any significant production code changes

- `scope` is a single word that best describes where the changes fit.
    - feature(`monitor`,`enforcer`)
    - test(`tests`, `bdd`)
    - chore(`build`)
- `subject` is a single line brief description of the changes made in the pull request.

-->