### PR TITLE
fix(core): Issues with host policy application

### DIFF
--- a/KubeArmor/core/kubeArmor.go
+++ b/KubeArmor/core/kubeArmor.go
@@ -397,6 +397,9 @@ func KubeArmor() {
 		dm.Node.KernelVersion = kl.GetCommandOutputWithoutErr("uname", []string{"-r"})
 		dm.Node.KernelVersion = strings.TrimSuffix(dm.Node.KernelVersion, "\n")
 
+		// add identity for matching node selector
+		dm.Node.Identities = append(dm.Node.Identities, "kubearmor.io/hostname"+"="+dm.Node.NodeName)
+
 		dm.NodeLock.Unlock()
 
 	} else if cfg.GlobalCfg.K8sEnv {

--- a/KubeArmor/core/kubeUpdate.go
+++ b/KubeArmor/core/kubeUpdate.go
@@ -1461,11 +1461,7 @@ func (dm *KubeArmorDaemon) UpdateHostSecurityPolicies() {
 	secPolicies := []tp.HostSecurityPolicy{}
 
 	for _, policy := range dm.HostSecurityPolicies {
-		if kl.IsK8sEnv() {
-			if kl.MatchIdentities(policy.Spec.NodeSelector.Identities, dm.Node.Identities) {
-				secPolicies = append(secPolicies, policy)
-			}
-		} else { // KubeArmorVM and KVMAgent
+		if kl.MatchIdentities(policy.Spec.NodeSelector.Identities, dm.Node.Identities) {
 			secPolicies = append(secPolicies, policy)
 		}
 	}
@@ -1907,6 +1903,7 @@ func (dm *KubeArmorDaemon) ParseAndUpdateHostSecurityPolicy(event tp.K8sKubeArmo
 		}
 		if !policymatch {
 			dm.Logger.Warnf("Failed to delete security policy. Policy doesn't exist")
+			dm.HostSecurityPoliciesLock.Unlock()
 			return pb.PolicyStatus_NotExist
 		}
 	}


### PR DESCRIPTION
**Purpose of PR?**:

- Fixes policies not getting applied in non-k8s mode.
- If delete event for a policy which didn't exist was sent to KubeArmor, it would go into deadlock and won't let any other policy functions work.
- Match identity for host policy received over gRPC so that a policy not meant for this host is not applied.

**Does this PR introduce a breaking change?**
No

**If the changes in this PR are manually verified, list down the scenarios covered:**:
- Delete a host policy which doesn't exist won't deadlock now.

**Additional information for reviewer?** :
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [x] Bug fix. Fixes #<issue number>
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Commit has unit tests
- [ ] Commit has integration tests

<!--

The PR title message must follow convention:
`<type>(<scope>): <subject>`.

Where: <br />
- `type` is to define what type of PR is this.
  Most common types are:
    - `feat`      - for new features, not a new feature for build script
    - `fix`       - for bug fixes or improvements, not a fix for build script
    - `chore`     - changes not related to production code
    - `docs`      - changes related to documentation
    - `style`     - formatting, missing semi colons, linting fix etc; no significant production code changes
    - `test`      - adding missing tests, refactoring tests; no production code change
    - `refactor`  - refactoring production code, eg. renaming a variable or function name, there should not be any significant production code changes

- `scope` is a single word that best describes where the changes fit.
    - feature(`monitor`,`enforcer`)
    - test(`tests`, `bdd`)
    - chore(`build`)
- `subject` is a single line brief description of the changes made in the pull request.

-->