### PR TITLE
fix(grpc): extend grpc maxrecvmsg size for cri handlers

### DIFF
--- a/KubeArmor/common/common.go
+++ b/KubeArmor/common/common.go
@@ -32,6 +32,13 @@ import (
 // == Common == //
 // ============ //
 
+const (
+	// grpc default is 4MB
+	// CRI i.e. containerd service can send msg extended upto 16MB
+	// https://github.com/containerd/containerd/blob/main/defaults/defaults.go#L22-L25
+	DefaultMaxRecvMaxSize = 16 << 20
+)
+
 // Clone Function
 func Clone(src, dst interface{}) error {
 	arr, _ := json.Marshal(src)

--- a/KubeArmor/core/containerdHandler.go
+++ b/KubeArmor/core/containerdHandler.go
@@ -247,13 +247,13 @@ func (ch *ContainerdHandler) GetContainerdContainers() map[string]context.Contex
 
 	req := pb.ListContainersRequest{}
 
-	if containerList, err := ch.client.List(ch.docker, &req); err == nil {
+	if containerList, err := ch.client.List(ch.docker, &req, grpc.MaxCallRecvMsgSize(kl.DefaultMaxRecvMaxSize)); err == nil {
 		for _, container := range containerList.Containers {
 			containers[container.ID] = ch.docker
 		}
 	}
 
-	if containerList, err := ch.client.List(ch.containerd, &req); err == nil {
+	if containerList, err := ch.client.List(ch.containerd, &req, grpc.MaxCallRecvMsgSize(kl.DefaultMaxRecvMaxSize)); err == nil {
 		for _, container := range containerList.Containers {
 			containers[container.ID] = ch.containerd
 		}

--- a/KubeArmor/core/crioHandler.go
+++ b/KubeArmor/core/crioHandler.go
@@ -159,7 +159,7 @@ func (ch *CrioHandler) GetCrioContainers() (map[string]struct{}, error) {
 
 	req := pb.ListContainersRequest{}
 
-	if containerList, err := ch.client.ListContainers(context.Background(), &req); err == nil {
+	if containerList, err := ch.client.ListContainers(context.Background(), &req, grpc.MaxCallRecvMsgSize(kl.DefaultMaxRecvMaxSize)); err == nil {
 		for _, container := range containerList.Containers {
 			containers[container.Id] = struct{}{}
 		}


### PR DESCRIPTION
**Purpose of PR?**:

when there are a lot of containers running, it might exceed the default grpc limit of 4MB msg size for cri handler services and that will lead to the issues.  
```
rpc error: code = ResourceExhausted desc = grpc: received message larger than max
```

**Does this PR introduce a breaking change?**
No
**If the changes in this PR are manually verified, list down the scenarios covered:**:

**Additional information for reviewer?** :
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [x] Bug fix
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Commit has unit tests
- [ ] Commit has integration tests

<!--

The PR title message must follow convention:
`<type>(<scope>): <subject>`.

Where: <br />
- `type` is to define what type of PR is this.
  Most common types are:
    - `feat`      - for new features, not a new feature for build script
    - `fix`       - for bug fixes or improvements, not a fix for build script
    - `chore`     - changes not related to production code
    - `docs`      - changes related to documentation
    - `style`     - formatting, missing semi colons, linting fix etc; no significant production code changes
    - `test`      - adding missing tests, refactoring tests; no production code change
    - `refactor`  - refactoring production code, eg. renaming a variable or function name, there should not be any significant production code changes

- `scope` is a single word that best describes where the changes fit.
    - feature(`monitor`,`enforcer`)
    - test(`tests`, `bdd`)
    - chore(`build`)
- `subject` is a single line brief description of the changes made in the pull request.

-->