### PR TITLE
chore(tests): change logic to get target alert for syscall test suite

### DIFF
--- a/tests/k8s_env/syscalls/syscalls_test.go
+++ b/tests/k8s_env/syscalls/syscalls_test.go
@@ -64,11 +64,16 @@ var _ = Describe("Syscalls", func() {
 			Expect(err).To(BeNil())
 
 			// check policy alert
-			_, alerts, err := KarmorGetLogs(5*time.Second, 1)
+			expect := protobuf.Alert{
+				PolicyName: "audit-all-unlink",
+				Severity:   "3",
+				Action:     "Audit",
+				Result:     "Passed",
+			}
+
+			res, err := KarmorGetTargetAlert(5*time.Second, &expect)
 			Expect(err).To(BeNil())
-			Expect(len(alerts)).To(BeNumerically(">=", 1))
-			Expect(alerts[0].PolicyName).To(Equal("audit-all-unlink"))
-			Expect(alerts[0].Severity).To(Equal("3"))
+			Expect(res.Found).To(BeTrue())
 
 		})
 
@@ -90,11 +95,16 @@ var _ = Describe("Syscalls", func() {
 			Expect(err).To(BeNil())
 
 			// check policy alert
-			_, alerts, err := KarmorGetLogs(5*time.Second, 1)
+			expect := protobuf.Alert{
+				PolicyName: "audit-unlink-fromsource",
+				Severity:   "4",
+				Action:     "Audit",
+				Result:     "Passed",
+			}
+
+			res, err := KarmorGetTargetAlert(5*time.Second, &expect)
 			Expect(err).To(BeNil())
-			Expect(len(alerts)).To(BeNumerically(">=", 1))
-			Expect(alerts[0].PolicyName).To(Equal("audit-unlink-fromsource"))
-			Expect(alerts[0].Severity).To(Equal("4"))
+			Expect(res.Found).To(BeTrue())
 
 		})
 
@@ -119,11 +129,16 @@ var _ = Describe("Syscalls", func() {
 			Expect(err).To(BeNil())
 
 			// check policy alert
-			_, alerts, err := KarmorGetLogs(5*time.Second, 1)
+			expect := protobuf.Alert{
+				PolicyName: "audit-unlink-fromsource-dir-recursive",
+				Severity:   "1",
+				Action:     "Audit",
+				Result:     "Passed",
+			}
+
+			res, err := KarmorGetTargetAlert(5*time.Second, &expect)
 			Expect(err).To(BeNil())
-			Expect(len(alerts)).To(BeNumerically(">=", 1))
-			Expect(alerts[0].PolicyName).To(Equal("audit-unlink-fromsource-dir-recursive"))
-			Expect(alerts[0].Severity).To(Equal("1"))
+			Expect(res.Found).To(BeTrue())
 
 		})
 
@@ -145,11 +160,16 @@ var _ = Describe("Syscalls", func() {
 			Expect(err).To(BeNil())
 
 			// check policy alert
-			_, alerts, err := KarmorGetLogs(5*time.Second, 1)
+			expect := protobuf.Alert{
+				PolicyName: "audit-unlink-fromsource-path",
+				Severity:   "1",
+				Action:     "Audit",
+				Result:     "Passed",
+			}
+
+			res, err := KarmorGetTargetAlert(5*time.Second, &expect)
 			Expect(err).To(BeNil())
-			Expect(len(alerts)).To(BeNumerically(">=", 1))
-			Expect(alerts[0].PolicyName).To(Equal("audit-unlink-fromsource-path"))
-			Expect(alerts[0].Severity).To(Equal("1"))
+			Expect(res.Found).To(BeTrue())
 
 		})
 
@@ -171,11 +191,16 @@ var _ = Describe("Syscalls", func() {
 			Expect(err).To(BeNil())
 
 			// check policy alert
-			_, alerts, err := KarmorGetLogs(5*time.Second, 1)
+			expect := protobuf.Alert{
+				PolicyName: "audit-unlink",
+				Severity:   "1",
+				Action:     "Audit",
+				Result:     "Passed",
+			}
+
+			res, err := KarmorGetTargetAlert(5*time.Second, &expect)
 			Expect(err).To(BeNil())
-			Expect(len(alerts)).To(BeNumerically(">=", 1))
-			Expect(alerts[0].PolicyName).To(Equal("audit-unlink"))
-			Expect(alerts[0].Severity).To(Equal("1"))
+			Expect(res.Found).To(BeTrue())
 
 		})
 
