### PR TITLE
fix govvv compile time rule error in makefile

### DIFF
--- a/KubeArmor/Makefile
+++ b/KubeArmor/Makefile
@@ -14,7 +14,7 @@ KUBEARMOR_PID    = $(shell pgrep kubearmor)
 
 
 re-govvv:
-	@if ! which govvv > /dev/null; then 
+	@if ! which govvv > /dev/null; then \
 					echo "installing govvv"; \
 			go install github.com/ahmetb/govvv; \
 	fi

--- a/KubeArmor/Makefile
+++ b/KubeArmor/Makefile
@@ -14,7 +14,7 @@ KUBEARMOR_PID    = $(shell pgrep kubearmor)
 
 
 re-govvv:
-	@if ! which govvv > /dev/null; then \
+	@if ! which govvv > /dev/null; then 
 					echo "installing govvv"; \
 			go install github.com/ahmetb/govvv; \
 	fi

--- a/KubeArmor/Makefile
+++ b/KubeArmor/Makefile
@@ -12,10 +12,12 @@ DLV_LPORT       := 2345
 DLV_RPORT       := $(shell expr $(DLV_LPORT) + $(NETNEXT))
 KUBEARMOR_PID    = $(shell pgrep kubearmor)
 
-ifeq (, $(shell which govvv))
-$(shell go install github.com/ahmetb/govvv)	# This works for older go version
-$(shell go install github.com/ahmetb/govvv@latest) # This works for new go version
-endif
+
+re-govvv:
+	@if ! which govvv > /dev/null; then \
+					echo "installing govvv"; \
+			go install github.com/ahmetb/govvv; \
+	fi
 
 GIT_INFO := $(shell govvv -flags)
 

--- a/KubeArmor/go.mod
+++ b/KubeArmor/go.mod
@@ -53,6 +53,7 @@ require (
 	github.com/Masterminds/goutils v1.1.1 // indirect
 	github.com/Masterminds/semver/v3 v3.2.1 // indirect
 	github.com/Microsoft/go-winio v0.6.1 // indirect
+	github.com/ahmetb/govvv v0.3.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/containerd/ttrpc v1.2.2 // indirect

--- a/KubeArmor/go.sum
+++ b/KubeArmor/go.sum
@@ -11,6 +11,8 @@ github.com/Masterminds/sprig/v3 v3.2.3 h1:eL2fZNezLomi0uOLqjQoN6BfsDD+fyLtgbJMAj
 github.com/Masterminds/sprig/v3 v3.2.3/go.mod h1:rXcFaZ2zZbLRJv/xSysmlgIM1u11eBaRMhvYXJNkGuM=
 github.com/Microsoft/go-winio v0.6.1 h1:9/kr64B9VUZrLm5YYwbGtUJnMgqWVOdUAXu6Migciow=
 github.com/Microsoft/go-winio v0.6.1/go.mod h1:LRdKpFKfdobln8UmuiYcKPot9D2v6svN5+sAH+4kjUM=
+github.com/ahmetb/govvv v0.3.0 h1:YGLGwEyiUwHFy5eh/RUhdupbuaCGBYn5T5GWXp+WJB0=
+github.com/ahmetb/govvv v0.3.0/go.mod h1:4WRFpdWtc/YtKgPFwa1dr5+9hiRY5uKAL08bOlxOR6s=
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 h1:DklsrG3dyBCFEj5IhUbnKptjxatkF07cF2ak3yi77so=
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=


### PR DESCRIPTION
**Purpose of PR?**:
Fix govvv package availability when building. 

Screenshot:
<img width="428" alt="image" src="https://github.com/kubearmor/KubeArmor/assets/56168768/2d85b197-13b2-4051-8a99-6c7cf8631028">
Before:
` 
make: govvv: Not a directory
installing govvv
no required module provides package github.com/ahmetb/govvv; to add it:
        go get github.com/ahmetb/govvv
make: *** [Makefile:19: re-govvv] Error 1`

After:
` make
make: govvv: Not a directory
installing govvv`

**Does this PR introduce a breaking change?**

No

**If the changes in this PR are manually verified, list down the scenarios covered:**:

Various scenarios covered:

- compile makefile
- go get
- go mod tidy

**Additional information for reviewer?** :

*Mention if this PR is part of any design or a continuation of previous PRs*
Original govvv design:
[https://github.com/kubearmor/KubeArmor/pull/1067](https://github.com/kubearmor/KubeArmor/pull/1067
)

**Checklist:**

- [x]  Bug fix. Fixes #
