### PR TITLE
fix(docs): Update KubeArmor VM/Bare-metal docs according to new conventions

### DIFF
--- a/getting-started/kubearmor_vm.md
+++ b/getting-started/kubearmor_vm.md
@@ -49,6 +49,9 @@ kind: KubeArmorHostPolicy
 metadata:
   name: hsp-kubearmor-dev-proc-path-block
 spec:
+  nodeSelector:
+    matchLabels:
+      kubearmor.io/hostname: "*" # Apply to all hosts
   process:
     matchPaths:
     - path: /usr/bin/sleep # try sleep 1
@@ -63,32 +66,36 @@ karmor vm policy add hostpolicy.yaml
 
 **Now if you run `sleep` command, the process would be denied execution.**
 
-> Note that `sleep` may not blocked if you run it in the same terminal where you apply the above policy. In that case, please open a new terminal and run `sleep` again to see if the command is blocked.
+> Note that `sleep` may not be blocked if you run it in the same terminal where you apply the above policy. In that case, please open a new terminal and run `sleep` again to see if the command is blocked.
 
 ## Get Alerts for policies and telemetry
 
 ```
-karmor logs --json
+karmor logs --gRPC=:32767 --json
 ```
 
-```json=
+```json
 {
-  "Timestamp": 1639803960,
-  "UpdatedTime": "2021-12-18T05:06:00.077564Z",
-  "ClusterName": "Default",
-  "HostName": "pandora",
-  "HostPID": 3390423,
-  "PPID": 168556,
-  "PID": 3390423,
-  "UID": 1000,
-  "PolicyName": "hsp-kubearmor-dev-proc-path-block",
-  "Severity": "1",
-  "Type": "MatchedHostPolicy",
-  "Source": "zsh",
-  "Operation": "Process",
-  "Resource": "/usr/bin/sleep",
-  "Data": "syscall=SYS_EXECVE",
-  "Action": "Block",
-  "Result": "Permission denied"
+"Timestamp":1717259989,
+"UpdatedTime":"2024-06-01T16:39:49.360067Z",
+"HostName":"kubearmor-dev",
+"HostPPID":1582,
+"HostPID":2420,
+"PPID":1582,
+"PID":2420,
+"UID":1000,
+"ParentProcessName":"/usr/bin/bash",
+"ProcessName":"/usr/bin/sleep",
+"PolicyName":"hsp-kubearmor-dev-proc-path-block",
+"Severity":"1",
+"Type":"MatchedHostPolicy",
+"Source":"/usr/bin/bash",
+"Operation":"Process",
+"Resource":"/usr/bin/sleep",
+"Data":"lsm=SECURITY_BPRM_CHECK",
+"Enforcer":"BPFLSM",
+"Action":"Block",
+"Result":"Permission denied",
+"Cwd":"/"
 }
 ```


### PR DESCRIPTION
**Purpose of PR?**:

Current documentation for KubeArmor VM/Bare-metal installation is outdated. This PR will fix the older policy spec example and getting logs using `karmor`.  

**Does this PR introduce a breaking change?**
No

**If the changes in this PR are manually verified, list down the scenarios covered:**:

**Additional information for reviewer?** :
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`

<!--

The PR title message must follow convention:
`<type>(<scope>): <subject>`.

Where: <br />
- `type` is to define what type of PR is this.
  Most common types are:
    - `feat`      - for new features, not a new feature for build script
    - `fix`       - for bug fixes or improvements, not a fix for build script
    - `chore`     - changes not related to production code
    - `docs`      - changes related to documentation
    - `style`     - formatting, missing semi colons, linting fix etc; no significant production code changes
    - `test`      - adding missing tests, refactoring tests; no production code change
    - `refactor`  - refactoring production code, eg. renaming a variable or function name, there should not be any significant production code changes

- `scope` is a single word that best describes where the changes fit.
    - feature(`monitor`,`enforcer`)
    - test(`tests`, `bdd`)
    - chore(`build`)
- `subject` is a single line brief description of the changes made in the pull request.

-->