### PR TITLE
fix(core) : updating owner info for job/cronjob controller

### DIFF
--- a/KubeArmor/core/k8sHandler.go
+++ b/KubeArmor/core/k8sHandler.go
@@ -591,6 +591,24 @@ func getTopLevelOwner(obj metav1.ObjectMeta, namespace string, objkind string) (
 		if len(pod.OwnerReferences) > 0 {
 			return getTopLevelOwner(pod.ObjectMeta, namespace, "Pod")
 		}
+	case "Job":
+		job, err := K8s.K8sClient.BatchV1().Jobs(namespace).Get(context.Background(), ownerRef.Name, metav1.GetOptions{})
+		if err != nil {
+			return "", "", "", err
+		}
+		if len(job.OwnerReferences) > 0 {
+			return getTopLevelOwner(job.ObjectMeta, namespace, "CronJob")
+		}
+		return job.Name, "Job", job.Namespace, nil
+	case "CronJob":
+		cronJob, err := K8s.K8sClient.BatchV1().CronJobs(namespace).Get(context.Background(), ownerRef.Name, metav1.GetOptions{})
+		if err != nil {
+			return "", "", "", err
+		}
+		if len(cronJob.OwnerReferences) > 0 {
+			return getTopLevelOwner(cronJob.ObjectMeta, namespace, "CronJob")
+		}
+		return cronJob.Name, "CronJob", cronJob.Namespace, nil
 	case "Deployment":
 		deployment, err := K8s.K8sClient.AppsV1().Deployments(namespace).Get(context.Background(), ownerRef.Name, metav1.GetOptions{})
 		if err != nil {

--- a/KubeArmor/core/kubeUpdate.go
+++ b/KubeArmor/core/kubeUpdate.go
@@ -763,6 +763,22 @@ func (dm *KubeArmorDaemon) WatchK8sPods() {
 								}
 							}
 
+						} else if dm.OwnerInfo[pod.Metadata["podName"]].Ref == "Job" {
+							job, err := K8s.K8sClient.BatchV1().Jobs(pod.Metadata["namespaceName"]).Get(context.Background(), podOwnerName, metav1.GetOptions{})
+							if err == nil {
+								for _, c := range job.Spec.Template.Spec.Containers {
+									containers = append(containers, c.Name)
+								}
+							}
+
+						} else if dm.OwnerInfo[pod.Metadata["podName"]].Ref == "CronJob" {
+							cronJob, err := K8s.K8sClient.BatchV1().CronJobs(pod.Metadata["namespaceName"]).Get(context.Background(), podOwnerName, metav1.GetOptions{})
+							if err == nil {
+								for _, c := range cronJob.Spec.JobTemplate.Spec.Template.Spec.Containers {
+									containers = append(containers, c.Name)
+								}
+							}
+
 						}
 
 					}


### PR DESCRIPTION
**Purpose of PR?**:
onwer info was showing controller type `Pod` if owner was job.

Partially Fixes # https://accu-knox.atlassian.net/browse/CNAPP-10787

**Does this PR introduce a breaking change?**
no

**If the changes in this PR are manually verified, list down the scenarios covered:**:

**Additional information for reviewer?** :
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [x] Bug fix. Fixes #<[issue number](https://accu-knox.atlassian.net/browse/CNAPP-10787)>
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Commit has unit tests
- [ ] Commit has integration tests

<!--

The PR title message must follow convention:
`<type>(<scope>): <subject>`.

Where: <br />
- `type` is to define what type of PR is this.
  Most common types are:
    - `feat`      - for new features, not a new feature for build script
    - `fix`       - for bug fixes or improvements, not a fix for build script
    - `chore`     - changes not related to production code
    - `docs`      - changes related to documentation
    - `style`     - formatting, missing semi colons, linting fix etc; no significant production code changes
    - `test`      - adding missing tests, refactoring tests; no production code change
    - `refactor`  - refactoring production code, eg. renaming a variable or function name, there should not be any significant production code changes

- `scope` is a single word that best describes where the changes fit.
    - feature(`monitor`,`enforcer`)
    - test(`tests`, `bdd`)
    - chore(`build`)
- `subject` is a single line brief description of the changes made in the pull request.

-->