### PR TITLE
fix(core):timeout when host & cluster security policies crds are not found

### DIFF
--- a/KubeArmor/core/kubeArmor.go
+++ b/KubeArmor/core/kubeArmor.go
@@ -708,8 +708,8 @@ func KubeArmor() {
 
 	// == //
 
+	timeout, err := time.ParseDuration(cfg.GlobalCfg.InitTimeout)
 	if dm.K8sEnabled && cfg.GlobalCfg.Policy {
-		timeout, err := time.ParseDuration(cfg.GlobalCfg.InitTimeout)
 		if err != nil {
 			dm.Logger.Warnf("Not a valid InitTimeout duration: %q, defaulting to '60s'", cfg.GlobalCfg.InitTimeout)
 			timeout = 60 * time.Second
@@ -726,14 +726,12 @@ func KubeArmor() {
 		dm.Logger.Print("Started to monitor security policies")
 
 		// watch cluster security policies
-		clusterSecurityPoliciesSynced := dm.WatchClusterSecurityPolicies()
+		clusterSecurityPoliciesSynced := dm.WatchClusterSecurityPolicies(timeout)
 		if clusterSecurityPoliciesSynced == nil {
-			// destroy the daemon
-			dm.DestroyKubeArmorDaemon()
-
-			return
+			dm.Logger.Warn("error while monitoring cluster security policies, informer cache not synced")
+		} else {
+			dm.Logger.Print("Started to monitor cluster security policies")
 		}
-		dm.Logger.Print("Started to monitor cluster security policies")
 
 		// watch default posture
 		defaultPostureSynced := dm.WatchDefaultPosture()
@@ -776,8 +774,7 @@ func KubeArmor() {
 
 	if dm.K8sEnabled && cfg.GlobalCfg.HostPolicy {
 		// watch host security policies
-		go dm.WatchHostSecurityPolicies()
-		dm.Logger.Print("Started to monitor host security policies")
+		go dm.WatchHostSecurityPolicies(timeout)
 	}
 
 	if !dm.K8sEnabled && (enableContainerPolicy || cfg.GlobalCfg.HostPolicy) {


### PR DESCRIPTION
**Purpose of PR?**:
in case host & cluster security policies crds are not found, we should timeout rather then infinitely looking for them and ultimately destroying kubearmor daemon.

Fixes #

**Does this PR introduce a breaking change?**
no

**If the changes in this PR are manually verified, list down the scenarios covered:**:

**Additional information for reviewer?** :
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [x] Bug fix. Fixes #<issue number>
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Commit has unit tests
- [ ] Commit has integration tests

<!--

The PR title message must follow convention:
`<type>(<scope>): <subject>`.

Where: <br />
- `type` is to define what type of PR is this.
  Most common types are:
    - `feat`      - for new features, not a new feature for build script
    - `fix`       - for bug fixes or improvements, not a fix for build script
    - `chore`     - changes not related to production code
    - `docs`      - changes related to documentation
    - `style`     - formatting, missing semi colons, linting fix etc; no significant production code changes
    - `test`      - adding missing tests, refactoring tests; no production code change
    - `refactor`  - refactoring production code, eg. renaming a variable or function name, there should not be any significant production code changes

- `scope` is a single word that best describes where the changes fit.
    - feature(`monitor`,`enforcer`)
    - test(`tests`, `bdd`)
    - chore(`build`)
- `subject` is a single line brief description of the changes made in the pull request.

-->