### PR TITLE
fix(build): add `go-get-tool` function in makefile of KubeArmorOperator

### DIFF
--- a/pkg/KubeArmorOperator/Makefile
+++ b/pkg/KubeArmorOperator/Makefile
@@ -32,6 +32,15 @@ endif
 SHELL = /usr/bin/env bash -o pipefail
 .SHELLFLAGS = -ec
 
+# Define a function to download a go tool if it is not installed.
+define go-get-tool
+@[ -f $(1) ] || { \
+set -e; \
+echo "Downloading $(2)" ;\
+go install $(2) ;\
+}
+endef
+
 .PHONY: all
 all: get snitch kubearmor-operator
 


### PR DESCRIPTION
**Purpose of PR?**:

Add a handy go-get-tool function to install go packages.

Fixes #1609

**Does this PR introduce a breaking change?**
No

**Checklist:**
- [x] Bug fix. Fixes #1609
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Commit has unit tests
- [ ] Commit has integration tests

**Screenshot:**

![image](https://github.com/kubearmor/KubeArmor/assets/72978371/5890dbf2-6ab6-4847-bfef-c90a0c64f9fe)
