### PR TITLE
fix(core): annotation logic for static pods

### DIFF
--- a/KubeArmor/core/k8sHandler.go
+++ b/KubeArmor/core/k8sHandler.go
@@ -286,16 +286,15 @@ func (kh *K8sHandler) PatchResourceWithAppArmorAnnotations(namespaceName, deploy
 		}
 		return nil
 
-	} else if kind == "Pod" {
-		_, err := kh.K8sClient.CoreV1().Pods(namespaceName).Patch(context.Background(), deploymentName, types.MergePatchType, []byte(spec), metav1.PatchOptions{})
+	} else if kind == "Deployment" {
+		_, err := kh.K8sClient.AppsV1().Deployments(namespaceName).Patch(context.Background(), deploymentName, types.StrategicMergePatchType, []byte(spec), metav1.PatchOptions{})
 		if err != nil {
-			panic(err.Error())
+			return err
 		}
+	} else if kind == "Pod" {
+		// this condition wont be triggered, handled by controller
+		return nil
 
-	}
-	_, err := kh.K8sClient.AppsV1().Deployments(namespaceName).Patch(context.Background(), deploymentName, types.StrategicMergePatchType, []byte(spec), metav1.PatchOptions{})
-	if err != nil {
-		return err
 	}
 
 	return nil

--- a/KubeArmor/core/kubeUpdate.go
+++ b/KubeArmor/core/kubeUpdate.go
@@ -784,7 +784,7 @@ func (dm *KubeArmorDaemon) WatchK8sPods() {
 						// update apparmor profiles
 						dm.RuntimeEnforcer.UpdateAppArmorProfiles(pod.Metadata["podName"], "ADDED", appArmorAnnotations, pod.PrivilegedAppArmorProfiles)
 
-						if updateAppArmor && pod.Annotations["kubearmor-policy"] == "enabled" {
+						if updateAppArmor && pod.Annotations["kubearmor-policy"] == "enabled" && pod.Metadata["owner.controller"] != "Pod" {
 							if deploymentName, ok := pod.Metadata["owner.controllerName"]; ok {
 								// patch the deployment with apparmor annotations
 								if err := K8s.PatchResourceWithAppArmorAnnotations(pod.Metadata["namespaceName"], deploymentName, appArmorAnnotations, pod.Metadata["owner.controller"]); err != nil {
@@ -804,7 +804,7 @@ func (dm *KubeArmorDaemon) WatchK8sPods() {
 									prevPolicyEnabled = val
 								}
 
-								if updateAppArmor && prevPolicyEnabled != "enabled" && pod.Annotations["kubearmor-policy"] == "enabled" {
+								if updateAppArmor && prevPolicyEnabled != "enabled" && pod.Annotations["kubearmor-policy"] == "enabled" && pod.Metadata["owner.controller"] != "Pod" {
 									if deploymentName, ok := pod.Metadata["owner.controllerName"]; ok {
 										// patch the deployment with apparmor annotations
 										if err := K8s.PatchResourceWithAppArmorAnnotations(pod.Metadata["namespaceName"], deploymentName, appArmorAnnotations, pod.Metadata["owner.controller"]); err != nil {


### PR DESCRIPTION
**Purpose of PR?**:

Fixes #1635 

**Does this PR introduce a breaking change?**
No

**If the changes in this PR are manually verified, list down the scenarios covered:**:

1: pod deployed before KubeArmor
2: pod deployed after KubeArmor


**Additional information for reviewer?** :

kubearmor cannot annotate static pod with apparmor annotations

```
2024-02-19 05:40:04.024021	ERROR	Failed to update AppArmor Annotations (default/nginx-pod/nginx-pod, Pod "nginx-pod" is invalid: metadata.annotations[container.apparmor.security.beta.kubernetes.io/nginx-pod]: Forbidden: may not add AppArmor annotations)
``` 

i still have the logic for annotating static pod in k8shandler , will/not remove based on review 

**Checklist:**
- [ ] Bug fix. Fixes #<issue number>
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Commit has unit tests
- [ ] Commit has integration tests

<!--

The PR title message must follow convention:
`<type>(<scope>): <subject>`.

Where: <br />
- `type` is to define what type of PR is this.
  Most common types are:
    - `feat`      - for new features, not a new feature for build script
    - `fix`       - for bug fixes or improvements, not a fix for build script
    - `chore`     - changes not related to production code
    - `docs`      - changes related to documentation
    - `style`     - formatting, missing semi colons, linting fix etc; no significant production code changes
    - `test`      - adding missing tests, refactoring tests; no production code change
    - `refactor`  - refactoring production code, eg. renaming a variable or function name, there should not be any significant production code changes

- `scope` is a single word that best describes where the changes fit.
    - feature(`monitor`,`enforcer`)
    - test(`tests`, `bdd`)
    - chore(`build`)
- `subject` is a single line brief description of the changes made in the pull request.

-->