### PR TITLE
fix : owner info available for every log

### DIFF
--- a/KubeArmor/core/kubeArmor.go
+++ b/KubeArmor/core/kubeArmor.go
@@ -63,6 +63,9 @@ type KubeArmorDaemon struct {
 	EndPoints     []tp.EndPoint
 	EndPointsLock *sync.RWMutex
 
+	// Owner Info
+	OwnerInfo map[string]tp.PodOwner
+
 	// Security policies
 	SecurityPolicies     []tp.SecurityPolicy
 	SecurityPoliciesLock *sync.RWMutex
@@ -141,6 +144,8 @@ func NewKubeArmorDaemon() *KubeArmorDaemon {
 	dm.WgDaemon = sync.WaitGroup{}
 
 	dm.MonitorLock = new(sync.RWMutex)
+
+	dm.OwnerInfo = map[string]tp.PodOwner{}
 
 	return dm
 }

--- a/KubeArmor/types/types.go
+++ b/KubeArmor/types/types.go
@@ -76,9 +76,8 @@ type Namespace struct {
 type EndPoint struct {
 	NamespaceName string `json:"namespaceName"`
 
-	EndPointName  string   `json:"endPointName"`
-	Owner         PodOwner `json:"owner,omitempty"`
-	ContainerName string   `json:"containerName"`
+	EndPointName  string `json:"endPointName"`
+	ContainerName string `json:"containerName"`
 
 	Labels     map[string]string `json:"labels"`
 	Identities []string          `json:"identities"`


### PR DESCRIPTION
**Purpose of PR?**:
introduce a new map which wlll carry the info for pod owners, earlier it was handled in `pod.metadata` for resp pods, which was not updated when pod were just started or modified or deleted.

Fixes #1629 

**Does this PR introduce a breaking change?**
no

**If the changes in this PR are manually verified, list down the scenarios covered:**:
checked the logs after modifying and deleting the pod

**Additional information for reviewer?** :
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [x] Bug fix. Fixes #<issue number>
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Commit has unit tests
- [ ] Commit has integration tests

<!--

The PR title message must follow convention:
`<type>(<scope>): <subject>`.

Where: <br />
- `type` is to define what type of PR is this.
  Most common types are:
    - `feat`      - for new features, not a new feature for build script
    - `fix`       - for bug fixes or improvements, not a fix for build script
    - `chore`     - changes not related to production code
    - `docs`      - changes related to documentation
    - `style`     - formatting, missing semi colons, linting fix etc; no significant production code changes
    - `test`      - adding missing tests, refactoring tests; no production code change
    - `refactor`  - refactoring production code, eg. renaming a variable or function name, there should not be any significant production code changes

- `scope` is a single word that best describes where the changes fit.
    - feature(`monitor`,`enforcer`)
    - test(`tests`, `bdd`)
    - chore(`build`)
- `subject` is a single line brief description of the changes made in the pull request.

-->