### PR TITLE
 fix(core): ensure only cluster policy is updated on new ns

### DIFF
--- a/KubeArmor/core/kubeUpdate.go
+++ b/KubeArmor/core/kubeUpdate.go
@@ -960,6 +960,11 @@ func (dm *KubeArmorDaemon) WatchK8sPods() {
 }
 
 func matchClusterSecurityPolicyRule(policy tp.SecurityPolicy) bool {
+
+	if len(policy.Spec.Selector.Identities) > 0 { // if is not a Cluster policy
+		return false
+	}
+
 	hasInOperator := false
 	excludedNamespaces := make(map[string]bool)
 


### PR DESCRIPTION
Regular policies are mistakenly modified and applied at cluster level over time

**Purpose of PR?**:

Fixes: #1840

**Does this PR introduce a breaking change?** No

**If the changes in this PR are manually verified, list down the scenarios covered:**:
Built and deployed, and verified that the policy is not applied on different namespaces or even the same namespace with no matching labels.


**Additional information for reviewer?** :


**Checklist:**
- [x] Bug fix. Fixes #1840
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Commit has unit tests
- [ ] Commit has integration tests

<!--

The PR title message must follow convention:
`<type>(<scope>): <subject>`.

Where: <br />
- `type` is to define what type of PR is this.
  Most common types are:
    - `feat`      - for new features, not a new feature for build script
    - `fix`       - for bug fixes or improvements, not a fix for build script
    - `chore`     - changes not related to production code
    - `docs`      - changes related to documentation
    - `style`     - formatting, missing semi colons, linting fix etc; no significant production code changes
    - `test`      - adding missing tests, refactoring tests; no production code change
    - `refactor`  - refactoring production code, eg. renaming a variable or function name, there should not be any significant production code changes

- `scope` is a single word that best describes where the changes fit.
    - feature(`monitor`,`enforcer`)
    - test(`tests`, `bdd`)
    - chore(`build`)
- `subject` is a single line brief description of the changes made in the pull request.

-->