### PR TITLE
fix(core): fix a couple race conditions

### DIFF
--- a/KubeArmor/config/config.go
+++ b/KubeArmor/config/config.go
@@ -52,6 +52,7 @@ type KubearmorConfig struct {
 	BPFFsPath          string   // path to the BPF filesystem
 	EnforcerAlerts     bool     // policy enforcer
 	DefaultPostureLogs bool     // Enable/Disable Default Posture logs for AppArmor LSM
+	InitTimeout        string   // Timeout for main thread init stages
 
 	StateAgent bool // enable KubeArmor state agent
 }
@@ -93,6 +94,7 @@ const (
 	BPFFsPath                            string = "bpfFsPath"
 	EnforcerAlerts                       string = "enforcerAlerts"
 	ConfigDefaultPostureLogs             string = "defaultPostureLogs"
+	ConfigInitTimeout                    string = "initTimeout"
 	ConfigStateAgent                     string = "enableKubeArmorStateAgent"
 )
 
@@ -137,6 +139,8 @@ func readCmdLineParams() {
 	enforcerAlerts := flag.Bool(EnforcerAlerts, true, "ebpf alerts")
 
 	defaultPostureLogs := flag.Bool(ConfigDefaultPostureLogs, true, "Default Posture Alerts (for Apparmor only)")
+
+	initTimeout := flag.String(ConfigInitTimeout, "60s", "Timeout for main thread init stages")
 
 	stateAgent := flag.Bool(ConfigStateAgent, false, "enabling KubeArmor State Agent client")
 
@@ -189,6 +193,8 @@ func readCmdLineParams() {
 	viper.SetDefault(EnforcerAlerts, *enforcerAlerts)
 
 	viper.SetDefault(ConfigDefaultPostureLogs, *defaultPostureLogs)
+
+	viper.SetDefault(ConfigInitTimeout, *initTimeout)
 
 	viper.SetDefault(ConfigStateAgent, *stateAgent)
 }
@@ -281,6 +287,8 @@ func LoadConfig() error {
 	GlobalCfg.EnforcerAlerts = viper.GetBool(EnforcerAlerts)
 
 	GlobalCfg.DefaultPostureLogs = viper.GetBool(ConfigDefaultPostureLogs)
+
+	GlobalCfg.InitTimeout = viper.GetString(ConfigInitTimeout)
 
 	GlobalCfg.StateAgent = viper.GetBool(ConfigStateAgent)
 

--- a/KubeArmor/monitor/systemMonitor.go
+++ b/KubeArmor/monitor/systemMonitor.go
@@ -352,7 +352,11 @@ func (mon *SystemMonitor) UpdateNsKeyMap(action string, nsKey NsKey, visibility 
 		if err != nil {
 			mon.Logger.Warnf("Cannot update visibility map. nskey=%+v, value=%+v, scope=capability", nsKey, capability.Value)
 		}
+
+		// Need to lock NsMap to print the following log message
+		mon.NsMapLock.RLock()
 		mon.Logger.Printf("Updated visibility map with key=%+v for cid %s", nsKey, mon.NsMap[nsKey])
+		mon.NsMapLock.RUnlock()
 	} else if action == "DELETED" {
 		err := mon.BpfNsVisibilityMap.Delete(nsKey)
 		if err != nil {


### PR DESCRIPTION
**Purpose of PR?**:

While using KubeArmor, I noticed a couple bugs related to race conditions, and these commits should fix them.

The first race condition is just a concurrent map access that didn't lock the map first, and if two goroutines accessed the map simultaneously the whole KubeArmor container would crash and restart.

The second race condition is at node/KubeArmor startup. We were getting rare alerts (default Audit posture) on container behavior that was explicitly allowed through certain policies at node startup, and I determined that this could happen if a container is being enforced before KubeArmor has loaded all of the security policies, and realized that there's no protections in KubeArmor against that possible race condition.

(There is also one other possible source of a partial-enforcement race condition [here](https://github.com/kubearmor/KubeArmor/blob/33d7814ce8ea6e0878e0a18f45b61b8fc8527c54/KubeArmor/enforcer/bpflsm/rulesHandling.go#L384-L460) which can happen any time pods start or policies change. Currently container rules are added one-by-one via `be.ContainerMap[id].Map.Put()`, but by using `be.ContainerMap[id].Map.BatchUpdate()` and `be.ContainerMap[id].Map.BatchDelete()` we could make sure eBPF policies for a container are updated atomically and there's no partial enforcement happening. Getting this logic right though would take a lot more work and it should definitely happen in a separate PR.)

**Does this PR introduce a breaking change?** No

**If the changes in this PR are manually verified, list down the scenarios covered:**:

I have not tested to see if these changes fix the race conditions I encountered, because I can't easily replicate them. However, the concurrent map access issue did give me a stack trace pointing to exactly where the issue was.

**Additional information for reviewer?** :

While `factory.WaitForCacheSync(wait.NeverStop)` will wait for all informers from the factory to finish syncing their caches, apparently it does not necessarily wait for all event handlers to finish syncing, which is why I replaced it with the `registration.HasSynced` functions. There's more details in the commit message for that change.


**Checklist:**
- [X] Bug fix. Fixes 
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [X] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Commit has unit tests
- [ ] Commit has integration tests

<!--

The PR title message must follow convention:
`<type>(<scope>): <subject>`.

Where: <br />
- `type` is to define what type of PR is this.
  Most common types are:
    - `feat`      - for new features, not a new feature for build script
    - `fix`       - for bug fixes or improvements, not a fix for build script
    - `chore`     - changes not related to production code
    - `docs`      - changes related to documentation
    - `style`     - formatting, missing semi colons, linting fix etc; no significant production code changes
    - `test`      - adding missing tests, refactoring tests; no production code change
    - `refactor`  - refactoring production code, eg. renaming a variable or function name, there should not be any significant production code changes

- `scope` is a single word that best describes where the changes fit.
    - feature(`monitor`,`enforcer`)
    - test(`tests`, `bdd`)
    - chore(`build`)
- `subject` is a single line brief description of the changes made in the pull request.

-->