### PR TITLE
fix(cert): read ca crt file only with externalcertloader

### DIFF
--- a/KubeArmor/cert/cert.go
+++ b/KubeArmor/cert/cert.go
@@ -46,7 +46,8 @@ var DefaultKubeArmorClientConfig = CertConfig{
 var DefaultKubeArmorCAConfig = CertConfig{
 	CN:           KubeArmor_CN,
 	Organization: KubeArmor_ORG,
-	KeyUsage:     x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+	IsCa:         true,
+	KeyUsage:     x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
 }
 
 type CertConfig struct {
@@ -54,6 +55,7 @@ type CertConfig struct {
 	Organization string
 	DNS          []string
 	IPs          []string
+	IsCa         bool
 	KeyUsage     x509.KeyUsage
 	ExtKeyUsage  []x509.ExtKeyUsage
 	NotAfter     time.Time
@@ -200,8 +202,10 @@ func GenerateCert(cfg *CertConfig) (*CertKeyPair, error) {
 		NotAfter:              cfg.NotAfter,
 		KeyUsage:              cfg.KeyUsage,
 		ExtKeyUsage:           cfg.ExtKeyUsage,
+		IsCA:                  cfg.IsCa,
 		BasicConstraintsValid: true,
 	}
+	template.DNSNames = append(template.DNSNames, cfg.DNS...)
 
 	for _, ip := range cfg.IPs {
 		template.IPAddresses = append(template.IPAddresses, net.ParseIP(ip))

--- a/KubeArmor/cert/certloader.go
+++ b/KubeArmor/cert/certloader.go
@@ -7,6 +7,7 @@ package cert
 import (
 	"crypto/tls"
 	"crypto/x509"
+	"encoding/pem"
 
 	"k8s.io/client-go/kubernetes"
 )
@@ -58,12 +59,13 @@ func (loader *ExternalCertLoader) GetCertificateAndCaPool() (*tls.Certificate, *
 	if err != nil {
 		return nil, nil, err
 	}
-	caCert, err := GetCertKeyPairFromCertBytes(caCertBytes)
+	caCertPem, _ := pem.Decode(caCertBytes.Crt)
+	caCert, err := x509.ParseCertificate(caCertPem.Bytes)
 	if err != nil {
 		return nil, nil, err
 	}
 	caCertPool := x509.NewCertPool()
-	caCertPool.AddCert(caCert.Crt)
+	caCertPool.AddCert(caCert)
 	// load server/client certificate from cert path
 	certBytes, err := ReadCertFromFile(&loader.CertPath)
 	if err != nil {


### PR DESCRIPTION
**Purpose of PR?**:
when externalcertloader is being used to load certificates provided externally using files, for CA it requires only certificate file to be read to add it to the certpool.

**Does this PR introduce a breaking change?**
No
**If the changes in this PR are manually verified, list down the scenarios covered:**:

**Additional information for reviewer?** :
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [ ] Bug fix. Fixes #<issue number>
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Commit has unit tests
- [ ] Commit has integration tests

<!--

The PR title message must follow convention:
`<type>(<scope>): <subject>`.

Where: <br />
- `type` is to define what type of PR is this.
  Most common types are:
    - `feat`      - for new features, not a new feature for build script
    - `fix`       - for bug fixes or improvements, not a fix for build script
    - `chore`     - changes not related to production code
    - `docs`      - changes related to documentation
    - `style`     - formatting, missing semi colons, linting fix etc; no significant production code changes
    - `test`      - adding missing tests, refactoring tests; no production code change
    - `refactor`  - refactoring production code, eg. renaming a variable or function name, there should not be any significant production code changes

- `scope` is a single word that best describes where the changes fit.
    - feature(`monitor`,`enforcer`)
    - test(`tests`, `bdd`)
    - chore(`build`)
- `subject` is a single line brief description of the changes made in the pull request.

-->