### PR TITLE
Enhancement: Implement RBAC policy and Service Account for relay service

### DIFF
--- a/deployments/get/defaults.go
+++ b/deployments/get/defaults.go
@@ -16,6 +16,9 @@ var (
 	KubeArmorClusterRoleBindingName                  = "kubearmor-clusterrolebinding"
 	KubeArmorClusterRoleName                         = "kubearmor-clusterrole"
 	RelayServiceName                                 = kubearmor
+	RelayServiceAccountName                          = "kubearmor-relay"
+	RelayClusterRoleName                             = "kubearmor-relay-clusterrole"
+	RelayClusterRoleBindingName                      = "kubearmor-relay-clusterrolebinding"
 	RelayDeploymentName                              = "kubearmor-relay"
 	KubeArmorConfigMapName                           = "kubearmor-config"
 	KubeArmorControllerDeploymentName                = "kubearmor-controller"

--- a/deployments/get/objects.go
+++ b/deployments/get/objects.go
@@ -159,7 +159,7 @@ func GetRelayDeployment(namespace string) *appsv1.Deployment {
 					Labels: relayDeploymentLabels,
 				},
 				Spec: corev1.PodSpec{
-					ServiceAccountName: kubearmor,
+					ServiceAccountName: RelayServiceAccountName,
 					NodeSelector: map[string]string{
 						"kubernetes.io/os": "linux",
 					},
@@ -177,6 +177,65 @@ func GetRelayDeployment(namespace string) *appsv1.Deployment {
 						},
 					},
 				},
+			},
+		},
+	}
+}
+
+// GetRelayServiceAccount Function
+func GetRelayServiceAccount(namespace string) *corev1.ServiceAccount {
+	return &corev1.ServiceAccount{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "ServiceAccount",
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      RelayServiceAccountName,
+			Namespace: namespace,
+		},
+	}
+}
+
+// GetRelayClusterRole Function
+func GetRelayClusterRole() *rbacv1.ClusterRole {
+	return &rbacv1.ClusterRole{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "ClusterRole",
+			APIVersion: "rbac.authorization.k8s.io/v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: RelayClusterRoleName,
+		},
+		Rules: []rbacv1.PolicyRule{
+			{
+				APIGroups: []string{""},
+				Resources: []string{"pods"},
+				Verbs:     []string{"get", "list"},
+			},
+		},
+	}
+}
+
+// GetRelayClusterRoleBinding Function
+func GetRelayClusterRoleBinding(namespace string) *rbacv1.ClusterRoleBinding {
+	return &rbacv1.ClusterRoleBinding{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "ClusterRoleBinding",
+			APIVersion: "rbac.authorization.k8s.io/v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: RelayClusterRoleBindingName,
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "ClusterRole",
+			Name:     RelayClusterRoleName,
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:      "ServiceAccount",
+				Name:      RelayServiceAccountName,
+				Namespace: namespace,
 			},
 		},
 	}

--- a/deployments/helm/KubeArmor/templates/RBAC/bindings.yaml
+++ b/deployments/helm/KubeArmor/templates/RBAC/bindings.yaml
@@ -14,6 +14,19 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
+  name: kubearmor-relay-clusterrolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kubearmor-relay-clusterrole
+subjects:
+- kind: ServiceAccount
+  name: kubearmor-relay
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
   name: {{ .Values.kubearmorController.name }}-clusterrolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/deployments/helm/KubeArmor/templates/RBAC/roles.yaml
+++ b/deployments/helm/KubeArmor/templates/RBAC/roles.yaml
@@ -49,6 +49,19 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+  name: kubearmor-relay-clusterrole
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
   name: {{ .Values.kubearmorController.name }}-clusterrole
 rules:
 - apiGroups:

--- a/deployments/helm/KubeArmor/templates/deployment.yaml
+++ b/deployments/helm/KubeArmor/templates/deployment.yaml
@@ -33,7 +33,7 @@ spec:
         - containerPort: 32767
       nodeSelector:
         kubernetes.io/os: linux
-      serviceAccountName: kubearmor
+      serviceAccountName: kubearmor-relay
 {{- end }}
 ---
 apiVersion: apps/v1

