### PR TITLE
chore(deployment):update rbac rules for jobs/cronjobs for kubearmor clusterRole

### DIFF
--- a/deployments/get/objects.go
+++ b/deployments/get/objects.go
@@ -52,6 +52,11 @@ func GetClusterRole() *rbacv1.ClusterRole {
 				Verbs:     []string{"get", "patch", "list", "watch", "update"},
 			},
 			{
+				APIGroups: []string{"batch"},
+				Resources: []string{"jobs", "cronjobs"},
+				Verbs:     []string{"get"},
+			},
+			{
 				APIGroups: []string{"security.kubearmor.com"},
 				Resources: []string{"kubearmorpolicies", "kubearmorhostpolicies"},
 				Verbs:     []string{"get", "list", "watch", "update", "delete"},

--- a/deployments/helm/KubeArmor/templates/RBAC/roles.yaml
+++ b/deployments/helm/KubeArmor/templates/RBAC/roles.yaml
@@ -30,6 +30,13 @@ rules:
   - watch
   - update
 - apiGroups:
+  - batch
+  resources:
+  - jobs
+  - cronjobs
+  verbs:
+  - get
+- apiGroups:
   - security.kubearmor.com
   resources:
   - kubearmorpolicies

--- a/deployments/helm/KubeArmorOperator/templates/clusterrole-rbac.yaml
+++ b/deployments/helm/KubeArmorOperator/templates/clusterrole-rbac.yaml
@@ -123,6 +123,13 @@ rules:
   - watch
   - update
 - apiGroups:
+  - batch
+  resources:
+  - jobs
+  - cronjobs
+  verbs:
+  - get
+- apiGroups:
   - security.kubearmor.com
   resources:
   - kubearmorpolicies

--- a/pkg/KubeArmorOperator/config/rbac/clusterrole.yaml
+++ b/pkg/KubeArmorOperator/config/rbac/clusterrole.yaml
@@ -124,6 +124,13 @@ rules:
   - watch
   - update
 - apiGroups:
+  - batch
+  resources:
+  - jobs
+  - cronjobs
+  verbs:
+  - get
+- apiGroups:
   - security.kubearmor.com
   resources:
   - kubearmorpolicies


### PR DESCRIPTION
**Purpose of PR?**:
To get owner info for job/cronjobs, we require `get` rule, which does not exist currently.

Connected to #1748 

Fixes #

**Does this PR introduce a breaking change?**
no

**If the changes in this PR are manually verified, list down the scenarios covered:**:
yes

**Additional information for reviewer?** :
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [ ] Bug fix. Fixes #<issue number>
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Commit has unit tests
- [ ] Commit has integration tests

<!--

The PR title message must follow convention:
`<type>(<scope>): <subject>`.

Where: <br />
- `type` is to define what type of PR is this.
  Most common types are:
    - `feat`      - for new features, not a new feature for build script
    - `fix`       - for bug fixes or improvements, not a fix for build script
    - `chore`     - changes not related to production code
    - `docs`      - changes related to documentation
    - `style`     - formatting, missing semi colons, linting fix etc; no significant production code changes
    - `test`      - adding missing tests, refactoring tests; no production code change
    - `refactor`  - refactoring production code, eg. renaming a variable or function name, there should not be any significant production code changes

- `scope` is a single word that best describes where the changes fit.
    - feature(`monitor`,`enforcer`)
    - test(`tests`, `bdd`)
    - chore(`build`)
- `subject` is a single line brief description of the changes made in the pull request.

-->