@@ -194,11 +219,16 @@ var _ = Describe("Syscalls", func() {
 			Expect(err).To(BeNil())
 
 			// check policy alert
-			_, alerts, err := KarmorGetLogs(5*time.Second, 1)
+			expect := protobuf.Alert{
+				PolicyName: "audit-unlink-file-path",
+				Severity:   "1",
+				Action:     "Audit",
+				Result:     "Passed",
+			}
+
+			res, err := KarmorGetTargetAlert(5*time.Second, &expect)
 			Expect(err).To(BeNil())
-			Expect(len(alerts)).To(BeNumerically(">=", 1))
-			Expect(alerts[0].PolicyName).To(Equal("audit-unlink-file-path"))
-			Expect(alerts[0].Severity).To(Equal("1"))
+			Expect(res.Found).To(BeTrue())
 
 		})
 
@@ -220,11 +250,16 @@ var _ = Describe("Syscalls", func() {
 			Expect(err).To(BeNil())
 
 			// check policy alert
-			_, alerts, err := KarmorGetLogs(5*time.Second, 1)
+			expect := protobuf.Alert{
+				PolicyName: "audit-unlink-dir-recursive-fromsource-path",
+				Severity:   "1",
+				Action:     "Audit",
+				Result:     "Passed",
+			}
+
+			res, err := KarmorGetTargetAlert(5*time.Second, &expect)
 			Expect(err).To(BeNil())
-			Expect(len(alerts)).To(BeNumerically(">=", 1))
-			Expect(alerts[0].PolicyName).To(Equal("audit-unlink-dir-recursive-fromsource-path"))
-			Expect(alerts[0].Severity).To(Equal("1"))
+			Expect(res.Found).To(BeTrue())
 
 		})
 
@@ -243,11 +278,16 @@ var _ = Describe("Syscalls", func() {
 			Expect(err).To(BeNil())
 
 			// check policy alert
-			_, alerts, err := KarmorGetLogs(5*time.Second, 1)
+			expect := protobuf.Alert{
+				PolicyName: "audit-unlink-dir-recursive-fromsource-recursive-dir",
+				Severity:   "1",
+				Action:     "Audit",
+				Result:     "Passed",
+			}
+
+			res, err := KarmorGetTargetAlert(5*time.Second, &expect)
 			Expect(err).To(BeNil())
-			Expect(len(alerts)).To(BeNumerically(">=", 1))
-			Expect(alerts[0].PolicyName).To(Equal("audit-unlink-dir-recursive-fromsource-recursive-dir"))
-			Expect(alerts[0].Severity).To(Equal("1"))
+			Expect(res.Found).To(BeTrue())
 
 		})
 
@@ -269,11 +309,16 @@ var _ = Describe("Syscalls", func() {
 			Expect(err).To(BeNil())
 
 			// check policy alert
-			_, alerts, err := KarmorGetLogs(5*time.Second, 1)
+			expect := protobuf.Alert{
+				PolicyName: "audit-unlink-dir-recursive-fromsource-dir",
+				Severity:   "1",
+				Action:     "Audit",
+				Result:     "Passed",
+			}
+
+			res, err := KarmorGetTargetAlert(5*time.Second, &expect)
 			Expect(err).To(BeNil())
-			Expect(len(alerts)).To(BeNumerically(">=", 1))
-			Expect(alerts[0].PolicyName).To(Equal("audit-unlink-dir-recursive-fromsource-dir"))
-			Expect(alerts[0].Severity).To(Equal("1"))
+			Expect(res.Found).To(BeTrue())
 
 		})
 
