### PR TITLE
fix(ci): coverage report generation for k8s_env tests

### DIFF
--- a/.github/workflows/ci-test-ginkgo.yml
+++ b/.github/workflows/ci-test-ginkgo.yml
@@ -117,14 +117,12 @@ jobs:
       - name: Measure code coverage
         if: ${{ always() }}
         run: |
-          go install github.com/modocache/gover@latest
-          gover
-          go tool cover -func=gover.coverprofile
-        working-directory: KubeArmor
+          go tool cover -func=coverprofile.out
+        working-directory: ./tests/k8s_env
         env:
           GOPATH: /home/runner/go
 
       - uses: codecov/codecov-action@v3
         if: ${{ always() }}
         with:
-          files: ./KubeArmor/gover.coverprofile
+          files: ./tests/k8s_env/coverprofile.out

--- a/tests/k8s_env/Makefile
+++ b/tests/k8s_env/Makefile
@@ -6,8 +6,8 @@ build:
 	@go mod tidy
 	# run in two steps as syscall suite fails if run at the very end
 	# see - https://github.com/kubearmor/KubeArmor/issues/1269
-	@ginkgo --vv --flake-attempts=10 --timeout=10m syscalls/
-	@ginkgo -r --vv --flake-attempts=10 --timeout=30m --skip-package "syscalls"
+	@ginkgo --vv --flake-attempts=10 --timeout=10m --coverpkg=github.com/kubearmor/KubeArmor/tests/... syscalls/
+	@ginkgo -r --vv --flake-attempts=10 --timeout=30m --coverpkg=github.com/kubearmor/KubeArmor/tests/... --skip-package "syscalls"
 .PHONY: test
 test:
 	@ginkgo -r -v


### PR DESCRIPTION
**Purpose of PR?**:

Fixes https://github.com/kubearmor/KubeArmor/issues/1758

**Does this PR introduce a breaking change?**
No, it changes Ci step

**If the changes in this PR are manually verified, list down the scenarios covered:**:
N/A

**Additional information for reviewer?** :
The main purpose of gover is to concatenate multiple cover profiles into a single file. We dont need to do this as ginkgo already stored the cover profile in a single file (by default coverprofile.out). 

The PR adds a flag in ginkgo test command to generate test profile for every package in the `github.com/kubearmor/KubeArmor/tests` . The reason to use full path is a bug in ginkgo when using relative path. It is supposedly fixed but using the relative path didnt work in our case (ref: https://github.com/onsi/ginkgo/issues/1161#issuecomment-1462585824)


**Checklist:**
- [x] Bug fix. Fixes https://github.com/kubearmor/KubeArmor/issues/1758
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Commit has unit tests
- [ ] Commit has integration tests

<!--

The PR title message must follow convention:
`<type>(<scope>): <subject>`.

Where: <br />
- `type` is to define what type of PR is this.
  Most common types are:
    - `feat`      - for new features, not a new feature for build script
    - `fix`       - for bug fixes or improvements, not a fix for build script
    - `chore`     - changes not related to production code
    - `docs`      - changes related to documentation
    - `style`     - formatting, missing semi colons, linting fix etc; no significant production code changes
    - `test`      - adding missing tests, refactoring tests; no production code change
    - `refactor`  - refactoring production code, eg. renaming a variable or function name, there should not be any significant production code changes

- `scope` is a single word that best describes where the changes fit.
    - feature(`monitor`,`enforcer`)
    - test(`tests`, `bdd`)
    - chore(`build`)
- `subject` is a single line brief description of the changes made in the pull request.

-->