--- a/deployments/helm/KubeArmor/templates/serviceaccount.yaml
+++ b/deployments/helm/KubeArmor/templates/serviceaccount.yaml
@@ -9,3 +9,9 @@ kind: ServiceAccount
 metadata:
   name: {{ .Values.kubearmorController.name }}
   namespace: {{ .Release.Namespace }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kubearmor-relay
+  namespace: {{ .Release.Namespace }}

--- a/deployments/main.go
+++ b/deployments/main.go
@@ -31,6 +31,7 @@ func main() {
 		v := []interface{}{
 			// ServiceAccounts
 			dp.GetServiceAccount(namespace),
+			dp.GetRelayServiceAccount(namespace),
 			dp.GetKubeArmorControllerServiceAccount(namespace),
 
 			// Configmap
@@ -42,12 +43,14 @@ func main() {
 
 			// ClusterRoles
 			dp.GetClusterRole(),
+			dp.GetRelayClusterRole(),
 			dp.GetKubeArmorControllerClusterRole(),
 			dp.GetKubeArmorControllerProxyRole(),
 			dp.GetKubeArmorControllerMetricsReaderRole(),
 
 			// ClusterRoleBindings
 			dp.GetClusterRoleBinding(namespace),
+			dp.GetRelayClusterRoleBinding(namespace),
 			dp.GetKubeArmorControllerClusterRoleBinding(namespace),
 			dp.GetKubeArmorControllerProxyRoleBinding(namespace),
 			dp.GetKubeArmorControllerMetricsReaderRoleBinding(namespace),

--- a/pkg/KubeArmorOperator/internal/controller/resources.go
+++ b/pkg/KubeArmorOperator/internal/controller/resources.go
@@ -394,17 +394,20 @@ func (clusterWatcher *ClusterWatcher) WatchRequiredResources() {
 	FirstRun := true
 	srvAccs := []*corev1.ServiceAccount{
 		addOwnership(deployments.GetServiceAccount(common.Namespace)).(*corev1.ServiceAccount),
+		addOwnership(deployments.GetRelayServiceAccount(common.Namespace)).(*corev1.ServiceAccount),
 		addOwnership(deployments.GetKubeArmorControllerServiceAccount(common.Namespace)).(*corev1.ServiceAccount),
 		addOwnership(genSnitchServiceAccount()).(*corev1.ServiceAccount),
 	}
 	clusterRoles := []*rbacv1.ClusterRole{
 		addOwnership(genSnitchRole()).(*rbacv1.ClusterRole),
 		addOwnership(deployments.GetClusterRole()).(*rbacv1.ClusterRole),
+		addOwnership(deployments.GetRelayClusterRole()).(*rbacv1.ClusterRole),
 		addOwnership(deployments.GetKubeArmorControllerProxyRole()).(*rbacv1.ClusterRole),
 		addOwnership(deployments.GetKubeArmorControllerClusterRole()).(*rbacv1.ClusterRole),
 	}
 	clusterRoleBindings := []*rbacv1.ClusterRoleBinding{
 		addOwnership(deployments.GetClusterRoleBinding(common.Namespace)).(*rbacv1.ClusterRoleBinding),
+		addOwnership(deployments.GetRelayClusterRoleBinding(common.Namespace)).(*rbacv1.ClusterRoleBinding),
 		addOwnership(deployments.GetKubeArmorControllerClusterRoleBinding(common.Namespace)).(*rbacv1.ClusterRoleBinding),
 		addOwnership(deployments.GetKubeArmorControllerProxyRoleBinding(common.Namespace)).(*rbacv1.ClusterRoleBinding),
 		addOwnership(genSnitchRoleBinding()).(*rbacv1.ClusterRoleBinding),


### PR DESCRIPTION
**Purpose of PR?**:

Fixes #1525 

**Does this PR introduce a breaking change?**

**If the changes in this PR are manually verified, list down the scenarios covered:**:
Verified and found that the only place where the application seems to be using the kubernetes API is to fetch a list of all the pods from all the namespaces while rest of the process takes place via gRPC and other means.

I initially tried configuring Role/RoleBinding for implementing RBAC policy considering both kubearmor and kubearmor-relay will be deployed in the same namespace `kubearmor` hoping the relay server would still work fetching only the pods from the kubearmor namespace but it fails (doesn't display the error in std error output).  To further debug, I tried fetching pods list with kubectl as the serviceaccount and it failed as well making sure that the kubernetes API doesn't allow fetching the entire list with Role and would require code change.

```bash
kubectl get pods -A --as=system:serviceaccount:kubearmor:kubearmor-relay
Error from server (Forbidden): pods is forbidden: User "system:serviceaccount:kubearmor:kubearmor-relay" cannot list resource "pods" in API group "" at the cluster scope
```

Due to which I went ahead and configured ClusterRole, which succeeded with the same command and kubearmor-relay was able to detect the pods.
 
![image](https://github.com/kubearmor/KubeArmor/assets/14823803/2e11d4d5-0db5-4f20-a5c4-6ed4920d99dc)

**Additional information for reviewer?** :

**Checklist:**
- [ ] Bug fix. Fixes #<issue number>
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Commit has unit tests
- [ ] Commit has integration tests

<!--

The PR title message must follow convention:
`<type>(<scope>): <subject>`.

Where: <br />
- `type` is to define what type of PR is this.
  Most common types are:
    - `feat`      - for new features, not a new feature for build script
    - `fix`       - for bug fixes or improvements, not a fix for build script
    - `chore`     - changes not related to production code
    - `docs`      - changes related to documentation
    - `style`     - formatting, missing semi colons, linting fix etc; no significant production code changes
    - `test`      - adding missing tests, refactoring tests; no production code change
    - `refactor`  - refactoring production code, eg. renaming a variable or function name, there should not be any significant production code changes

- `scope` is a single word that best describes where the changes fit.
    - feature(`monitor`,`enforcer`)
    - test(`tests`, `bdd`)
    - chore(`build`)
- `subject` is a single line brief description of the changes made in the pull request.

-->