### PR TITLE
refactor(operator): remove config empty check

### DIFF
--- a/KubeArmor/core/kubeUpdate.go
+++ b/KubeArmor/core/kubeUpdate.go
@@ -2739,13 +2739,17 @@ func (dm *KubeArmorDaemon) WatchConfigMap() cache.InformerSynced {
 				if _, ok := cm.Data[cfg.ConfigAlertThrottling]; ok {
 					cfg.GlobalCfg.AlertThrottling = (cm.Data[cfg.ConfigAlertThrottling] == "true")
 				}
-				cfg.GlobalCfg.MaxAlertPerSec, err = strconv.Atoi(cm.Data[cfg.ConfigMaxAlertPerSec])
-				if err != nil {
-					dm.Logger.Warnf("Error: %s", err)
+				if _, ok := cm.Data[cfg.ConfigMaxAlertPerSec]; ok {
+					cfg.GlobalCfg.MaxAlertPerSec, err = strconv.Atoi(cm.Data[cfg.ConfigMaxAlertPerSec])
+					if err != nil {
+						dm.Logger.Warnf("Error: %s", err)
+					}
 				}
-				cfg.GlobalCfg.ThrottleSec, err = strconv.Atoi(cm.Data[cfg.ConfigThrottleSec])
-				if err != nil {
-					dm.Logger.Warnf("Error: %s", err)
+				if _, ok := cm.Data[cfg.ConfigMaxAlertPerSec]; ok {
+					cfg.GlobalCfg.ThrottleSec, err = strconv.Atoi(cm.Data[cfg.ConfigThrottleSec])
+					if err != nil {
+						dm.Logger.Warnf("Error: %s", err)
+					}
 				}
 				dm.SystemMonitor.UpdateThrottlingConfig()
 

--- a/pkg/KubeArmorOperator/common/defaults.go
+++ b/pkg/KubeArmorOperator/common/defaults.go
@@ -119,6 +119,11 @@ var (
 	KubeArmorRelayServerSecretName string   = "kubearmor-relay-server-certs"
 	DefaultTlsCertPath             string   = "/var/lib/kubearmor/tls"
 	DefaultMode                    int32    = 420 // deciaml representation of octal value 644
+
+	// throttling
+	AlertThrottling       bool   = true
+	DefaultMaxAlertPerSec string = "10"
+	DefaultThrottleSec    string = "30"
 )
 
 var ConfigMapData = map[string]string{

--- a/pkg/KubeArmorOperator/internal/controller/cluster.go
+++ b/pkg/KubeArmorOperator/internal/controller/cluster.go
@@ -806,25 +806,19 @@ func UpdateConfigMapData(config *opv1.KubeArmorConfigSpec) bool {
 		}
 	}
 	AlertThrottlingEnabled := strconv.FormatBool(config.AlertThrottling)
-	if AlertThrottlingEnabled != "" {
-		if common.ConfigMapData[common.ConfigAlertThrottling] != AlertThrottlingEnabled {
-			common.ConfigMapData[common.ConfigAlertThrottling] = AlertThrottlingEnabled
-			updated = true
-		}
+	if common.ConfigMapData[common.ConfigAlertThrottling] != AlertThrottlingEnabled {
+		common.ConfigMapData[common.ConfigAlertThrottling] = AlertThrottlingEnabled
+		updated = true
 	}
 	MaxAlertPerSec := strconv.FormatInt(int64(config.MaxAlertPerSec), 10)
-	if MaxAlertPerSec != "" {
-		if common.ConfigMapData[common.ConfigMaxAlertPerSec] != MaxAlertPerSec {
-			common.ConfigMapData[common.ConfigMaxAlertPerSec] = MaxAlertPerSec
-			updated = true
-		}
+	if common.ConfigMapData[common.ConfigMaxAlertPerSec] != MaxAlertPerSec {
+		common.ConfigMapData[common.ConfigMaxAlertPerSec] = MaxAlertPerSec
+		updated = true
 	}
 	ThrottleSec := strconv.FormatInt(int64(config.ThrottleSec), 10)
-	if MaxAlertPerSec != "" {
-		if common.ConfigMapData[common.ConfigThrottleSec] != ThrottleSec {
-			common.ConfigMapData[common.ConfigThrottleSec] = ThrottleSec
-			updated = true
-		}
+	if common.ConfigMapData[common.ConfigThrottleSec] != ThrottleSec {
+		common.ConfigMapData[common.ConfigThrottleSec] = ThrottleSec
+		updated = true
 	}
 
 	return updated

--- a/pkg/KubeArmorOperator/internal/controller/cluster.go
+++ b/pkg/KubeArmorOperator/internal/controller/cluster.go
@@ -811,16 +811,22 @@ func UpdateConfigMapData(config *opv1.KubeArmorConfigSpec) bool {
 		updated = true
 	}
 	MaxAlertPerSec := strconv.FormatInt(int64(config.MaxAlertPerSec), 10)
+	if config.MaxAlertPerSec == 0 {
+		MaxAlertPerSec = common.DefaultMaxAlertPerSec
+	}
 	if common.ConfigMapData[common.ConfigMaxAlertPerSec] != MaxAlertPerSec {
 		common.ConfigMapData[common.ConfigMaxAlertPerSec] = MaxAlertPerSec
 		updated = true
 	}
+
 	ThrottleSec := strconv.FormatInt(int64(config.ThrottleSec), 10)
+	if config.ThrottleSec == 0 {
+		ThrottleSec = common.DefaultThrottleSec
+	}
 	if common.ConfigMapData[common.ConfigThrottleSec] != ThrottleSec {
 		common.ConfigMapData[common.ConfigThrottleSec] = ThrottleSec
 		updated = true
 	}
-
 	return updated
 }
 


### PR DESCRIPTION
The config elements, though optional, are not ptr, so they are initialized with the respective type default values. As result, strconv.Format... will never return an empty string, so the check is unnecessary. I also found that the setting of ThrottleSec was depending on MaxAlertPerSec, but because that one is never empty, the dependency wasn't actually effective anyways.

**Purpose of PR?**:

Clean up

**Does this PR introduce a breaking change?** No

**If the changes in this PR are manually verified, list down the scenarios covered:**:

**Additional information for reviewer?** :

I stumbled into this code while troubleshooting something else. This is a clean up and doesn't impact existing logic.


**Checklist:**
- [ ] Bug fix. Fixes #<issue number>
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Commit has unit tests
- [ ] Commit has integration tests

<!--

The PR title message must follow convention:
`<type>(<scope>): <subject>`.

Where: <br />
- `type` is to define what type of PR is this.
  Most common types are:
    - `feat`      - for new features, not a new feature for build script
    - `fix`       - for bug fixes or improvements, not a fix for build script
    - `chore`     - changes not related to production code
    - `docs`      - changes related to documentation
    - `style`     - formatting, missing semi colons, linting fix etc; no significant production code changes
    - `test`      - adding missing tests, refactoring tests; no production code change
    - `refactor`  - refactoring production code, eg. renaming a variable or function name, there should not be any significant production code changes

- `scope` is a single word that best describes where the changes fit.
    - feature(`monitor`,`enforcer`)
    - test(`tests`, `bdd`)
    - chore(`build`)
- `subject` is a single line brief description of the changes made in the pull request.

-->