### PR TITLE
feat(security): Refine hostPaths/capabilities in deployments and remove init container

### DIFF
--- a/.github/workflows/ci-test-controllers.yml
+++ b/.github/workflows/ci-test-controllers.yml
@@ -53,6 +53,11 @@ jobs:
         if: steps.filter.outputs.kubearmor == 'true'
         run: GITHUB_SHA=$GITHUB_SHA ./KubeArmor/build/build_kubearmor.sh
 
+      - name: Build Kubearmor-Operator
+        working-directory: pkg/KubeArmorOperator
+        run: |
+          make docker-build
+
       - name: Build KubeArmorController
         run: make -C pkg/KubeArmorController/ docker-build TAG=latest
 

--- a/.github/workflows/ci-test-controllers.yml
+++ b/.github/workflows/ci-test-controllers.yml
@@ -53,11 +53,6 @@ jobs:
         if: steps.filter.outputs.kubearmor == 'true'
         run: GITHUB_SHA=$GITHUB_SHA ./KubeArmor/build/build_kubearmor.sh
 
-      - name: Build Kubearmor-Operator
-        working-directory: pkg/KubeArmorOperator
-        run: |
-          make docker-build
-
       - name: Build KubeArmorController
         run: make -C pkg/KubeArmorController/ docker-build TAG=latest
 

--- a/.github/workflows/ci-test-ubi-image.yml
+++ b/.github/workflows/ci-test-ubi-image.yml
@@ -78,7 +78,11 @@ jobs:
           kubectl wait --timeout=7m --for=condition=ready pod -l kubearmor-app,kubearmor-app!=kubearmor-snitch,kubearmor-app!=kubearmor-controller -n kubearmor
           kubectl wait --timeout=1m --for=condition=ready pod -l kubearmor-app=kubearmor-controller -n kubearmor
           kubectl get pods -A
-
+      
+      - name: Operator may take upto 10 sec to enable TLS, Sleep for 15Sec
+        run: |
+          sleep 15
+      
       - name: Test KubeArmor using Ginkgo
         run: |
           go install -mod=mod github.com/onsi/ginkgo/v2/ginkgo

