### PR TITLE
fix: updater to install bpf-lsm in appropriate grub config on latest RHEL env

### DIFF
--- a/deployments/controller/updaterscript.yaml
+++ b/deployments/controller/updaterscript.yaml
@@ -28,6 +28,7 @@
             echo "current lsmlist=\$lsmlist"
             sed -i "s/^GRUB_CMDLINE_LINUX=.*$/GRUB_CMDLINE_LINUX=\"lsm=\$lsmlist,bpf\"/g" /etc/default/grub
             command -v grub2-mkconfig >/dev/null 2>&1 && grub2-mkconfig -o /boot/grub2.cfg
+            command -v grub2-mkconfig >/dev/null 2>&1 && grub2-mkconfig -o /boot/grub2/grub.cfg
             command -v grub-mkconfig >/dev/null 2>&1 && grub-mkconfig -o /boot/grub.cfg
             command -v aa-status >/dev/null 2>&1 || yum install apparmor-utils -y
             command -v update-grub >/dev/null 2>&1 && update-grub


### PR DESCRIPTION
**Purpose of PR?**:

[Updater yaml](https://github.com/kubearmor/KubeArmor/blob/main/getting-started/FAQ.md#debug-kubearmor-installation-issue) that allows auto-update of bpf-lsm didn't work in Alibaba Cloud 3 env. The problem was that the incorrect grub file was used. On latest RHEL env, the location of the grub file is different. This patch adds the new path in additon to previous ones. There is no harm in generating an additional grub file so that we do not break backward compatibility of the updater mechanism.

**Does this PR introduce a breaking change?**
No

**If the changes in this PR are manually verified, list down the scenarios covered:**:
Yes, tested on Alibaba cloud env.
The change was tested in following way:
1. Created a VM on Alibaba Cloud Elastic Compute Service using distribution `Alibaba Cloud Linux 3 (Soaring Falcon)`
2. Installed k3s single node cluster
3. Installed kubearmor
4. checked `karmor probe` and it didn't showed any active LSM
5. Applied updaterscript.yaml
6. The node was rebooted
7. After reboot checked the `karmor probe` and found BPFLSM enabled.

```
[root@iZrj9d83zmwg0ievu9ne30Z ~]# kubectl get nodes -o wide
NAME                      STATUS   ROLES                  AGE   VERSION        INTERNAL-IP      EXTERNAL-IP   OS-IMAGE                                 KERNEL-VERSION             CONTAINER-RUNTIME
izrj9d83zmwg0ievu9ne30z   Ready    control-plane,master   47m   v1.28.6+k3s2   172.26.177.254   <none>        Alibaba Cloud Linux 3 (Soaring Falcon)   5.10.134-16.1.al8.x86_64   containerd://1.7.11-k3s2
```

**Checklist:**
- [x] Bug fix.
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`

<!--

The PR title message must follow convention:
`<type>(<scope>): <subject>`.

Where: <br />
- `type` is to define what type of PR is this.
  Most common types are:
    - `feat`      - for new features, not a new feature for build script
    - `fix`       - for bug fixes or improvements, not a fix for build script
    - `chore`     - changes not related to production code
    - `docs`      - changes related to documentation
    - `style`     - formatting, missing semi colons, linting fix etc; no significant production code changes
    - `test`      - adding missing tests, refactoring tests; no production code change
    - `refactor`  - refactoring production code, eg. renaming a variable or function name, there should not be any significant production code changes

- `scope` is a single word that best describes where the changes fit.
    - feature(`monitor`,`enforcer`)
    - test(`tests`, `bdd`)
    - chore(`build`)
- `subject` is a single line brief description of the changes made in the pull request.

-->