### PR TITLE
fix(enforcer): suppress permission denied alerts for any non bpflsm enforcer

### DIFF
--- a/KubeArmor/feeder/feeder.go
+++ b/KubeArmor/feeder/feeder.go
@@ -518,9 +518,9 @@ func (fd *Feeder) PushLog(log tp.Log) {
 	   in case of enforcer = AppArmor only Default Posture logs will be converted to
 	   container/host log depending upon the defaultPostureLogs flag
 	*/
-	if (cfg.GlobalCfg.EnforcerAlerts && fd.Enforcer == "BPFLSM" && log.Enforcer != "BPFLSM") || (fd.Enforcer == "AppArmor" && !cfg.GlobalCfg.DefaultPostureLogs) {
+	if (cfg.GlobalCfg.EnforcerAlerts && fd.Enforcer == "BPFLSM" && log.Enforcer != "BPFLSM") || (fd.Enforcer != "BPFLSM" && !cfg.GlobalCfg.DefaultPostureLogs) {
 		log = fd.UpdateMatchedPolicy(log)
-		if (log.Type == "MatchedPolicy" || log.Type == "MatchedHostPolicy") && ((fd.Enforcer == "BPFLSM" && (strings.Contains(log.PolicyName, "DefaultPosture") || !strings.Contains(log.Action, "Audit"))) || (fd.Enforcer == "AppArmor" && strings.Contains(log.PolicyName, "DefaultPosture"))) {
+		if (log.Type == "MatchedPolicy" || log.Type == "MatchedHostPolicy") && ((fd.Enforcer == "BPFLSM" && (strings.Contains(log.PolicyName, "DefaultPosture") || !strings.Contains(log.Action, "Audit"))) || (fd.Enforcer != "BPFLSM" && strings.Contains(log.PolicyName, "DefaultPosture"))) {
 			if log.Type == "MatchedPolicy" {
 				log.Type = "ContainerLog"
 			} else if log.Type == "MatchedHostPolicy" {


### PR DESCRIPTION


**Purpose of PR?**:

On hosts where a suitable LSM is not found, we send out any Permission Denied events as Alerts. This is misleading and the alerts are not due to KubeArmor.

This PR helps use the existing configuration to suppress KubeArmor alerts as logs. 

**Does this PR introduce a breaking change?**

NA

**If the changes in this PR are manually verified, list down the scenarios covered:**:

**Additional information for reviewer?** :
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [ ] Bug fix. Fixes #<issue number>
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Commit has unit tests
- [ ] Commit has integration tests

<!--

The PR title message must follow convention:
`<type>(<scope>): <subject>`.

Where: <br />
- `type` is to define what type of PR is this.
  Most common types are:
    - `feat`      - for new features, not a new feature for build script
    - `fix`       - for bug fixes or improvements, not a fix for build script
    - `chore`     - changes not related to production code
    - `docs`      - changes related to documentation
    - `style`     - formatting, missing semi colons, linting fix etc; no significant production code changes
    - `test`      - adding missing tests, refactoring tests; no production code change
    - `refactor`  - refactoring production code, eg. renaming a variable or function name, there should not be any significant production code changes

- `scope` is a single word that best describes where the changes fit.
    - feature(`monitor`,`enforcer`)
    - test(`tests`, `bdd`)
    - chore(`build`)
- `subject` is a single line brief description of the changes made in the pull request.

-->