--- a/.github/workflows/cleanup.sh
+++ b/.github/workflows/cleanup.sh
@@ -6,11 +6,13 @@
 cleanup() {
   echo "Performing cleanup..."
   
-  ./usr/local/bin/k3s-killall.sh
+  /usr/local/bin/k3s-killall.sh
   
   /usr/local/bin/k3s-uninstall.sh
   
   docker system prune -a -f
+  
+  sudo podman system prune -a -f
   
   # rm -rf /home/vagrant/actions-runner/_work/KubeArmor
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 
 ### Builder
 
-FROM golang:1.22-alpine3.19 as builder
+FROM golang:1.22-alpine3.20 as builder
 
 RUN apk --no-cache update
 RUN apk add --no-cache git clang llvm make gcc protobuf
@@ -40,7 +40,7 @@ RUN make
 
 ### Make executable image
 
-FROM alpine:3.19 as kubearmor
+FROM alpine:3.20 as kubearmor
 
 RUN echo "@community http://dl-cdn.alpinelinux.org/alpine/edge/community" | tee -a /etc/apk/repositories
 
@@ -48,7 +48,7 @@ RUN apk --no-cache update
 RUN apk add apparmor@community apparmor-utils@community bash
 
 COPY --from=builder /usr/src/KubeArmor/KubeArmor/kubearmor /KubeArmor/kubearmor
-COPY --from=builder /usr/src/KubeArmor/BPF/*.o /KubeArmor/BPF/
+COPY --from=builder /usr/src/KubeArmor/BPF/*.o /opt/kubearmor/BPF/
 COPY --from=builder /usr/src/KubeArmor/KubeArmor/templates/* /KubeArmor/templates/
 
 ENTRYPOINT ["/KubeArmor/kubearmor"]
@@ -88,7 +88,7 @@ RUN groupadd --gid 1000 default \
 
 COPY LICENSE /licenses/license.txt
 COPY --from=builder --chown=default:default /usr/src/KubeArmor/KubeArmor/kubearmor /KubeArmor/kubearmor
-COPY --from=builder --chown=default:default /usr/src/KubeArmor/BPF/*.o /KubeArmor/BPF/
+COPY --from=builder --chown=default:default /usr/src/KubeArmor/BPF/*.o /opt/kubearmor/BPF/
 COPY --from=builder --chown=default:default /usr/src/KubeArmor/KubeArmor/templates/* /KubeArmor/templates/
 
 # TODO

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,7 +48,7 @@ RUN apk --no-cache update
 RUN apk add apparmor@community apparmor-utils@community bash
 
 COPY --from=builder /usr/src/KubeArmor/KubeArmor/kubearmor /KubeArmor/kubearmor
-COPY --from=builder /usr/src/KubeArmor/BPF/*.o /opt/kubearmor/BPF/
+COPY --from=builder /usr/src/KubeArmor/BPF/*.o /KubeArmor/BPF/
 COPY --from=builder /usr/src/KubeArmor/KubeArmor/templates/* /KubeArmor/templates/
 
 ENTRYPOINT ["/KubeArmor/kubearmor"]
@@ -88,6 +88,7 @@ RUN groupadd --gid 1000 default \
 
 COPY LICENSE /licenses/license.txt
 COPY --from=builder --chown=default:default /usr/src/KubeArmor/KubeArmor/kubearmor /KubeArmor/kubearmor
+COPY --from=builder --chown=default:default /usr/src/KubeArmor/BPF/*.o /KubeArmor/BPF/
 COPY --from=builder --chown=default:default /usr/src/KubeArmor/KubeArmor/templates/* /KubeArmor/templates/
 
 # TODO

--- a/KubeArmor/go.mod
+++ b/KubeArmor/go.mod
@@ -2,7 +2,7 @@ module github.com/kubearmor/KubeArmor/KubeArmor
 
 go 1.21.0
 
-toolchain go1.21.9
+toolchain go1.21.11
 
 replace (
 	github.com/kubearmor/KubeArmor => ../../

--- a/deployments/get/objects.go
+++ b/deployments/get/objects.go
@@ -271,10 +271,6 @@ func GenerateDaemonSet(env, namespace string) *appsv1.DaemonSet {
 			ReadOnly:  true,
 		},
 		{
-			Name:      "sys-fs-bpf-path", //BPF (read-write)
-			MountPath: "/sys/fs/bpf",
-		},
-		{
 			Name:      "sys-kernel-security-path", //LSM (read-only)
 			MountPath: "/sys/kernel/security",
 		},
@@ -302,15 +298,6 @@ func GenerateDaemonSet(env, namespace string) *appsv1.DaemonSet {
 				HostPath: &corev1.HostPathVolumeSource{
 					Path: "/lib/modules",
 					Type: &hostPathDirectoryOrCreate,
-				},
-			},
-		},
-		{
-			Name: "sys-fs-bpf-path",
-			VolumeSource: corev1.VolumeSource{
-				HostPath: &corev1.HostPathVolumeSource{
-					Path: "/sys/fs/bpf",
-					Type: &hostPathDirectory,
 				},
 			},
 		},

--- a/deployments/go.mod
+++ b/deployments/go.mod
@@ -2,7 +2,7 @@ module github.com/kubearmor/KubeArmor/deployments
 
 go 1.21.0
 
-toolchain go1.21.9
+toolchain go1.21.11
 
 replace (
 	github.com/kubearmor/KubeArmor => ../

--- a/deployments/helm/KubeArmor/values.yaml
+++ b/deployments/helm/KubeArmor/values.yaml
@@ -163,8 +163,6 @@ kubearmor:
   - mountPath: /lib/modules
     name: lib-modules-path
     readOnly: true
-  - mountPath: /sys/fs/bpf
-    name: sys-fs-bpf-path
   - mountPath: /sys/kernel/security
     name: sys-kernel-security-path
   - mountPath: /sys/kernel/debug
@@ -183,8 +181,6 @@ kubearmor:
     - mountPath: /lib/modules
       name: lib-modules-path
       readOnly: true
-    - mountPath: /sys/fs/bpf
-      name: sys-fs-bpf-path
     - mountPath: /sys/kernel/security
       name: sys-kernel-security-path
     - mountPath: /sys/kernel/debug
@@ -205,8 +201,6 @@ kubearmor:
     - mountPath: /lib/modules
       name: lib-modules-path
       readOnly: true
-    - mountPath: /sys/fs/bpf
-      name: sys-fs-bpf-path
     - mountPath: /sys/kernel/security
       name: sys-kernel-security-path
     - mountPath: /sys/kernel/debug
@@ -227,8 +221,6 @@ kubearmor:
     - mountPath: /lib/modules
       name: lib-modules-path
       readOnly: true
-    - mountPath: /sys/fs/bpf
-      name: sys-fs-bpf-path
     - mountPath: /sys/kernel/security
       name: sys-kernel-security-path
     - mountPath: /sys/kernel/debug
@@ -249,8 +241,6 @@ kubearmor:
     - mountPath: /lib/modules
       name: lib-modules-path
       readOnly: true
-    - mountPath: /sys/fs/bpf
-      name: sys-fs-bpf-path
     - mountPath: /sys/kernel/security
       name: sys-kernel-security-path
     - mountPath: /sys/kernel/debug
@@ -271,8 +261,6 @@ kubearmor:
     - mountPath: /lib/modules
       name: lib-modules-path
       readOnly: true
-    - mountPath: /sys/fs/bpf
-      name: sys-fs-bpf-path
     - mountPath: /sys/kernel/security
       name: sys-kernel-security-path
     - mountPath: /sys/kernel/debug
@@ -293,8 +281,6 @@ kubearmor:
     - mountPath: /lib/modules
       name: lib-modules-path
       readOnly: true
-    - mountPath: /sys/fs/bpf
-      name: sys-fs-bpf-path
     - mountPath: /sys/kernel/security
       name: sys-kernel-security-path
     - mountPath: /sys/kernel/debug
@@ -315,8 +301,6 @@ kubearmor:
     - mountPath: /lib/modules
       name: lib-modules-path
       readOnly: true
-    - mountPath: /sys/fs/bpf
-      name: sys-fs-bpf-path
     - mountPath: /sys/kernel/security
       name: sys-kernel-security-path
     - mountPath: /sys/kernel/debug
@@ -333,8 +317,6 @@ kubearmor:
     - mountPath: /lib/modules
       name: lib-modules-path
       readOnly: true
-    - mountPath: /sys/fs/bpf
-      name: sys-fs-bpf-path
     - mountPath: /sys/kernel/security
       name: sys-kernel-security-path
     - mountPath: /sys/kernel/debug
@@ -355,8 +337,6 @@ kubearmor:
     - mountPath: /lib/modules
       name: lib-modules-path
       readOnly: true
-    - mountPath: /sys/fs/bpf
-      name: sys-fs-bpf-path
     - mountPath: /sys/kernel/security
       name: sys-kernel-security-path
     - mountPath: /sys/kernel/debug
@@ -377,8 +357,6 @@ kubearmor:
     - mountPath: /lib/modules
       name: lib-modules-path
       readOnly: true
-    - mountPath: /sys/fs/bpf
-      name: sys-fs-bpf-path
     - mountPath: /sys/kernel/security
       name: sys-kernel-security-path
     - mountPath: /sys/kernel/debug
@@ -404,10 +382,6 @@ kubearmor:
         path: /lib/modules
         type: DirectoryOrCreate
       name: lib-modules-path
-    - hostPath:
-        path: /sys/fs/bpf
-        type: Directory
-      name: sys-fs-bpf-path
     - hostPath:
         path: /sys/kernel/security
         type: Directory
@@ -439,10 +413,6 @@ kubearmor:
         type: DirectoryOrCreate
       name: lib-modules-path
     - hostPath:
-        path: /sys/fs/bpf
-        type: Directory
-      name: sys-fs-bpf-path
-    - hostPath:
         path: /sys/kernel/security
         type: Directory
       name: sys-kernel-security-path
@@ -472,10 +442,6 @@ kubearmor:
         path: /lib/modules
         type: DirectoryOrCreate
       name: lib-modules-path
-    - hostPath:
-        path: /sys/fs/bpf
-        type: Directory
-      name: sys-fs-bpf-path
     - hostPath:
         path: /sys/kernel/security
         type: Directory
@@ -507,10 +473,6 @@ kubearmor:
         type: DirectoryOrCreate
       name: lib-modules-path
     - hostPath:
-        path: /sys/fs/bpf
-        type: Directory
-      name: sys-fs-bpf-path
-    - hostPath:
         path: /sys/kernel/security
         type: Directory
       name: sys-kernel-security-path
@@ -540,10 +502,6 @@ kubearmor:
         path: /lib/modules
         type: DirectoryOrCreate
       name: lib-modules-path
-    - hostPath:
-        path: /sys/fs/bpf
-        type: Directory
-      name: sys-fs-bpf-path
     - hostPath:
         path: /sys/kernel/security
         type: Directory
@@ -575,10 +533,6 @@ kubearmor:
         type: Directory
       name: lib-modules-path
     - hostPath:
-        path: /sys/fs/bpf
-        type: Directory
-      name: sys-fs-bpf-path
-    - hostPath:
         path: /sys/kernel/security
         type: Directory
       name: sys-kernel-security-path
@@ -608,10 +562,6 @@ kubearmor:
         path: /lib/modules
         type: DirectoryOrCreate
       name: lib-modules-path
-    - hostPath:
-        path: /sys/fs/bpf
-        type: Directory
-      name: sys-fs-bpf-path
     - hostPath:
         path: /sys/kernel/security
         type: Directory
@@ -643,10 +593,6 @@ kubearmor:
         type: DirectoryOrCreate
       name: lib-modules-path
     - hostPath:
-        path: /sys/fs/bpf
-        type: Directory
-      name: sys-fs-bpf-path
-    - hostPath:
         path: /sys/kernel/security
         type: Directory
       name: sys-kernel-security-path
@@ -672,10 +618,6 @@ kubearmor:
         path: /lib/modules
         type: DirectoryOrCreate
       name: lib-modules-path
-    - hostPath:
-        path: /sys/fs/bpf
-        type: Directory
-      name: sys-fs-bpf-path
     - hostPath:
         path: /sys/kernel/security
         type: Directory
@@ -706,10 +648,6 @@ kubearmor:
         path: /lib/modules
         type: DirectoryOrCreate
       name: lib-modules-path
-    - hostPath:
-        path: /sys/fs/bpf
-        type: Directory
-      name: sys-fs-bpf-path
     - hostPath:
         path: /sys/kernel/security
         type: Directory

--- a/deployments/helm/KubeArmorOperator/templates/clusterrole-rbac.yaml
+++ b/deployments/helm/KubeArmorOperator/templates/clusterrole-rbac.yaml
@@ -90,6 +90,13 @@ rules:
   - customresourcedefinitions
   verbs:
   - create
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  - cronjobs
+  verbs:
+  - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/deployments/helm/KubeArmorOperator/templates/deployment.yaml
+++ b/deployments/helm/KubeArmorOperator/templates/deployment.yaml
@@ -26,4 +26,13 @@ spec:
         {{- end }}
         image: {{ include "operatorImage" . }}
         imagePullPolicy: {{ .Values.kubearmorOperator.imagePullPolicy }}
+        
+        {{- $tag := (split ":" (include "operatorImage" .))._1 -}}
+        {{- if or (eq $tag "latest") (and (hasPrefix "v" $tag) (semverCompare "^1.4.0" $tag)) }}
+        # initDeploy flag is only supported from v1.4.0
+        args:
+          - --initDeploy={{.Values.kubearmorOperator.initDeploy }}
+        {{- end }}
+
       serviceAccountName: {{ .Values.kubearmorOperator.name }}
+  

--- a/deployments/helm/KubeArmorOperator/values.yaml
+++ b/deployments/helm/KubeArmorOperator/values.yaml
@@ -36,6 +36,7 @@ kubearmorOperator:
     repository: kubearmor/kubearmor-operator
     tag: ""
   imagePullPolicy: IfNotPresent
+  initDeploy: true
 
 kubearmorConfig:
   defaultCapabilitiesPosture: audit

--- a/pkg/KubeArmorController/go.mod
+++ b/pkg/KubeArmorController/go.mod
@@ -2,7 +2,7 @@ module github.com/kubearmor/KubeArmor/pkg/KubeArmorController
 
 go 1.21.0
 
-toolchain go1.21.9
+toolchain go1.21.11
 
 require (
 	github.com/go-logr/logr v1.4.1

--- a/pkg/KubeArmorOperator/cmd/operator/main.go
+++ b/pkg/KubeArmorOperator/cmd/operator/main.go
@@ -27,6 +27,7 @@ var PathPrefix string
 var DeploymentName string
 var ExtClient *apiextensionsclientset.Clientset
 var Opv1Client *opv1client.Clientset
+var InitDeploy bool
 
 // Cmd represents the base command when called without any subcommands
 var Cmd = &cobra.Command{
@@ -43,7 +44,7 @@ var Cmd = &cobra.Command{
 		return nil
 	},
 	Run: func(cmd *cobra.Command, args []string) {
-		nodeWatcher := controllers.NewClusterWatcher(K8sClient, Logger, ExtClient, Opv1Client, PathPrefix, DeploymentName)
+		nodeWatcher := controllers.NewClusterWatcher(K8sClient, Logger, ExtClient, Opv1Client, PathPrefix, DeploymentName, InitDeploy)
 		go nodeWatcher.WatchConfigCrd()
 		nodeWatcher.WatchNodes()
 
@@ -69,6 +70,8 @@ func init() {
 	Cmd.PersistentFlags().StringVar(&LsmOrder, "lsm", "bpf,apparmor,selinux", "lsm preference order to use")
 	Cmd.PersistentFlags().StringVar(&PathPrefix, "pathprefix", "/rootfs/", "path prefix for runtime search")
 	Cmd.PersistentFlags().StringVar(&DeploymentName, "deploymentName", "kubearmor-operator", "operator deployment name")
+	// TODO:- set initDeploy to false by default once this change is added to stable
+	Cmd.PersistentFlags().BoolVar(&InitDeploy, "initDeploy", true, "Init container deployment")
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.

--- a/pkg/KubeArmorOperator/common/defaults.go
+++ b/pkg/KubeArmorOperator/common/defaults.go
@@ -218,13 +218,23 @@ func ShortSHA(s string) string {
 	return hex.EncodeToString(res)[:5]
 }
 
-var CommonVolumes = []corev1.Volume{
+var BPFVolumes = []corev1.Volume{
 	{
 		Name: "bpf",
 		VolumeSource: corev1.VolumeSource{
 			EmptyDir: &corev1.EmptyDirVolumeSource{},
 		},
 	},
+}
+
+var BPFVolumesMount = []corev1.VolumeMount{
+	{
+		Name:      "bpf",
+		MountPath: "/opt/kubearmor/BPF",
+	},
+}
+
+var CommonVolumes = []corev1.Volume{
 	{
 		Name: "sys-kernel-debug-path",
 		VolumeSource: corev1.VolumeSource{
@@ -234,30 +244,12 @@ var CommonVolumes = []corev1.Volume{
 			},
 		},
 	},
-	{
-		Name: "os-release-path",
-		VolumeSource: corev1.VolumeSource{
-			HostPath: &corev1.HostPathVolumeSource{
-				Path: "/etc/os-release",
-				Type: &HostPathFile,
-			},
-		},
-	},
 }
 
 var CommonVolumesMount = []corev1.VolumeMount{
 	{
-		Name:      "bpf",
-		MountPath: "/opt/kubearmor/BPF",
-	},
-	{
 		Name:      "sys-kernel-debug-path",
 		MountPath: "/sys/kernel/debug",
-	},
-	{
-		Name:      "os-release-path",
-		MountPath: "/media/root/etc/os-release",
-		ReadOnly:  true,
 	},
 }
 
@@ -369,6 +361,15 @@ var KernelHeaderVolumes = []corev1.Volume{
 			},
 		},
 	},
+	{
+		Name: "os-release-path",
+		VolumeSource: corev1.VolumeSource{
+			HostPath: &corev1.HostPathVolumeSource{
+				Path: "/etc/os-release",
+				Type: &HostPathFile,
+			},
+		},
+	},
 }
 
 var KernelHeaderVolumesMount = []corev1.VolumeMount{
@@ -380,6 +381,11 @@ var KernelHeaderVolumesMount = []corev1.VolumeMount{
 	{
 		Name:      "lib-modules-path",
 		MountPath: "/lib/modules",
+		ReadOnly:  true,
+	},
+	{
+		Name:      "os-release-path",
+		MountPath: "/media/root/etc/os-release",
 		ReadOnly:  true,
 	},
 }

--- a/pkg/KubeArmorOperator/common/defaults.go
+++ b/pkg/KubeArmorOperator/common/defaults.go
@@ -169,12 +169,6 @@ var EnforcerVolumesMounts = map[string][]corev1.VolumeMount{
 			MountPath: "/etc/apparmor.d",
 		},
 	},
-	"bpf": {
-		{
-			Name:      "sys-fs-bpf-path",
-			MountPath: "/sys/fs/bpf",
-		},
-	},
 }
 
 var EnforcerVolumes = map[string][]corev1.Volume{
@@ -184,18 +178,6 @@ var EnforcerVolumes = map[string][]corev1.Volume{
 			VolumeSource: corev1.VolumeSource{
 				HostPath: &corev1.HostPathVolumeSource{
 					Path: "/etc/apparmor.d",
-					Type: &HostPathDirectory,
-				},
-			},
-		},
-	},
-	"bpf": {
-
-		{
-			Name: "sys-fs-bpf-path",
-			VolumeSource: corev1.VolumeSource{
-				HostPath: &corev1.HostPathVolumeSource{
-					Path: "/sys/fs/bpf",
 					Type: &HostPathDirectory,
 				},
 			},

--- a/pkg/KubeArmorOperator/go.mod
+++ b/pkg/KubeArmorOperator/go.mod
@@ -2,7 +2,7 @@ module github.com/kubearmor/KubeArmor/pkg/KubeArmorOperator
 
 go 1.21.0
 
-toolchain go1.21.9
+toolchain go1.21.11
 
 replace (
 	github.com/kubearmor/KubeArmor/KubeArmor => ../../KubeArmor

--- a/pkg/KubeArmorOperator/internal/controller/resources.go
+++ b/pkg/KubeArmorOperator/internal/controller/resources.go
@@ -39,11 +39,12 @@ func generateDaemonset(name, enforcer, runtime, socket, btfPresent, apparmorfs, 
 	volMnts = append(volMnts, runtimeVolumeMounts...)
 	commonVols := common.CommonVolumes
 	commonVolMnts := common.CommonVolumesMount
+
 	if btfPresent == "no" {
-		commonVols = append(commonVols, common.KernelHeaderVolumes...)
 		commonVols = append(commonVols, common.BPFVolumes...)
-		commonVolMnts = append(commonVolMnts, common.KernelHeaderVolumesMount...)
 		commonVolMnts = append(commonVolMnts, common.BPFVolumesMount...)
+		commonVols = append(commonVols, common.KernelHeaderVolumes...)
+		commonVolMnts = append(commonVolMnts, common.KernelHeaderVolumesMount...)
 	}
 	vols = append(vols, commonVols...)
 	volMnts = append(volMnts, commonVolMnts...)

--- a/pkg/KubeArmorOperator/internal/controller/resources.go
+++ b/pkg/KubeArmorOperator/internal/controller/resources.go
@@ -24,7 +24,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func generateDaemonset(name, enforcer, runtime, socket, btfPresent, apparmorfs, seccompPresent string) *appsv1.DaemonSet {
+func generateDaemonset(name, enforcer, runtime, socket, btfPresent, apparmorfs, seccompPresent string, initDeploy bool) *appsv1.DaemonSet {
 	enforcerVolumes := []corev1.Volume{}
 	enforcerVolumeMounts := []corev1.VolumeMount{}
 	if !(enforcer == "apparmor" && apparmorfs == "no") {
@@ -40,7 +40,7 @@ func generateDaemonset(name, enforcer, runtime, socket, btfPresent, apparmorfs, 
 	commonVols := common.CommonVolumes
 	commonVolMnts := common.CommonVolumesMount
 
-	if btfPresent == "no" {
+	if btfPresent == "no" || initDeploy {
 		commonVols = append(commonVols, common.BPFVolumes...)
 		commonVolMnts = append(commonVolMnts, common.BPFVolumesMount...)
 		commonVols = append(commonVols, common.KernelHeaderVolumes...)
@@ -50,7 +50,7 @@ func generateDaemonset(name, enforcer, runtime, socket, btfPresent, apparmorfs, 
 	volMnts = append(volMnts, commonVolMnts...)
 	daemonset := deployments.GenerateDaemonSet("generic", common.Namespace)
 
-	if btfPresent != "no" {
+	if btfPresent != "no" && !initDeploy {
 		daemonset.Spec.Template.Spec.InitContainers = []corev1.Container{}
 	}
 	daemonset.Name = name
@@ -105,7 +105,7 @@ func generateDaemonset(name, enforcer, runtime, socket, btfPresent, apparmorfs, 
 	daemonset.Spec.Template.Spec.Containers[0].Image = common.GetApplicationImage(common.KubeArmorName)
 	daemonset.Spec.Template.Spec.Containers[0].ImagePullPolicy = corev1.PullPolicy(common.KubeArmorImagePullPolicy)
 
-	if btfPresent == "no" {
+	if btfPresent == "no" || initDeploy {
 		daemonset.Spec.Template.Spec.InitContainers[0].VolumeMounts = commonVolMnts
 		daemonset.Spec.Template.Spec.InitContainers[0].Image = common.GetApplicationImage(common.KubeArmorInitName)
 		daemonset.Spec.Template.Spec.InitContainers[0].ImagePullPolicy = corev1.PullPolicy(common.KubeArmorInitImagePullPolicy)
@@ -238,9 +238,25 @@ func deploySnitch(nodename string, runtime string) *batchv1.Job {
 						},
 						ImagePullPolicy: corev1.PullIfNotPresent,
 						VolumeMounts: []corev1.VolumeMount{
+
 							{
-								Name:      "rootfs",
-								MountPath: PathPrefix,
+								Name:      "var-path",
+								MountPath: "/rootfs/var/",
+								ReadOnly:  true,
+							},
+							{
+								Name:      "run-path",
+								MountPath: "/rootfs/run/",
+								ReadOnly:  true,
+							},
+							{
+								Name:      "sys-path",
+								MountPath: "/rootfs/sys/",
+								ReadOnly:  true,
+							},
+							{
+								Name:      "apparmor-path",
+								MountPath: "/rootfs/etc/apparmor.d/",
 								ReadOnly:  true,
 							},
 							{
@@ -268,16 +284,45 @@ func deploySnitch(nodename string, runtime string) *batchv1.Job {
 				// For Unknown Reasons hostPID will be true if snitch gets deployed on OpenShift
 				// for some reasons github.com/kubearmor/KubeArmor/KubeArmor/utils/bpflsmprobe will
 				// not work if hostPID is set false.
+
+				// change for snitch host path
 				HostPID:            common.HostPID,
 				NodeName:           nodename,
 				RestartPolicy:      corev1.RestartPolicyOnFailure,
 				ServiceAccountName: common.KubeArmorSnitchRoleName,
 				Volumes: []corev1.Volume{
 					{
-						Name: "rootfs",
+						Name: "sys-path",
 						VolumeSource: corev1.VolumeSource{
 							HostPath: &corev1.HostPathVolumeSource{
-								Path: "/",
+								Path: "/sys/",
+								Type: &common.HostPathDirectory,
+							},
+						},
+					},
+					{
+						Name: "apparmor-path",
+						VolumeSource: corev1.VolumeSource{
+							HostPath: &corev1.HostPathVolumeSource{
+								Path: "/etc/apparmor.d/",
+								Type: &common.HostPathDirectory,
+							},
+						},
+					},
+					{
+						Name: "var-path",
+						VolumeSource: corev1.VolumeSource{
+							HostPath: &corev1.HostPathVolumeSource{
+								Path: "/var/",
+								Type: &common.HostPathDirectory,
+							},
+						},
+					},
+					{
+						Name: "run-path",
+						VolumeSource: corev1.VolumeSource{
+							HostPath: &corev1.HostPathVolumeSource{
+								Path: "/run/",
 								Type: &common.HostPathDirectory,
 							},
 						},

--- a/pkg/KubeArmorOperator/internal/controller/resources.go
+++ b/pkg/KubeArmorOperator/internal/controller/resources.go
@@ -41,11 +41,17 @@ func generateDaemonset(name, enforcer, runtime, socket, btfPresent, apparmorfs, 
 	commonVolMnts := common.CommonVolumesMount
 	if btfPresent == "no" {
 		commonVols = append(commonVols, common.KernelHeaderVolumes...)
+		commonVols = append(commonVols, common.BPFVolumes...)
 		commonVolMnts = append(commonVolMnts, common.KernelHeaderVolumesMount...)
+		commonVolMnts = append(commonVolMnts, common.BPFVolumesMount...)
 	}
 	vols = append(vols, commonVols...)
 	volMnts = append(volMnts, commonVolMnts...)
 	daemonset := deployments.GenerateDaemonSet("generic", common.Namespace)
+
+	if btfPresent != "no" {
+		daemonset.Spec.Template.Spec.InitContainers = []corev1.Container{}
+	}
 	daemonset.Name = name
 	labels := map[string]string{
 		common.EnforcerLabel: enforcer,
@@ -80,7 +86,6 @@ func generateDaemonset(name, enforcer, runtime, socket, btfPresent, apparmorfs, 
 		common.AddOrReplaceArg("-tlsEnabled=false", "-tlsEnabled=true", &daemonset.Spec.Template.Spec.Containers[0].Args)
 	}
 	daemonset.Spec.Template.Spec.Volumes = vols
-	daemonset.Spec.Template.Spec.InitContainers[0].VolumeMounts = commonVolMnts
 	daemonset.Spec.Template.Spec.Containers[0].VolumeMounts = volMnts
 	// update images
 
@@ -98,8 +103,12 @@ func generateDaemonset(name, enforcer, runtime, socket, btfPresent, apparmorfs, 
 
 	daemonset.Spec.Template.Spec.Containers[0].Image = common.GetApplicationImage(common.KubeArmorName)
 	daemonset.Spec.Template.Spec.Containers[0].ImagePullPolicy = corev1.PullPolicy(common.KubeArmorImagePullPolicy)
-	daemonset.Spec.Template.Spec.InitContainers[0].Image = common.GetApplicationImage(common.KubeArmorInitName)
-	daemonset.Spec.Template.Spec.InitContainers[0].ImagePullPolicy = corev1.PullPolicy(common.KubeArmorInitImagePullPolicy)
+
+	if btfPresent == "no" {
+		daemonset.Spec.Template.Spec.InitContainers[0].VolumeMounts = commonVolMnts
+		daemonset.Spec.Template.Spec.InitContainers[0].Image = common.GetApplicationImage(common.KubeArmorInitName)
+		daemonset.Spec.Template.Spec.InitContainers[0].ImagePullPolicy = corev1.PullPolicy(common.KubeArmorInitImagePullPolicy)
+	}
 
 	daemonset = addOwnership(daemonset).(*appsv1.DaemonSet)
 	fmt.Printf("generated daemonset: %v", daemonset)

--- a/pkg/KubeArmorOperator/internal/controller/resources.go
+++ b/pkg/KubeArmorOperator/internal/controller/resources.go
@@ -88,29 +88,29 @@ func generateDaemonset(name, enforcer, runtime, socket, btfPresent, apparmorfs, 
 	}
 	daemonset.Spec.Template.Spec.Volumes = vols
 	daemonset.Spec.Template.Spec.Containers[0].VolumeMounts = volMnts
-	// update images
-
-	if seccompPresent == "yes" && common.ConfigDefaultSeccompEnabled == "true" {
-		daemonset.Spec.Template.Spec.Containers[0].SecurityContext.SeccompProfile = &corev1.SeccompProfile{
-			Type:             corev1.SeccompProfileTypeLocalhost,
-			LocalhostProfile: &common.SeccompProfile,
-		}
-		daemonset.Spec.Template.Spec.InitContainers[0].SecurityContext.SeccompProfile = &corev1.SeccompProfile{
-			Type:             corev1.SeccompProfileTypeLocalhost,
-			LocalhostProfile: &common.SeccompInitProfile,
-		}
-
-	}
-
-	daemonset.Spec.Template.Spec.Containers[0].Image = common.GetApplicationImage(common.KubeArmorName)
-	daemonset.Spec.Template.Spec.Containers[0].ImagePullPolicy = corev1.PullPolicy(common.KubeArmorImagePullPolicy)
 
 	if btfPresent == "no" || initDeploy {
 		daemonset.Spec.Template.Spec.InitContainers[0].VolumeMounts = commonVolMnts
 		daemonset.Spec.Template.Spec.InitContainers[0].Image = common.GetApplicationImage(common.KubeArmorInitName)
 		daemonset.Spec.Template.Spec.InitContainers[0].ImagePullPolicy = corev1.PullPolicy(common.KubeArmorInitImagePullPolicy)
 	}
+	// update images
+	if seccompPresent == "yes" && common.ConfigDefaultSeccompEnabled == "true" {
+		daemonset.Spec.Template.Spec.Containers[0].SecurityContext.SeccompProfile = &corev1.SeccompProfile{
+			Type:             corev1.SeccompProfileTypeLocalhost,
+			LocalhostProfile: &common.SeccompProfile,
+		}
+		if len(daemonset.Spec.Template.Spec.InitContainers) != 0 {
+			daemonset.Spec.Template.Spec.InitContainers[0].SecurityContext.SeccompProfile = &corev1.SeccompProfile{
+				Type:             corev1.SeccompProfileTypeLocalhost,
+				LocalhostProfile: &common.SeccompInitProfile,
+			}
+		}
 
+	}
+
+	daemonset.Spec.Template.Spec.Containers[0].Image = common.GetApplicationImage(common.KubeArmorName)
+	daemonset.Spec.Template.Spec.Containers[0].ImagePullPolicy = corev1.PullPolicy(common.KubeArmorImagePullPolicy)
 	daemonset = addOwnership(daemonset).(*appsv1.DaemonSet)
 	fmt.Printf("generated daemonset: %v", daemonset)
 	return daemonset

--- a/protobuf/go.mod
+++ b/protobuf/go.mod
@@ -2,7 +2,7 @@ module github.com/kubearmor/KubeArmor/protobuf
 
 go 1.21.0
 
-toolchain go1.21.9
+toolchain go1.21.11
 
 replace (
 	github.com/kubearmor/KubeArmor => ../

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -2,7 +2,7 @@ module github.com/kubearmor/KubeArmor/tests
 
 go 1.21.0
 
-toolchain go1.21.9
+toolchain go1.21.11
 
 replace (
 	github.com/cilium/cilium => github.com/cilium/cilium v1.14.8


### PR DESCRIPTION
**Purpose of PR?**:

KubeArmor Init container is responsible for compiling our eBPF System Monitor. The compilation needs to happen on client machine because of kernel dependencies.

But with BPF CORE, we don't need it. But BTF info is only available on kernel above 5.2.

This PR ships a CORE compiled object file in main kubearmor image. And let's operator decide if init container needs to be deployed or not based on availability of BTF info.

**Does this PR introduce a breaking change?**

No

**If the changes in this PR are manually verified, list down the scenarios covered:**:

Deployed on both btf/non btf environments

**Additional information for reviewer?** :
Documentation for the hostpaths used by kubearmor :-
https://github.com/kubearmor/KubeArmor/wiki/HostPath-Mounts-Used-by-KubeArmor-%F0%9F%9A%A7%5BWIP%5D

Future steps would include adding an option to provide custom btf file such that users do not need to deploy init image on older kernels as well, provided they can make BTF info available. 
**Checklist:**
- [ ] Bug fix. Fixes #<issue number>
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Commit has unit tests
- [ ] Commit has integration tests

<!--

The PR title message must follow convention:
`<type>(<scope>): <subject>`.

Where: <br />
- `type` is to define what type of PR is this.
  Most common types are:
    - `feat`      - for new features, not a new feature for build script
    - `fix`       - for bug fixes or improvements, not a fix for build script
    - `chore`     - changes not related to production code
    - `docs`      - changes related to documentation
    - `style`     - formatting, missing semi colons, linting fix etc; no significant production code changes
    - `test`      - adding missing tests, refactoring tests; no production code change
    - `refactor`  - refactoring production code, eg. renaming a variable or function name, there should not be any significant production code changes

- `scope` is a single word that best describes where the changes fit.
    - feature(`monitor`,`enforcer`)
    - test(`tests`, `bdd`)
    - chore(`build`)
- `subject` is a single line brief description of the changes made in the pull request.


