### PR TITLE
fix(setup.sh): Enable LLVM tools installation on Ubuntu 24.04

### DIFF
--- a/contribution/self-managed-k8s/setup.sh
+++ b/contribution/self-managed-k8s/setup.sh
@@ -30,8 +30,14 @@ if [ "$VERSION_CODENAME" == "focal" ] || [ "$VERSION_CODENAME" == "bionic" ]; th
         sudo rm -f /usr/bin/$tool
         sudo ln -s /usr/bin/$tool-12 /usr/bin/$tool
     done
-else # VERSION_CODENAME == jammy
+elif [ "$VERSION_CODENAME" == "jammy" ]; then
     sudo ./llvm.sh 14
+    for tool in "clang" "llc" "llvm-strip" "opt" "llvm-dis"; do
+        sudo rm -f /usr/bin/$tool
+        sudo ln -s /usr/bin/$tool-14 /usr/bin/$tool
+    done
+else # VERSION_CODENAME == noble
+    sudo apt-get -y install llvm-14-tools
     for tool in "clang" "llc" "llvm-strip" "opt" "llvm-dis"; do
         sudo rm -f /usr/bin/$tool
         sudo ln -s /usr/bin/$tool-14 /usr/bin/$tool
@@ -39,7 +45,7 @@ else # VERSION_CODENAME == jammy
 fi
 
 # install libbpf-dev
-if [ "$VERSION_CODENAME" == "jammy" ]; then
+if [ "$VERSION_CODENAME" == "jammy" ] || [ "$VERSION_CODENAME" == "noble" ]; then
     sudo apt-get -y install libbpf-dev
 fi
 


### PR DESCRIPTION
**Purpose of PR?**:

Fixes #1755

LLVM tools are not installed successfully on `Ubuntu 24.04` via `sudo ./llvm.sh 14` because of no available release channel. They need to be installed via the `llvm-14-tools` package.

**Does this PR introduce a breaking change?**
No

**If the changes in this PR are manually verified, list down the scenarios covered:**:

**Additional information for reviewer?** :
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [x] Bug fix. Fixes #1755 
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`

<!--

The PR title message must follow convention:
`<type>(<scope>): <subject>`.

Where: <br />
- `type` is to define what type of PR is this.
  Most common types are:
    - `feat`      - for new features, not a new feature for build script
    - `fix`       - for bug fixes or improvements, not a fix for build script
    - `chore`     - changes not related to production code
    - `docs`      - changes related to documentation
    - `style`     - formatting, missing semi colons, linting fix etc; no significant production code changes
    - `test`      - adding missing tests, refactoring tests; no production code change
    - `refactor`  - refactoring production code, eg. renaming a variable or function name, there should not be any significant production code changes

- `scope` is a single word that best describes where the changes fit.
    - feature(`monitor`,`enforcer`)
    - test(`tests`, `bdd`)
    - chore(`build`)
- `subject` is a single line brief description of the changes made in the pull request.

-->