### PR TITLE
Support for un-orchestrated containerd containers

### DIFF
--- a/KubeArmor/core/containerdHandler.go
+++ b/KubeArmor/core/containerdHandler.go
@@ -24,6 +24,7 @@ import (
 	tp "github.com/kubearmor/KubeArmor/KubeArmor/types"
 
 	pb "github.com/containerd/containerd/api/services/containers/v1"
+	nm "github.com/containerd/containerd/api/services/namespaces/v1"
 	pt "github.com/containerd/containerd/api/services/tasks/v1"
 	"github.com/containerd/containerd/namespaces"
 	"google.golang.org/grpc"
@@ -57,6 +58,7 @@ var defaultCaps = []string{
 
 // Containerd Handler
 var Containerd *ContainerdHandler
+var IsK8sEnabled bool
 
 // init Function
 func init() {
@@ -75,6 +77,9 @@ type ContainerdHandler struct {
 	// connection
 	conn *grpc.ClientConn
 
+	//namespace client
+	namespacesClient nm.NamespacesClient
+
 	// container client
 	client pb.ContainersClient
 
@@ -82,7 +87,7 @@ type ContainerdHandler struct {
 	taskClient pt.TasksClient
 
 	// context
-	containerd context.Context
+	containerd []context.Context
 	docker     context.Context
 
 	// active containers
@@ -99,6 +104,8 @@ func NewContainerdHandler() *ContainerdHandler {
 	}
 
 	ch.conn = conn
+	// namespace client
+	ch.namespacesClient = nm.NewNamespacesClient(conn)
 
 	// container client
 	ch.client = pb.NewContainersClient(ch.conn)
@@ -109,8 +116,20 @@ func NewContainerdHandler() *ContainerdHandler {
 	// docker namespace
 	ch.docker = namespaces.WithNamespace(context.Background(), "moby")
 
-	// containerd namespace
-	ch.containerd = namespaces.WithNamespace(context.Background(), "k8s.io")
+	// Get the list of namespaces
+	ctx := context.Background()
+	listedNamespaces, err := ch.namespacesClient.List(ctx, &nm.ListNamespacesRequest{})
+	if err != nil {
+		return nil
+	}
+
+	if !IsK8sEnabled {
+		for _, namespace := range listedNamespaces.Namespaces {
+			ch.containerd = append(ch.containerd, namespaces.WithNamespace(context.Background(), namespace.Name))
+		}
+	} else {
+		ch.containerd = append(ch.containerd, namespaces.WithNamespace(context.Background(), "k8s.io"))
+	}
 
 	// active containers
 	ch.containers = map[string]context.Context{}
@@ -146,7 +165,11 @@ func (ch *ContainerdHandler) GetContainerInfo(ctx context.Context, containerID s
 	// == container base == //
 
 	container.ContainerID = res.Container.ID
-	container.ContainerName = res.Container.ID
+	if val, ok := res.Container.Labels["nerdctl/name"]; ok {
+		container.ContainerName = val
+	} else {
+		container.ContainerName = res.Container.ID
+	}
 	container.NamespaceName = "Unknown"
 	container.EndPointName = "Unknown"
 
@@ -253,9 +276,11 @@ func (ch *ContainerdHandler) GetContainerdContainers() map[string]context.Contex
 		}
 	}
 
-	if containerList, err := ch.client.List(ch.containerd, &req, grpc.MaxCallRecvMsgSize(kl.DefaultMaxRecvMaxSize)); err == nil {
-		for _, container := range containerList.Containers {
-			containers[container.ID] = ch.containerd
+	for _, containerdContext := range ch.containerd {
+		if containerList, err := ch.client.List(containerdContext, &req, grpc.MaxCallRecvMsgSize(kl.DefaultMaxRecvMaxSize)); err == nil {
+			for _, container := range containerList.Containers {
+				containers[container.ID] = containerdContext
+			}
 		}
 	}
 
@@ -289,6 +314,34 @@ func (ch *ContainerdHandler) GetDeletedContainerdContainers(containers map[strin
 	ch.containers = containers
 
 	return deletedContainers
+}
+
+// SetContainerVisibility function enables visibility flag arguments for un-orchestrated container
+func (dm *KubeArmorDaemon) SetContainerdVisibility(ctx context.Context, containerID string) {
+
+	// get container information from docker client
+	container, err := Containerd.GetContainerInfo(ctx, containerID, dm.OwnerInfo)
+	if err != nil {
+		return
+	}
+
+	if strings.Contains(cfg.GlobalCfg.Visibility, "process") {
+		container.ProcessVisibilityEnabled = true
+	}
+	if strings.Contains(cfg.GlobalCfg.Visibility, "file") {
+		container.FileVisibilityEnabled = true
+	}
+	if strings.Contains(cfg.GlobalCfg.Visibility, "network") {
+		container.NetworkVisibilityEnabled = true
+	}
+	if strings.Contains(cfg.GlobalCfg.Visibility, "capabilities") {
+		container.CapabilitiesVisibilityEnabled = true
+	}
+
+	container.EndPointName = container.ContainerName
+	container.NamespaceName = "container_namespace"
+
+	dm.Containers[container.ContainerID] = container
 }
 
 // UpdateContainerdContainer Function
@@ -455,6 +508,13 @@ func (dm *KubeArmorDaemon) UpdateContainerdContainer(ctx context.Context, contai
 			return false
 		}
 
+		if !dm.K8sEnabled {
+			dm.ContainersLock.Lock()
+			dm.SetContainerdVisibility(ctx, containerID)
+			container = dm.Containers[containerID]
+			dm.ContainersLock.Unlock()
+		}
+
 		if dm.SystemMonitor != nil && cfg.GlobalCfg.Policy {
 			// for throttling
 			dm.SystemMonitor.Logger.ContainerNsKey[containerID] = common.OuterKey{
@@ -554,6 +614,12 @@ func (dm *KubeArmorDaemon) UpdateContainerdContainer(ctx context.Context, contai
 func (dm *KubeArmorDaemon) MonitorContainerdEvents() {
 	dm.WgDaemon.Add(1)
 	defer dm.WgDaemon.Done()
+
+	if !dm.K8sEnabled {
+		IsK8sEnabled = false
+	} else {
+		IsK8sEnabled = true
+	}
 
 	Containerd = NewContainerdHandler()
 


### PR DESCRIPTION
**Purpose of PR?**:
When it comes to unorchestrated or non-kubernetes containers, right now KubeArmor works the best only with Docker runtime but not for containerd runtime,this PR fixes the issue related to monitoring and enforcement of containerd containers

Fixes #1426 

**Does this PR introduce a breaking change?**
No

Apply this policy to a contianerd container
```
apiVersion: security.kubearmor.com/v1
kind: KubeArmorPolicy
metadata:
  name: ksp-block-policy
spec:
  severity: 3
  selector:
    matchLabels:
      kubearmor.io/container.name: nerdctl-nginx-jul-21
  process:
    matchPaths:
    - path: /usr/bin/ls
    - path: /usr/bin/sleep
    - path: /usr/bin/curl
  action:
    Block
```
It blocks showing enforcement
![image](https://github.com/user-attachments/assets/2e5e9915-9ab1-4327-8198-7ac6a0b59dfe)

**Checklist:**
- [ ] Bug fix. Fixes #1426 
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Commit has unit tests
- [ ] Commit has integration tests

<!--

The PR title message must follow convention:
`<type>(<scope>): <subject>`.

Where: <br />
- `type` is to define what type of PR is this.
  Most common types are:
    - `feat`      - for new features, not a new feature for build script
    - `fix`       - for bug fixes or improvements, not a fix for build script
    - `chore`     - changes not related to production code
    - `docs`      - changes related to documentation
    - `style`     - formatting, missing semi colons, linting fix etc; no significant production code changes
    - `test`      - adding missing tests, refactoring tests; no production code change
    - `refactor`  - refactoring production code, eg. renaming a variable or function name, there should not be any significant production code changes

- `scope` is a single word that best describes where the changes fit.
    - feature(`monitor`,`enforcer`)
    - test(`tests`, `bdd`)
    - chore(`build`)
- `subject` is a single line brief description of the changes made in the pull request.

-->