### PR TITLE
feat(core): add label/regex matching in non-k8s

### DIFF
--- a/KubeArmor/Makefile
+++ b/KubeArmor/Makefile
@@ -55,7 +55,7 @@ run: build
 .PHONY: run-container
 run-container: build
 	cd $(CURDIR); sudo rm -f /tmp/kubearmor.log
-	cd $(CURDIR); DEBUG=true sudo -E ./kubearmor -logPath=/tmp/kubearmor.log -enableKubeArmorHostPolicy -enableKubeArmorPolicy -k8s=false -criSocket=unix:///var/run/docker.sock
+	cd $(CURDIR); sudo -E ./kubearmor -logPath=/tmp/kubearmor.log -enableKubeArmorHostPolicy -enableKubeArmorPolicy -k8s=false -criSocket=unix:///var/run/docker.sock
 
 .PHONY: run-host-only
 run-host-only: build

--- a/KubeArmor/core/kubeArmor.go
+++ b/KubeArmor/core/kubeArmor.go
@@ -390,6 +390,12 @@ func KubeArmor() {
 		dm.Node.NodeName = cfg.GlobalCfg.Host
 		dm.Node.NodeIP = kl.GetExternalIPAddr()
 
+		// add identity for matching node selector
+		dm.Node.Labels = make(map[string]string)
+		dm.Node.Labels["kubearmor.io/hostname"] = dm.Node.NodeName
+
+		dm.Node.Identities = append(dm.Node.Identities, "kubearmor.io/hostname"+"="+dm.Node.NodeName)
+
 		dm.Node.Annotations = map[string]string{}
 		dm.HandleNodeAnnotations(&dm.Node)
 
@@ -405,9 +411,6 @@ func KubeArmor() {
 
 		dm.Node.KernelVersion = kl.GetCommandOutputWithoutErr("uname", []string{"-r"})
 		dm.Node.KernelVersion = strings.TrimSuffix(dm.Node.KernelVersion, "\n")
-
-		// add identity for matching node selector
-		dm.Node.Identities = append(dm.Node.Identities, "kubearmor.io/hostname"+"="+dm.Node.NodeName)
 
 		dm.NodeLock.Unlock()
 

--- a/KubeArmor/state/stateAgent.go
+++ b/KubeArmor/state/stateAgent.go
@@ -22,7 +22,7 @@ const (
 	stateEventBufferSize = 25
 
 	// EventAdded denotes an add event
-	EventAdded   = "added"
+	EventAdded = "added"
 	// EventUpdated denotes an update event
 	EventUpdated = "updated"
 	// EventDeleted denotes an delete event
@@ -31,9 +31,9 @@ const (
 	// KindContainer denotes a container kind
 	KindContainer = "container"
 	// KindPod denotes a pod kind
-	KindPod       = "pod"
+	KindPod = "pod"
 	// KindNode denotes a node kind
-	KindNode      = "node"
+	KindNode = "node"
 	// KindNamespace denotes a namespace kind
 	KindNamespace = "namespace"
 )

--- a/KubeArmor/types/types.go
+++ b/KubeArmor/types/types.go
@@ -73,6 +73,8 @@ type Namespace struct {
 }
 
 // EndPoint Structure
+// k8s: Endpoint ~= pod
+// non-k8s: Endpoint ~= container
 type EndPoint struct {
 	NamespaceName string `json:"namespaceName"`
 

--- a/contribution/self-managed-k8s/k8s/initialize_kubernetes.sh
+++ b/contribution/self-managed-k8s/k8s/initialize_kubernetes.sh
@@ -67,7 +67,8 @@ elif [ "$CNI" == "weave" ]; then
     kubectl apply -f "https://cloud.weave.works/k8s/net?k8s-version=$kubever"
 elif [ "$CNI" == "calico" ]; then
     # install a pod network (calico)
-    kubectl apply -f https://projectcalico.docs.tigera.io/manifests/calico.yaml
+    kubectl apply -f https://raw.githubusercontent.com/projectcalico/calico/v3.27.0/manifests/calico.yaml
+    #kubectl apply -f https://projectcalico.docs.tigera.io/manifests/calico.yaml
 elif [ "$CNI" == "cilium" ]; then
     # install a pod network (cilium)
     curl -L --remote-name-all https://github.com/cilium/cilium-cli/releases/latest/download/cilium-linux-amd64.tar.gz{,.sha256sum}


### PR DESCRIPTION
Signed-off-by: Rudraksh Pareek <rudraksh@accuknox.com>

**Purpose of PR?**:

- `matchLabels` in non-k8s mode now supports adding labels other than `kubearmor.io/container.name`.
- Names entered in `kubearmor.io/container.name` will be interpreted as regex (leftmost longest matching)
- The `kubeamor.io/container.name` is mutually exclusive with other labels **in non-k8s mode**.
- AppArmor will only continue to support `kubearmor.io/container.name` as apparmor profile is created based on container name.

*NOTE: The only impact these changes will have on K8s is improvement in multicontainer policies, otherwise all other changes are for non-k8s mode*

**Does this PR introduce a breaking change?**
No

**If the changes in this PR are manually verified, list down the scenarios covered:**:
Various scenarios covered:
- Policy enforcement before & after container creation
- Changing identities of policy in both the the above cases
- Container/policy deletion and recreation
- Backup/restore

**Additional information for reviewer?** :
_Mention if this PR is part of any design or a continuation of previous PRs_

**Checklist:**
- [ ] Bug fix. Fixes #<issue number>
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Commit has unit tests
- [ ] Commit has integration tests

<!--

The PR title message must follow convention:
`<type>(<scope>): <subject>`.

Where: <br />
- `type` is to define what type of PR is this.
  Most common types are:
    - `feat`      - for new features, not a new feature for build script
    - `fix`       - for bug fixes or improvements, not a fix for build script
    - `chore`     - changes not related to production code
    - `docs`      - changes related to documentation
    - `style`     - formatting, missing semi colons, linting fix etc; no significant production code changes
    - `test`      - adding missing tests, refactoring tests; no production code change
    - `refactor`  - refactoring production code, eg. renaming a variable or function name, there should not be any significant production code changes

- `scope` is a single word that best describes where the changes fit.
    - feature(`monitor`,`enforcer`)
    - test(`tests`, `bdd`)
    - chore(`build`)
- `subject` is a single line brief description of the changes made in the pull request.

-->