### PR TITLE
Set initDeploy to false by default

### DIFF
--- a/deployments/helm/KubeArmorOperator/values.yaml
+++ b/deployments/helm/KubeArmorOperator/values.yaml
@@ -45,6 +45,7 @@ kubearmorOperator:
   podAnnotations: {}
   podSecurityContext: {}
   securityContext: {}
+  initDeploy: false
 
 kubearmorConfig:
   defaultCapabilitiesPosture: audit

--- a/pkg/KubeArmorOperator/cmd/operator/main.go
+++ b/pkg/KubeArmorOperator/cmd/operator/main.go
@@ -87,8 +87,7 @@ func init() {
 	Cmd.PersistentFlags().StringVar(&ProviderHostname, "providerHostname", "", "IMDS URL hostname for retrieving cluster name")
 	Cmd.PersistentFlags().StringVar(&ProviderEndpoint, "providerEndpoint", "", "IMDS URL endpoint for retrieving cluster name")
 	// TODO:- set initDeploy to false by default once this change is added to stable
-	Cmd.PersistentFlags().BoolVar(&InitDeploy, "initDeploy", true, "Init container deployment")
-	Cmd.PersistentFlags().StringVar(&LogLevel, "loglevel", "info", "log level, e.g., debug, info, warn, error")
+	Cmd.PersistentFlags().BoolVar(&InitDeploy, "initDeploy", false, "Init container deployment")
 	Cmd.PersistentFlags().BoolVar(&AnnotateResource, "annotateResource", false, "when true kubearmor annotate k8s resources with apparmor annotation")
 	Cmd.PersistentFlags().BoolVar(&AnnotateExisting, "annotateExisting", false, "when true kubearmor-controller restarts and annotates existing resources, with required annotations")
 


### PR DESCRIPTION
**Purpose of PR?**:

As, now we have a stable release with bpf core changes we can set `initdeploy` flag to false by default
Note:- all kubearmor images before `1.4.0` would still require init container

**Does this PR introduce a breaking change?**

**If the changes in this PR are manually verified, list down the scenarios covered:**:

**Additional information for reviewer?** :
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [ ] Bug fix. Fixes #<issue number>
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Commit has unit tests
- [ ] Commit has integration tests

<!--

The PR title message must follow convention:
`<type>(<scope>): <subject>`.

Where: <br />
- `type` is to define what type of PR is this.
  Most common types are:
    - `feat`      - for new features, not a new feature for build script
    - `fix`       - for bug fixes or improvements, not a fix for build script
    - `chore`     - changes not related to production code
    - `docs`      - changes related to documentation
    - `style`     - formatting, missing semi colons, linting fix etc; no significant production code changes
    - `test`      - adding missing tests, refactoring tests; no production code change
    - `refactor`  - refactoring production code, eg. renaming a variable or function name, there should not be any significant production code changes

- `scope` is a single word that best describes where the changes fit.
    - feature(`monitor`,`enforcer`)
    - test(`tests`, `bdd`)
    - chore(`build`)
- `subject` is a single line brief description of the changes made in the pull request.

-->