### PR TITLE
Fix : Pods not being annotated with `kubearmor-policy=enabled` by Kubearmor controller

### DIFF
--- a/pkg/KubeArmorController/handlers/pod_mutation.go
+++ b/pkg/KubeArmorController/handlers/pod_mutation.go
@@ -19,7 +19,7 @@ import (
 // PodAnnotator Structure
 type PodAnnotator struct {
 	Client   client.Client
-	decoder  *admission.Decoder
+	Decoder  *admission.Decoder
 	Logger   logr.Logger
 	Enforcer string
 }
@@ -33,7 +33,7 @@ const appArmorAnnotation = "container.apparmor.security.beta.kubernetes.io/"
 func (a *PodAnnotator) Handle(ctx context.Context, req admission.Request) admission.Response {
 	pod := &corev1.Pod{}
 
-	if err := a.decoder.Decode(req, pod); err != nil {
+	if err := a.Decoder.Decode(req, pod); err != nil {
 		return admission.Errored(http.StatusBadRequest, err)
 	}
 
@@ -101,12 +101,6 @@ func (a *PodAnnotator) Handle(ctx context.Context, req admission.Request) admiss
 		return admission.Errored(http.StatusInternalServerError, err)
 	}
 	return admission.PatchResponseFromRaw(req.Object.Raw, marshaledPod)
-}
-
-// InjectDecoder gets a decoder injected for us
-func (a *PodAnnotator) InjectDecoder(d *admission.Decoder) error {
-	a.decoder = d
-	return nil
 }
 
 // == Add AppArmor annotations == //

--- a/pkg/KubeArmorController/main.go
+++ b/pkg/KubeArmorController/main.go
@@ -21,6 +21,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	"github.com/go-logr/logr"
 	securityv1 "github.com/kubearmor/KubeArmor/pkg/KubeArmorController/api/security.kubearmor.com/v1"
@@ -97,6 +98,7 @@ func main() {
 			Client:   mgr.GetClient(),
 			Logger:   setupLog,
 			Enforcer: detectEnforcer(setupLog),
+			Decoder:  admission.NewDecoder(mgr.GetScheme()),
 		},
 	})
 


### PR DESCRIPTION
**Purpose of PR?**:

Fixes #CI failure for BPFLSM 

Context - 
We updated the dependencies for controller runtime to v0.15.3 [in](https://github.com/kubearmor/KubeArmor/pull/1595). 
Apparently, after v0.15the `injection pkg`  is removed, causing the decoder to be created with a `nil` value in our kubearmor controller code. 

The change in this PR  is made in accordance with the updated logs of [kubernetes-sigs controller-runtime](https://github.com/kubernetes-sigs/controller-runtime/releases/tag/v0.15.0).

How we verified the error
- whenever a new deployment was created we tried to update the annotation of the pod through the `(a *PodAnnotator) Handle()` function this caused panic in the controller logs. 

**Does this PR introduce a breaking change?**
  
**If the changes in this PR are manually verified, list down the scenarios covered:**:
- Build `KubarmorController` locally , and try to deploy a new pod. Watch controller logs `kubectl logs -n kubearmor<> -f`.
 There should be no panic error in logs.
**Additional information for reviewer?** :
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [ ] Bug fix. Fixes #<issue number>
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Commit has unit tests
- [ ] Commit has integration tests

<!--

The PR title message must follow convention:
`<type>(<scope>): <subject>`.

Where: <br />
- `type` is to define what type of PR is this.
  Most common types are:
    - `feat`      - for new features, not a new feature for build script
    - `fix`       - for bug fixes or improvements, not a fix for build script
    - `chore`     - changes not related to production code
    - `docs`      - changes related to documentation
    - `style`     - formatting, missing semi colons, linting fix etc; no significant production code changes
    - `test`      - adding missing tests, refactoring tests; no production code change
    - `refactor`  - refactoring production code, eg. renaming a variable or function name, there should not be any significant production code changes

- `scope` is a single word that best describes where the changes fit.
    - feature(`monitor`,`enforcer`)
    - test(`tests`, `bdd`)
    - chore(`build`)
- `subject` is a single line brief description of the changes made in the pull request.

-->