### PR TITLE
Fix hyperlink in hardening guide

### DIFF
--- a/getting-started/hardening_guide.md
+++ b/getting-started/hardening_guide.md
@@ -18,7 +18,7 @@ KubeArmor client tool (karmor) provides a way (`karmor recommend`) to fetch the 
 The output is a set of [`KubeArmorPolicy`](security_policy_specification.md) or [`KubeArmorHostPolicy`](host_security_policy_specification.md) that can be applied using k8s native tools (such as `kubectl apply`).
 
 The rules in hardening policies are based on inputs from:
-1. [MITRE TTPs](https://github.com/kubearmor/policy-templates/)
+1. [MITRE TTPs](https://attack.mitre.org/)
 2. [Security Technical Implementation Guides (STIGs)](https://public.cyber.mil/stigs/)
 3. [NIST SP 800-53A](https://csrc.nist.gov/publications/detail/sp/800-53a/rev-4/final)
 4. [Center for Internet Security (CIS)](https://www.cisecurity.org/cis-benchmarks/)


### PR DESCRIPTION
**Purpose of PR?**:

Fixes wrong hyperlink in [hardening guide doc](https://github.com/kubearmor/KubeArmor/blob/main/getting-started/hardening_guide.md#what-is-the-source-of-these-hardening-policies).


**Does this PR introduce a breaking change?**

**If the changes in this PR are manually verified, list down the scenarios covered:**:

**Additional information for reviewer?** :
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [ ] Bug fix. Fixes #<issue number>
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Commit has unit tests
- [ ] Commit has integration tests

<!--

The PR title message must follow convention:
`<type>(<scope>): <subject>`.

Where: <br />
- `type` is to define what type of PR is this.
  Most common types are:
    - `feat`      - for new features, not a new feature for build script
    - `fix`       - for bug fixes or improvements, not a fix for build script
    - `chore`     - changes not related to production code
    - `docs`      - changes related to documentation
    - `style`     - formatting, missing semi colons, linting fix etc; no significant production code changes
    - `test`      - adding missing tests, refactoring tests; no production code change
    - `refactor`  - refactoring production code, eg. renaming a variable or function name, there should not be any significant production code changes

- `scope` is a single word that best describes where the changes fit.
    - feature(`monitor`,`enforcer`)
    - test(`tests`, `bdd`)
    - chore(`build`)
- `subject` is a single line brief description of the changes made in the pull request.

-->