@@ -295,13 +340,18 @@ var _ = Describe("Syscalls", func() {
 			Expect(err).To(BeNil())
 
 			// check policy alert
-			_, alerts, err := KarmorGetLogs(5*time.Second, 1)
+			expect := protobuf.Alert{
+				PolicyName: "audit-unlink-global-information",
+				Severity:   "8",
+				Action:     "Audit",
+				Result:     "Passed",
+				Message:    "Global message",
+			}
+
+			res, err := KarmorGetTargetAlert(5*time.Second, &expect)
 			Expect(err).To(BeNil())
-			Expect(len(alerts)).To(BeNumerically(">=", 1))
-			Expect(alerts[0].PolicyName).To(Equal("audit-unlink-global-information"))
-			Expect(alerts[0].Severity).To(Equal("8"))
-			Expect(alerts[0].Tags).To(Equal("Global tag"))
-			Expect(alerts[0].Message).To(Equal("Global message"))
+			Expect(res.Found).To(BeTrue())
+
 		})
 
 		It("can detect unlink syscall recursive target with local informations", func() {
@@ -319,13 +369,18 @@ var _ = Describe("Syscalls", func() {
 			Expect(err).To(BeNil())
 
 			// check policy alert
-			_, alerts, err := KarmorGetLogs(5*time.Second, 1)
+			expect := protobuf.Alert{
+				PolicyName: "audit-unlink-local-information",
+				Severity:   "8",
+				Action:     "Audit",
+				Result:     "Passed",
+				Message:    "Local message",
+			}
+
+			res, err := KarmorGetTargetAlert(5*time.Second, &expect)
 			Expect(err).To(BeNil())
-			Expect(len(alerts)).To(BeNumerically(">=", 1))
-			Expect(alerts[0].PolicyName).To(Equal("audit-unlink-local-information"))
-			Expect(alerts[0].Severity).To(Equal("8"))
-			Expect(alerts[0].Tags).To(Equal("Local tag"))
-			Expect(alerts[0].Message).To(Equal("Local message"))
+			Expect(res.Found).To(BeTrue())
+
 		})
 
 		It("can detect unlink syscall recursive target with local informations when global is set", func() {
@@ -343,13 +398,18 @@ var _ = Describe("Syscalls", func() {
 			Expect(err).To(BeNil())
 
 			// check policy alert
-			_, alerts, err := KarmorGetLogs(5*time.Second, 1)
+			expect := protobuf.Alert{
+				PolicyName: "audit-unlink-local-trumps-global-information",
+				Severity:   "7",
+				Action:     "Audit",
+				Result:     "Passed",
+				Message:    "Local message",
+			}
+
+			res, err := KarmorGetTargetAlert(5*time.Second, &expect)
 			Expect(err).To(BeNil())
-			Expect(len(alerts)).To(BeNumerically(">=", 1))
-			Expect(alerts[0].PolicyName).To(Equal("audit-unlink-local-trumps-global-information"))
-			Expect(alerts[0].Severity).To(Equal("7"))
-			Expect(alerts[0].Tags).To(Equal("Local tag"))
-			Expect(alerts[0].Message).To(Equal("Local message"))
+			Expect(res.Found).To(BeTrue())
+
 		})
 
 		It("can detect unlink syscall recursive target with missing local informations when global is set", func() {
@@ -367,13 +427,18 @@ var _ = Describe("Syscalls", func() {
 			Expect(err).To(BeNil())
 
 			// check policy alert
-			_, alerts, err := KarmorGetLogs(5*time.Second, 1)
+			expect := protobuf.Alert{
+				PolicyName: "audit-unlink-global-fill-missing-local-information",
+				Severity:   "7",
+				Action:     "Audit",
+				Result:     "Passed",
+				Message:    "Local message",
+			}
+
+			res, err := KarmorGetTargetAlert(5*time.Second, &expect)
 			Expect(err).To(BeNil())
-			Expect(len(alerts)).To(BeNumerically(">=", 1))
-			Expect(alerts[0].PolicyName).To(Equal("audit-unlink-global-fill-missing-local-information"))
-			Expect(alerts[0].Severity).To(Equal("7"))
-			Expect(alerts[0].Tags).To(Equal("Global tag"))
-			Expect(alerts[0].Message).To(Equal("Local message"))
+			Expect(res.Found).To(BeTrue())
+
 		})
 	})
 
@@ -393,13 +458,18 @@ var _ = Describe("Syscalls", func() {
 			Expect(err).To(BeNil())
 
 			// check policy alert
-			_, alerts, err := KarmorGetLogs(5*time.Second, 1)
+			expect := protobuf.Alert{
+				PolicyName: "audit-unlink-global-information",
+				Severity:   "8",
+				Action:     "Audit",
+				Result:     "Passed",
+				Message:    "Global message",
+			}
+
+			res, err := KarmorGetTargetAlert(5*time.Second, &expect)
 			Expect(err).To(BeNil())
-			Expect(len(alerts)).To(BeNumerically(">=", 1))
-			Expect(alerts[0].PolicyName).To(Equal("audit-unlink-global-information"))
-			Expect(alerts[0].Severity).To(Equal("8"))
-			Expect(alerts[0].Tags).To(Equal("Global tag"))
-			Expect(alerts[0].Message).To(Equal("Global message"))
+			Expect(res.Found).To(BeTrue())
+
 		})
 
 		It("can detect unlink syscall recursive target with local informations", func() {
@@ -417,13 +487,18 @@ var _ = Describe("Syscalls", func() {
 			Expect(err).To(BeNil())
 
 			// check policy alert
-			_, alerts, err := KarmorGetLogs(5*time.Second, 1)
+			expect := protobuf.Alert{
+				PolicyName: "audit-unlink-local-information",
+				Severity:   "8",
+				Action:     "Audit",
+				Result:     "Passed",
+				Message:    "Local message",
+			}
+
+			res, err := KarmorGetTargetAlert(5*time.Second, &expect)
 			Expect(err).To(BeNil())
-			Expect(len(alerts)).To(BeNumerically(">=", 1))
-			Expect(alerts[0].PolicyName).To(Equal("audit-unlink-local-information"))
-			Expect(alerts[0].Severity).To(Equal("8"))
-			Expect(alerts[0].Tags).To(Equal("Local tag"))
-			Expect(alerts[0].Message).To(Equal("Local message"))
+			Expect(res.Found).To(BeTrue())
+
 		})
 
 		It("can detect unlink syscall recursive target with local informations when global is set", func() {
@@ -441,13 +516,18 @@ var _ = Describe("Syscalls", func() {
 			Expect(err).To(BeNil())
 
 			// check policy alert
-			_, alerts, err := KarmorGetLogs(5*time.Second, 1)
+			expect := protobuf.Alert{
+				PolicyName: "audit-unlink-local-trumps-global-information",
+				Severity:   "7",
+				Action:     "Audit",
+				Result:     "Passed",
+				Message:    "Local message",
+			}
+
+			res, err := KarmorGetTargetAlert(5*time.Second, &expect)
 			Expect(err).To(BeNil())
-			Expect(len(alerts)).To(BeNumerically(">=", 1))
-			Expect(alerts[0].PolicyName).To(Equal("audit-unlink-local-trumps-global-information"))
-			Expect(alerts[0].Severity).To(Equal("7"))
-			Expect(alerts[0].Tags).To(Equal("Local tag"))
-			Expect(alerts[0].Message).To(Equal("Local message"))
+			Expect(res.Found).To(BeTrue())
+
 		})
 
 		It("can detect unlink syscall recursive target with missing local informations when global is set", func() {
@@ -465,13 +545,18 @@ var _ = Describe("Syscalls", func() {
 			Expect(err).To(BeNil())
 
 			// check policy alert
-			_, alerts, err := KarmorGetLogs(5*time.Second, 1)
+			expect := protobuf.Alert{
+				PolicyName: "audit-unlink-global-fill-missing-local-information",
+				Severity:   "7",
+				Action:     "Audit",
+				Result:     "Passed",
+				Message:    "Local message",
+			}
+
+			res, err := KarmorGetTargetAlert(5*time.Second, &expect)
 			Expect(err).To(BeNil())
-			Expect(len(alerts)).To(BeNumerically(">=", 1))
-			Expect(alerts[0].PolicyName).To(Equal("audit-unlink-global-fill-missing-local-information"))
-			Expect(alerts[0].Severity).To(Equal("7"))
-			Expect(alerts[0].Tags).To(Equal("Global tag"))
-			Expect(alerts[0].Message).To(Equal("Local message"))
+			Expect(res.Found).To(BeTrue())
+
 		})
 
 		It("mount will be blocked by default for a pod", func() {


### PR DESCRIPTION
**Purpose of PR?**:
To reduce flakiness with syscall tests suite changing the logic to get target alert for applied policy.

**Does this PR introduce a breaking change?**

**If the changes in this PR are manually verified, list down the scenarios covered:**:

**Additional information for reviewer?** :
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [ ] Bug fix. Fixes #<issue number>
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Commit has unit tests
- [ ] Commit has integration tests

<!--

The PR title message must follow convention:
`<type>(<scope>): <subject>`.

Where: <br />
- `type` is to define what type of PR is this.
  Most common types are:
    - `feat`      - for new features, not a new feature for build script
    - `fix`       - for bug fixes or improvements, not a fix for build script
    - `chore`     - changes not related to production code
    - `docs`      - changes related to documentation
    - `style`     - formatting, missing semi colons, linting fix etc; no significant production code changes
    - `test`      - adding missing tests, refactoring tests; no production code change
    - `refactor`  - refactoring production code, eg. renaming a variable or function name, there should not be any significant production code changes

- `scope` is a single word that best describes where the changes fit.
    - feature(`monitor`,`enforcer`)
    - test(`tests`, `bdd`)
    - chore(`build`)
- `subject` is a single line brief description of the changes made in the pull request.

-->