### PR TITLE
bug: fix systemd release workflow

### DIFF
--- a/.github/workflows/ci-systemd-release.yml
+++ b/.github/workflows/ci-systemd-release.yml
@@ -5,17 +5,13 @@ on:
     tags:
       - "*"
 
-# Declare default permissions as read only.
-permissions:
-  id-token: write # requires for cosign keyless signing
-  contents: write # requires for goreleaser to write to GitHub release
-
 jobs:
   goreleaser:
     runs-on: ubuntu-20.04
     if: github.repository == 'kubearmor/kubearmor'
     permissions:
-      contents: write
+      id-token: write # requires for cosign keyless signing
+      contents: write # requires for goreleaser to write to GitHub release
     steps:
       - uses: actions/checkout@v3
         with:

--- a/KubeArmor/.goreleaser.yaml
+++ b/KubeArmor/.goreleaser.yaml
@@ -14,8 +14,6 @@ signs:
     certificate: '${artifact}.cert'
     args:
       - sign-blob
-      - '--oidc-issuer=https://token.actions.githubusercontent.com'
-      - '--oidc-provider=github-actions'
       - '--output-certificate=${certificate}' 
       - '--output-signature=${signature}'
       - '${artifact}'


### PR DESCRIPTION
job level permissions were overriding global permissions and that was the reason it was failing.

tested it on a fork: 
- https://github.com/kranurag78/KubeArmor/releases/tag/v1.3.8