### PR TITLE
refactor(tests): replace K8sExecInPod with AssertCommand for consistency in test assertions

### DIFF
--- a/tests/k8s_env/blockposture/block_test.go
+++ b/tests/k8s_env/blockposture/block_test.go
@@ -73,11 +73,10 @@ var _ = Describe("Posture", func() {
 				wp, "wordpress-mysql", []string{"bash", "-c", "curl google.com"},
 				MatchRegexp("curl.*Could not resolve host: google.com"), true,
 			)
-
-			out, _, err := K8sExecInPod(wp, "wordpress-mysql", []string{"bash", "-c", "curl 142.250.193.46"})
-			Expect(err).To(BeNil())
-			fmt.Printf("---START---\n%s---END---\n", out)
-			Expect(out).To(MatchRegexp("<HTML>((?:.*\r?\n?)*)</HTML>"))
+			AssertCommand(
+				wp, "wordpress-mysql", []string{"bash", "-c", "curl 142.250.193.46"}, 
+				MatchRegexp("<HTML>((?:.*\r?\n?)*)</HTML>"), false,
+			)
 			// check policy violation alert
 			_, alerts, err := KarmorGetLogs(5*time.Second, 1)
 			Expect(err).To(BeNil())
@@ -101,16 +100,15 @@ var _ = Describe("Posture", func() {
 			Expect(err).To(BeNil())
 
 			//curl needs UDP for DNS resolution
-			sout, _, err := K8sExecInPod(wp, "wordpress-mysql", []string{"bash", "-c", "cat wp-config.php"})
-			Expect(err).To(BeNil())
-			fmt.Printf("---START---\n%s---END---\n", sout)
-			Expect(sout).To(MatchRegexp("cat.*Permission denied"))
-
+			AssertCommand(
+				wp, "wordpress-mysql", []string{"bash", "-c", "cat wp-config.php"}, 
+				MatchRegexp("cat.*Permission denied"), false,
+			)
 			//test that tcp is whitelisted
-			out, _, err := K8sExecInPod(wp, "wordpress-mysql", []string{"bash", "-c", "cat readme.html"})
-			Expect(err).To(BeNil())
-			fmt.Printf("---START---\n%s---END---\n", out)
-			Expect(out).To(MatchRegexp("<!DOCTYPE html>((?:.*\r?\n?)*)</html>"))
+			AssertCommand(
+				wp, "wordpress-mysql", []string{"bash", "-c", "cat readme.html"}, 
+				MatchRegexp("<!DOCTYPE html>((?:.*\r?\n?)*)</html>"), false,
+			)
 			// check policy violation alert
 			_, alerts, err := KarmorGetLogs(5*time.Second, 1)
 			Expect(err).To(BeNil())

--- a/tests/k8s_env/ksp/ksp_test.go
+++ b/tests/k8s_env/ksp/ksp_test.go
@@ -84,9 +84,10 @@ var _ = Describe("Ksp", func() {
 			err = KarmorLogStart("all", "nginx", "", pods.Items[0].Name)
 			Expect(err).To(BeNil())
 
-			sout, _, err := K8sExecInPod(pods.Items[0].Name, "nginx", []string{"ls"})
-			Expect(err).To(BeNil())
-			fmt.Printf("---START---\n%s---END---\n", sout)
+			AssertCommand(
+				pods.Items[0].Name, "nginx", []string{"ls"}, 
+			        MatchRegexp(".*"), false,
+			)
 
 			// check audit logs
 			logs, _, err := KarmorGetLogs(5*time.Second, 50)
@@ -110,12 +111,10 @@ var _ = Describe("Ksp", func() {
 			err = KarmorLogStart("policy", "multiubuntu", "Network", ub1)
 			Expect(err).To(BeNil())
 
-			sout, _, err := K8sExecInPod(ub1, "multiubuntu",
-				[]string{"bash", "-c", "ping -c 1 127.0.0.1"})
-			Expect(err).To(BeNil())
-			fmt.Printf("OUTPUT: %s\n", sout)
-			Expect(sout).To(MatchRegexp("PING.*127.0.0.1"))
-
+			AssertCommand(
+				ub1, "multiubuntu", []string{"bash", "-c", "ping -c 1 127.0.0.1"}, 
+				MatchRegexp("PING.*127.0.0.1"), false,
+			)
 			expect := protobuf.Alert{
 				PolicyName: "ksp-ubuntu-1-audit-net-icmp",
 				Severity:   "8",
@@ -220,11 +219,10 @@ var _ = Describe("Ksp", func() {
 			err = KarmorLogStart("policy", "multiubuntu", "Network", ub1)
 			Expect(err).To(BeNil())
 
-			sout, _, err := K8sExecInPod(ub1, "multiubuntu",
-				[]string{"bash", "-c", "arping -c 1 127.0.0.1"})
-			Expect(err).To(BeNil())
-			fmt.Printf("OUTPUT: %s\n", sout)
-			Expect(sout).To(MatchRegexp("ARPING 127.0.0.1"))
+			AssertCommand(
+				ub1, "multiubuntu", []string{"bash", "-c", "arping -c 1 127.0.0.1"}, 
+				MatchRegexp("ARPING 127.0.0.1"), false,
+			)
 
 			expect := protobuf.Alert{
 				PolicyName: "ksp-ubuntu-1-audit-net-raw",
@@ -396,10 +394,10 @@ var _ = Describe("Ksp", func() {
 			err = KarmorLogStart("policy", "multiubuntu", "Process", ub4)
 			Expect(err).To(BeNil())
 
-			sout, _, err := K8sExecInPod(ub4, "multiubuntu",
-				[]string{"bash", "-c", "sleep 1"})
-			Expect(err).To(BeNil())
-			fmt.Printf("OUTPUT: %s\n", sout)
+			AssertCommand(
+				ub4, "multiubuntu", []string{"bash", "-c", "sleep 1"}, 
+				MatchRegexp(""), false,
+			)
 
 			expect := protobuf.Alert{
 				PolicyName: "ksp-group-2-audit-proc-path",
@@ -603,11 +601,10 @@ var _ = Describe("Ksp", func() {
 			AssertCommand(ub3, "multiubuntu", []string{"bash", "-c", "/home/user1/hello"},
 				MatchRegexp("hello.*Permission denied"), true,
 			)
-			sout, _, err := K8sExecInPod(ub3, "multiubuntu",
-				[]string{"bash", "-c", "/home/user1/hello"})
-			Expect(err).To(BeNil())
-			fmt.Printf("OUTPUT: %s\n", sout)
-			Expect(sout).To(MatchRegexp("hello.*Permission denied"))
+			AssertCommand(
+				ub3, "multiubuntu", []string{"bash", "-c", "/home/user1/hello"}, 
+				MatchRegexp("hello.*Permission denied"), false,
+			)
 
 			expect := protobuf.Alert{
 				PolicyName: "ksp-ubuntu-3-block-proc-path-owner",
@@ -908,10 +905,10 @@ var _ = Describe("Ksp", func() {
 			err = KarmorLogStart("policy", "multiubuntu", "File", ub1)
 			Expect(err).To(BeNil())
 
-			sout, _, err := K8sExecInPod(ub1, "multiubuntu",
-				[]string{"bash", "-c", "touch  /home/user1/new1"})
-			Expect(err).To(BeNil())
-			fmt.Printf("OUTPUT: %s\n", sout)
+			AssertCommand(
+				ub1, "multiubuntu", []string{"bash", "-c", "touch /home/user1/new1"}, 
+				MatchRegexp(".*"), false,
+			)
 
 			expect := protobuf.Alert{
 				PolicyName: "ksp-ubuntu-1-audit-file-access-owner-readonly",
@@ -1488,10 +1485,11 @@ var _ = Describe("Ksp", func() {
 			err = KarmorLogStart("system", "multiubuntu", "File", ub4)
 			Expect(err).To(BeNil())
 
-			sout, _, err := K8sExecInPod(ub4, "multiubuntu",
-				[]string{"bash", "-c", "su - user1 -c 'cat /home/user1/secret_data1.txt'"})
-			Expect(err).To(BeNil())
-			fmt.Printf("OUTPUT: %s\n", sout)
+			AssertCommand(
+				ub4, "multiubuntu", []string{"bash", "-c", "su - user1 -c 'cat /home/user1/secret_data1.txt'"}, 
+				MatchRegexp(".*"), false,
+			)
+
 			// Expect(sout).To(ContainSubstring("secret file user1"))
 
 			expectLog := protobuf.Log{
@@ -1605,10 +1603,10 @@ var _ = Describe("Ksp", func() {
 
 			// Test 3: write operation on the file by the owner should also be allowed
 			// No need for AssertCommand here since there is nothing to match
-			sout, _, err := K8sExecInPod(ub3, "multiubuntu",
-				[]string{"bash", "-c", "su - user1 -c 'echo user1 >> /home/user1/secret_data1.txt'"})
-			Expect(err).To(BeNil())
-			fmt.Printf("OUTPUT: %s\n", sout)
+			AssertCommand(
+				ub3, "multiubuntu", []string{"bash", "-c", "su - user1 -c 'echo user1 >> /home/user1/secret_data1.txt'"}, 
+				MatchRegexp(".*"), false,
+			)
 
 		})
 
@@ -1667,11 +1665,10 @@ var _ = Describe("Ksp", func() {
 			err = KarmorLogStart("system", "multiubuntu", "File", ub4)
 			Expect(err).To(BeNil())
 
-			sout, _, err := K8sExecInPod(ub4, "multiubuntu",
-				[]string{"bash", "-c", "./readwrite -r /secret.txt"})
-			Expect(err).To(BeNil())
-			fmt.Printf("OUTPUT: %s\n", sout)
-			Expect(sout).To(ContainSubstring("s"))
+			AssertCommand(
+				ub4, "multiubuntu", []string{"bash", "-c", "./readwrite -r /secret.txt"}, 
+				MatchRegexp("s"), false,
+			)
 
 			expectLog = protobuf.Log{
 				Resource: "secret.txt",
@@ -1705,10 +1702,10 @@ var _ = Describe("Ksp", func() {
 			err = KarmorLogStart("policy", "multiubuntu", "File", ub4)
 			Expect(err).To(BeNil())
 
-			sout, _, err := K8sExecInPod(ub4, "multiubuntu",
-				[]string{"bash", "-c", "./readwrite -w /credentials/password"})
-			Expect(err).To(BeNil())
-			fmt.Printf("OUTPUT: %s\n", sout)
+			AssertCommand(
+				ub4, "multiubuntu", []string{"bash", "-c", "./readwrite -w /credentials/password"}, 
+				MatchRegexp(".*"), false,
+			)
 
 			expect := protobuf.Alert{
 				PolicyName: "DefaultPosture",
@@ -1724,10 +1721,10 @@ var _ = Describe("Ksp", func() {
 
 			// Test 3: reading some other file should be denied as not allowed by the policy
 
-			sout, _, err = K8sExecInPod(ub4, "multiubuntu",
-				[]string{"bash", "-c", "./readwrite -r /secret.txt"})
-			Expect(err).To(BeNil())
-			fmt.Printf("OUTPUT: %s\n", sout)
+			AssertCommand(
+				ub4, "multiubuntu", []string{"bash", "-c", "./readwrite -r /secret.txt"}, 
+				MatchRegexp(".*"), false,
+			)
 
 			expect = protobuf.Alert{
 				PolicyName: "DefaultPosture",
@@ -1806,10 +1803,10 @@ var _ = Describe("Ksp", func() {
 			err = KarmorLogStart("policy", "multiubuntu", "File", ub4)
 			Expect(err).To(BeNil())
 
-			sout, _, err := K8sExecInPod(ub4, "multiubuntu",
-				[]string{"bash", "-c", "touch /dev/shm/new"})
-			Expect(err).To(BeNil())
-			fmt.Printf("OUTPUT: %s\n", sout)
+			AssertCommand(
+				ub4, "multiubuntu", []string{"bash", "-c", "touch /dev/shm/new"}, 
+				MatchRegexp(".*"), false,
+			)
 
 			expect := protobuf.Alert{
 				PolicyName: "ksp-ubuntu-4-audit-file-path-readonly",
@@ -1982,11 +1979,11 @@ var _ = Describe("Ksp", func() {
 			err = KarmorLogStart("system", "multiubuntu", "File", ub4)
 			Expect(err).To(BeNil())
 
-			sout, _, err := K8sExecInPod(ub4, "multiubuntu",
-				[]string{"bash", "-c", "cat /credentials/password"})
-			Expect(err).To(BeNil())
-			fmt.Printf("OUTPUT: %s\n", sout)
-			Expect(sout).To(ContainSubstring("password file"))
+			AssertCommand(
+				ub4, "multiubuntu", []string{"bash", "-c", "cat /credentials/password"}, 
+				ContainSubstring("password file"), false,
+			)
+
 		})
 
 	})

--- a/tests/k8s_env/syscalls/syscalls_test.go
+++ b/tests/k8s_env/syscalls/syscalls_test.go
@@ -4,7 +4,6 @@
 package syscalls
 
 import (
-	"fmt"
 	"time"
 
 	"github.com/kubearmor/KubeArmor/protobuf"
@@ -58,10 +57,14 @@ var _ = Describe("Syscalls", func() {
 			err = KarmorLogStart("policy", "syscalls", "Syscall", ubuntu)
 			Expect(err).To(BeNil())
 
-			_, _, err = K8sExecInPod(ubuntu, "syscalls", []string{"bash", "-c", "touch /dummy"})
-			Expect(err).To(BeNil())
-			_, _, err = K8sExecInPod(ubuntu, "syscalls", []string{"bash", "-c", "unlink /dummy"})
-			Expect(err).To(BeNil())
+			AssertCommand(
+				ubuntu, "syscalls", []string{"bash", "-c", "touch /dummy"}, 
+				MatchRegexp(".*"), false,
+			)
+			AssertCommand(
+				ubuntu, "syscalls", []string{"bash", "-c", "unlink /dummy"}, 
+				MatchRegexp(".*"), false,
+			)
 
 			// check policy alert
 			expect := protobuf.Alert{
@@ -86,13 +89,19 @@ var _ = Describe("Syscalls", func() {
 			err = KarmorLogStart("policy", "syscalls", "Syscall", ubuntu)
 			Expect(err).To(BeNil())
 
-			_, _, err = K8sExecInPod(ubuntu, "syscalls", []string{"bash", "-c", "cp /usr/bin/unlink /bin/unlink"})
-			Expect(err).To(BeNil())
+			AssertCommand(
+				ubuntu, "syscalls", []string{"bash", "-c", "cp /usr/bin/unlink /bin/unlink"}, 
+				MatchRegexp(".*"), false,
+			)
 
-			_, _, err = K8sExecInPod(ubuntu, "syscalls", []string{"bash", "-c", "touch /dummy"})
-			Expect(err).To(BeNil())
-			_, _, err = K8sExecInPod(ubuntu, "syscalls", []string{"bash", "-c", "/bin/unlink /dummy"})
-			Expect(err).To(BeNil())
+			AssertCommand(
+				ubuntu, "syscalls", []string{"bash", "-c", "touch /dummy"}, 
+				MatchRegexp(".*"), false,
+			)
+			AssertCommand(
+				ubuntu, "syscalls", []string{"bash", "-c", "/bin/unlink /dummy"}, 
+				MatchRegexp(".*"), false,
+			)
 
 			// check policy alert
 			expect := protobuf.Alert{
@@ -117,16 +126,25 @@ var _ = Describe("Syscalls", func() {
 			err = KarmorLogStart("policy", "syscalls", "Syscall", ubuntu)
 			Expect(err).To(BeNil())
 
-			_, _, err = K8sExecInPod(ubuntu, "syscalls", []string{"bash", "-c", "mkdir -p /foo/bar"})
-			Expect(err).To(BeNil())
+			AssertCommand(
+				ubuntu, "syscalls", []string{"bash", "-c", "mkdir -p /foo/bar"}, 
+				MatchRegexp(".*"), false,
+			)
 
-			_, _, err = K8sExecInPod(ubuntu, "syscalls", []string{"bash", "-c", "cp /usr/bin/unlink /foo/bar/unlink"})
-			Expect(err).To(BeNil())
+			AssertCommand(
+				ubuntu, "syscalls", []string{"bash", "-c", "cp /usr/bin/unlink /foo/bar/unlink"}, 
+				MatchRegexp(".*"), false,
+			)
 
-			_, _, err = K8sExecInPod(ubuntu, "syscalls", []string{"bash", "-c", "touch /dummy"})
-			Expect(err).To(BeNil())
-			_, _, err = K8sExecInPod(ubuntu, "syscalls", []string{"bash", "-c", "/foo/bar/unlink /dummy"})
-			Expect(err).To(BeNil())
+			AssertCommand(
+				ubuntu, "syscalls", []string{"bash", "-c", "touch /dummy"}, 
+				MatchRegexp(".*"), false,
+			)
+
+			AssertCommand(
+				ubuntu, "syscalls", []string{"bash", "-c", "/foo/bar/unlink /dummy"}, 
+				MatchRegexp(".*"), false,
+			)
 
 			// check policy alert
 			expect := protobuf.Alert{
@@ -151,13 +169,20 @@ var _ = Describe("Syscalls", func() {
 			err = KarmorLogStart("policy", "syscalls", "Syscall", ubuntu)
 			Expect(err).To(BeNil())
 
-			_, _, err = K8sExecInPod(ubuntu, "syscalls", []string{"bash", "-c", "cp /usr/bin/unlink /unlink"})
-			Expect(err).To(BeNil())
+			AssertCommand(
+				ubuntu, "syscalls", []string{"bash", "-c", "cp /usr/bin/unlink /unlink"}, 
+				MatchRegexp(".*"), false,
+			)
 
-			_, _, err = K8sExecInPod(ubuntu, "syscalls", []string{"bash", "-c", "touch /dummy"})
-			Expect(err).To(BeNil())
-			_, _, err = K8sExecInPod(ubuntu, "syscalls", []string{"bash", "-c", "/unlink /dummy"})
-			Expect(err).To(BeNil())
+			AssertCommand(
+				ubuntu, "syscalls", []string{"bash", "-c", "touch /dummy"}, 
+				MatchRegexp(".*"), false,
+			)
+
+			AssertCommand(
+				ubuntu, "syscalls", []string{"bash", "-c", "/unlink /dummy"}, 
+				MatchRegexp(".*"), false,
+			)
 
 			// check policy alert
 			expect := protobuf.Alert{
@@ -185,10 +210,15 @@ var _ = Describe("Syscalls", func() {
 			err = KarmorLogStart("policy", "syscalls", "Syscall", ubuntu)
 			Expect(err).To(BeNil())
 
-			_, _, err = K8sExecInPod(ubuntu, "syscalls", []string{"bash", "-c", "touch /home/dummy"})
-			Expect(err).To(BeNil())
-			_, _, err = K8sExecInPod(ubuntu, "syscalls", []string{"bash", "-c", "unlink /home/dummy"})
-			Expect(err).To(BeNil())
+			AssertCommand(
+				ubuntu, "syscalls", []string{"bash", "-c", "touch /home/dummy"}, 
+				MatchRegexp(".*"), false,
+			)
+
+			AssertCommand(
+				ubuntu, "syscalls", []string{"bash", "-c", "unlink /home/dummy"}, 
+				MatchRegexp(".*"), false,
+			)
 
 			// check policy alert
 			expect := protobuf.Alert{
@@ -213,10 +243,15 @@ var _ = Describe("Syscalls", func() {
 			err = KarmorLogStart("policy", "syscalls", "Syscall", ubuntu)
 			Expect(err).To(BeNil())
 
-			_, _, err = K8sExecInPod(ubuntu, "syscalls", []string{"bash", "-c", "touch /dummy"})
-			Expect(err).To(BeNil())
-			_, _, err = K8sExecInPod(ubuntu, "syscalls", []string{"bash", "-c", "unlink /dummy"})
-			Expect(err).To(BeNil())
+			AssertCommand(
+				ubuntu, "syscalls", []string{"bash", "-c", "touch /dummy"}, 
+				MatchRegexp(".*"), false,
+			)
+
+			AssertCommand(
+				ubuntu, "syscalls", []string{"bash", "-c", "unlink /dummy"}, 
+				MatchRegexp(".*"), false,
+			)
 
 			// check policy alert
 			expect := protobuf.Alert{
@@ -237,17 +272,24 @@ var _ = Describe("Syscalls", func() {
 			err := K8sApply([]string{"manifests/matchpaths/unlink-dir-recursive-fromsource-path.yaml"})
 			Expect(err).To(BeNil())
 
-			_, _, err = K8sExecInPod(ubuntu, "syscalls", []string{"bash", "-c", "cp /usr/bin/unlink /bin/unlink"})
-			Expect(err).To(BeNil())
+			AssertCommand(
+				ubuntu, "syscalls", []string{"bash", "-c", "cp /usr/bin/unlink /bin/unlink"}, 
+				MatchRegexp(".*"), false,
+			)
 
 			// Start Kubearmor Logs
 			err = KarmorLogStart("policy", "syscalls", "Syscall", ubuntu)
 			Expect(err).To(BeNil())
 
-			_, _, err = K8sExecInPod(ubuntu, "syscalls", []string{"bash", "-c", "touch /home/dummy"})
-			Expect(err).To(BeNil())
-			_, _, err = K8sExecInPod(ubuntu, "syscalls", []string{"bash", "-c", "/bin/unlink /home/dummy"})
-			Expect(err).To(BeNil())
+			AssertCommand(
+				ubuntu, "syscalls", []string{"bash", "-c", "touch /home/dummy"},
+    				MatchRegexp(".*"), false,
+			)		
+
+			AssertCommand(
+		    		ubuntu, "syscalls", []string{"bash", "-c", "/bin/unlink /home/dummy"},
+    				MatchRegexp(".*"), false,
+			)
 
 			// check policy alert
 			expect := protobuf.Alert{
@@ -272,10 +314,15 @@ var _ = Describe("Syscalls", func() {
 			err = KarmorLogStart("policy", "syscalls", "Syscall", ubuntu)
 			Expect(err).To(BeNil())
 
-			_, _, err = K8sExecInPod(ubuntu, "syscalls", []string{"bash", "-c", "touch /home/dummy"})
-			Expect(err).To(BeNil())
-			_, _, err = K8sExecInPod(ubuntu, "syscalls", []string{"bash", "-c", "unlink /home/dummy"})
-			Expect(err).To(BeNil())
+			AssertCommand(
+		   		ubuntu, "syscalls", []string{"bash", "-c", "touch /home/dummy"},
+    				MatchRegexp(".*"), false,
+			)
+
+			AssertCommand(
+    			ubuntu, "syscalls", []string{"bash", "-c", "/bin/unlink /home/dummy"},
+	    		MatchRegexp(".*"), false,
+			)
 
 			// check policy alert
 			expect := protobuf.Alert{
@@ -296,17 +343,24 @@ var _ = Describe("Syscalls", func() {
 			err := K8sApply([]string{"manifests/matchpaths/unlink-dir-recursive-fromsource-dir.yaml"})
 			Expect(err).To(BeNil())
 
-			_, _, err = K8sExecInPod(ubuntu, "syscalls", []string{"bash", "-c", "cp /usr/bin/unlink /bin/unlink"})
-			Expect(err).To(BeNil())
+			AssertCommand(
+		    		ubuntu, "syscalls", []string{"bash", "-c", "cp /usr/bin/unlink /bin/unlink"},
+    				MatchRegexp(".*"), false,
+			)
 
 			// Start Kubearmor Logs
 			err = KarmorLogStart("policy", "syscalls", "Syscall", ubuntu)
 			Expect(err).To(BeNil())
 
-			_, _, err = K8sExecInPod(ubuntu, "syscalls", []string{"bash", "-c", "touch /home/dummy"})
-			Expect(err).To(BeNil())
-			_, _, err = K8sExecInPod(ubuntu, "syscalls", []string{"bash", "-c", "/bin/unlink /home/dummy"})
-			Expect(err).To(BeNil())
+			AssertCommand(
+    				ubuntu, "syscalls", []string{"bash", "-c", "touch /home/dummy"},
+    				MatchRegexp(".*"), false,
+			)
+
+			AssertCommand(
+    				ubuntu, "syscalls", []string{"bash", "-c", "/bin/unlink /home/dummy"},
+    				MatchRegexp(".*"), false,
+			)
 
 			// check policy alert
 			expect := protobuf.Alert{
@@ -334,10 +388,15 @@ var _ = Describe("Syscalls", func() {
 			err = KarmorLogStart("policy", "syscalls", "Syscall", ubuntu)
 			Expect(err).To(BeNil())
 
-			_, _, err = K8sExecInPod(ubuntu, "syscalls", []string{"bash", "-c", "touch /home/dummy"})
-			Expect(err).To(BeNil())
-			_, _, err = K8sExecInPod(ubuntu, "syscalls", []string{"bash", "-c", "unlink /home/dummy"})
-			Expect(err).To(BeNil())
+			AssertCommand(
+	    			ubuntu, "syscalls", []string{"bash", "-c", "touch /home/dummy"},
+    				MatchRegexp(".*"), false,
+			)
+
+			AssertCommand(
+    				ubuntu, "syscalls", []string{"bash", "-c", "unlink /home/dummy"},
+    				MatchRegexp(".*"), false,
+			)
 
 			// check policy alert
 			expect := protobuf.Alert{
@@ -363,10 +422,15 @@ var _ = Describe("Syscalls", func() {
 			err = KarmorLogStart("policy", "syscalls", "Syscall", ubuntu)
 			Expect(err).To(BeNil())
 
-			_, _, err = K8sExecInPod(ubuntu, "syscalls", []string{"bash", "-c", "touch /home/dummy"})
-			Expect(err).To(BeNil())
-			_, _, err = K8sExecInPod(ubuntu, "syscalls", []string{"bash", "-c", "unlink /home/dummy"})
-			Expect(err).To(BeNil())
+			AssertCommand(
+    				ubuntu, "syscalls", []string{"bash", "-c", "touch /home/dummy"},
+	    			MatchRegexp(".*"), false,
+			)
+
+			AssertCommand(
+    				ubuntu, "syscalls", []string{"bash", "-c", "unlink /home/dummy"},
+    				MatchRegexp(".*"), false,
+			)
 
 			// check policy alert
 			expect := protobuf.Alert{
@@ -392,10 +456,15 @@ var _ = Describe("Syscalls", func() {
 			err = KarmorLogStart("policy", "syscalls", "Syscall", ubuntu)
 			Expect(err).To(BeNil())
 
-			_, _, err = K8sExecInPod(ubuntu, "syscalls", []string{"bash", "-c", "touch /home/dummy"})
-			Expect(err).To(BeNil())
-			_, _, err = K8sExecInPod(ubuntu, "syscalls", []string{"bash", "-c", "unlink /home/dummy"})
-			Expect(err).To(BeNil())
+			AssertCommand(
+    				ubuntu, "syscalls", []string{"bash", "-c", "touch /home/dummy"},
+    				MatchRegexp(".*"), false,
+			)
+
+			AssertCommand(
+		    		ubuntu, "syscalls", []string{"bash", "-c", "unlink /home/dummy"},
+    				MatchRegexp(".*"), false,
+			)
 
 			// check policy alert
 			expect := protobuf.Alert{
@@ -421,10 +490,15 @@ var _ = Describe("Syscalls", func() {
 			err = KarmorLogStart("policy", "syscalls", "Syscall", ubuntu)
 			Expect(err).To(BeNil())
 
-			_, _, err = K8sExecInPod(ubuntu, "syscalls", []string{"bash", "-c", "touch /home/dummy"})
-			Expect(err).To(BeNil())
-			_, _, err = K8sExecInPod(ubuntu, "syscalls", []string{"bash", "-c", "unlink /home/dummy"})
-			Expect(err).To(BeNil())
+			AssertCommand(
+    				ubuntu, "syscalls", []string{"bash", "-c", "touch /home/dummy"},
+    				MatchRegexp(".*"), false,
+			)
+
+			AssertCommand(
+    				ubuntu, "syscalls", []string{"bash", "-c", "unlink /home/dummy"},
+    				MatchRegexp(".*"), false,
+			)
 
 			// check policy alert
 			expect := protobuf.Alert{
@@ -452,10 +526,15 @@ var _ = Describe("Syscalls", func() {
 			err = KarmorLogStart("policy", "syscalls", "Syscall", ubuntu)
 			Expect(err).To(BeNil())
 
-			_, _, err = K8sExecInPod(ubuntu, "syscalls", []string{"bash", "-c", "touch /home/dummy"})
-			Expect(err).To(BeNil())
-			_, _, err = K8sExecInPod(ubuntu, "syscalls", []string{"bash", "-c", "unlink /home/dummy"})
-			Expect(err).To(BeNil())
+			AssertCommand(
+    				ubuntu, "syscalls", []string{"bash", "-c", "touch /home/dummy"},
+    				MatchRegexp(".*"), false,
+			)
+
+			AssertCommand(
+		    		ubuntu, "syscalls", []string{"bash", "-c", "unlink /home/dummy"},
+    				MatchRegexp(".*"), false,
+			)
 
 			// check policy alert
 			expect := protobuf.Alert{
@@ -481,10 +560,15 @@ var _ = Describe("Syscalls", func() {
 			err = KarmorLogStart("policy", "syscalls", "Syscall", ubuntu)
 			Expect(err).To(BeNil())
 
-			_, _, err = K8sExecInPod(ubuntu, "syscalls", []string{"bash", "-c", "touch /home/dummy"})
-			Expect(err).To(BeNil())
-			_, _, err = K8sExecInPod(ubuntu, "syscalls", []string{"bash", "-c", "unlink /home/dummy"})
-			Expect(err).To(BeNil())
+			AssertCommand(
+    				ubuntu, "syscalls", []string{"bash", "-c", "touch /home/dummy"},
+    				MatchRegexp(".*"), false,
+			)
+
+			AssertCommand(
+    				ubuntu, "syscalls", []string{"bash", "-c", "unlink /home/dummy"},
+    				MatchRegexp(".*"), false,
+			)
 
 			// check policy alert
 			expect := protobuf.Alert{
@@ -510,10 +594,15 @@ var _ = Describe("Syscalls", func() {
 			err = KarmorLogStart("policy", "syscalls", "Syscall", ubuntu)
 			Expect(err).To(BeNil())
 
-			_, _, err = K8sExecInPod(ubuntu, "syscalls", []string{"bash", "-c", "touch /home/dummy"})
-			Expect(err).To(BeNil())
-			_, _, err = K8sExecInPod(ubuntu, "syscalls", []string{"bash", "-c", "unlink /home/dummy"})
-			Expect(err).To(BeNil())
+			AssertCommand(
+    				ubuntu, "syscalls", []string{"bash", "-c", "touch /home/dummy"},
+		    		MatchRegexp(".*"), false,
+			)
+
+			AssertCommand(
+    				ubuntu, "syscalls", []string{"bash", "-c", "unlink /home/dummy"},
+		    		MatchRegexp(".*"), false,
+			)
 
 			// check policy alert
 			expect := protobuf.Alert{
@@ -539,10 +628,15 @@ var _ = Describe("Syscalls", func() {
 			err = KarmorLogStart("policy", "syscalls", "Syscall", ubuntu)
 			Expect(err).To(BeNil())
 
-			_, _, err = K8sExecInPod(ubuntu, "syscalls", []string{"bash", "-c", "touch /home/dummy"})
-			Expect(err).To(BeNil())
-			_, _, err = K8sExecInPod(ubuntu, "syscalls", []string{"bash", "-c", "unlink /home/dummy"})
-			Expect(err).To(BeNil())
+			AssertCommand(
+    				ubuntu, "syscalls", []string{"bash", "-c", "touch /home/dummy"},
+    				MatchRegexp(".*"), false,
+			)
+
+			AssertCommand(
+    				ubuntu, "syscalls", []string{"bash", "-c", "unlink /home/dummy"},
+    				MatchRegexp(".*"), false,
+			)
 
 			// check policy alert
 			expect := protobuf.Alert{
@@ -567,13 +661,15 @@ var _ = Describe("Syscalls", func() {
 			Expect(err).To(BeNil())
 
 			// execute mount inside the pod
-			sout, _, err := K8sExecInPod(ubuntu, "syscalls",
-				[]string{"bash", "-c", "mkdir /mnt/test"})
-			Expect(err).To(BeNil())
-			sout, _, err = K8sExecInPod(ubuntu, "syscalls",
-				[]string{"bash", "-c", "mount /home /mnt/test"})
-			Expect(err).To(BeNil())
-			fmt.Printf("OUTPUT: %s\n", sout)
+			AssertCommand(
+    				ubuntu, "syscalls", []string{"bash", "-c", "mkdir /mnt/test"},
+    				MatchRegexp(".*"), false,
+			)
+
+			AssertCommand(
+    				ubuntu, "syscalls", []string{"bash", "-c", "mount /home /mnt/test"},
+	    			MatchRegexp(".*"), false,
+			)
 
 			expect := protobuf.Alert{
 				PolicyName: "DefaultPosture",
@@ -596,10 +692,10 @@ var _ = Describe("Syscalls", func() {
 			Expect(err).To(BeNil())
 
 			// execute umount inside the pod
-			sout, _, err := K8sExecInPod(ubuntu, "syscalls",
-				[]string{"bash", "-c", "umount /mnt"})
-			Expect(err).To(BeNil())
-			fmt.Printf("OUTPUT: %s\n", sout)
+			AssertCommand(
+				ubuntu, "syscalls", []string{"bash", "-c", "umount /mnt"},
+    				MatchRegexp(".*"), false,
+			)
 
 			expect := protobuf.Alert{
 				PolicyName: "DefaultPosture",

--- a/tests/k8s_env/throttling/throttling_test.go
+++ b/tests/k8s_env/throttling/throttling_test.go
@@ -73,13 +73,13 @@ var _ = Describe("Smoke", func() {
 
 			// wait for policy creation
 			time.Sleep(5 * time.Second)
-
-			sout, _, err := K8sExecInPod(wp, "wordpress-mysql",
-				[]string{"bash", "-c", "count=0; while [ $count -lt 5 ]; do apt; count=$((count + 1)); done;"})
-			Expect(err).To(BeNil())
-			fmt.Printf("OUTPUT: %s\n", sout)
-			Expect(sout).To(MatchRegexp("apt.*Permission denied"))
-
+			AssertCommand(
+ 			wp,
+    			"wordpress-mysql",
+		        []string{"bash", "-c", "count=0; while [ $count -lt 5 ]; do apt; count=$((count + 1)); done;"},
+    			MatchRegexp("apt.*Permission denied"),
+    			false,
+			)
 			// check policy violation alert
 			_, alerts, err := KarmorGetLogs(5*time.Second, 1)
 			Expect(err).To(BeNil())
@@ -93,12 +93,12 @@ var _ = Describe("Smoke", func() {
 			Expect(err).To(BeNil())
 
 			// check for throttling, alerts should not be genrated
-			sout, _, err = K8sExecInPod(wp, "wordpress-mysql",
-				[]string{"bash", "-c", "apt update"})
-			Expect(err).To(BeNil())
-			fmt.Printf("---START---\n%s---END---\n", sout)
-			Expect(sout).To(MatchRegexp("apt.*Permission denied"))
-
+			AssertCommand(wp, 
+			"wordpress-mysql", 
+			[]string{"bash", "-c", "apt update"}, 
+			MatchRegexp("apt.*Permission denied"), 
+			false,
+			)
 			_, alerts, err = KarmorGetLogs(5*time.Second, 1)
 			Expect(err).To(BeNil())
 			fmt.Printf("throttling alert :%v\n", alerts)

--- a/tests/k8s_env/visibility/visibility_test.go
+++ b/tests/k8s_env/visibility/visibility_test.go
@@ -60,9 +60,8 @@ var _ = Describe("Visibility", func() {
 			err = KarmorLogStart("all", "wordpress-mysql", "", wp)
 			Expect(err).To(BeNil())
 
-			sout, _, err := K8sExecInPod(wp, "wordpress-mysql", []string{"bash", "-c", "ping google.com -c1"})
-			Expect(err).To(BeNil())
-			fmt.Printf("---START---\n%s---END---\n", sout)
+			// Use Assert command
+			AssertCommand(wp, "wordpress-mysql", []string{"bash", "-c", "ping google.com -c1"}, MatchRegexp(".*"), false)
 
 			// check audit logs
 			logs, _, err := KarmorGetLogs(5*time.Second, 50)
@@ -89,9 +88,8 @@ var _ = Describe("Visibility", func() {
 			err = KarmorLogStart("all", "wordpress-mysql", "", wp)
 			Expect(err).To(BeNil())
 
-			sout, _, err := K8sExecInPod(wp, "wordpress-mysql", []string{"bash", "-c", "ping google.com -c1"})
-			Expect(err).To(BeNil())
-			fmt.Printf("---START---\n%s---END---\n", sout)
+			// Use Assert command
+                        AssertCommand(wp, "wordpress-mysql", []string{"bash", "-c", "ping google.com -c1"}, MatchRegexp(".*"), false)
 
 			// check audit logs
 			logs, _, err := KarmorGetLogs(5*time.Second, 50)
@@ -115,9 +113,9 @@ var _ = Describe("Visibility", func() {
 			err = KarmorLogStart("all", "wordpress-mysql", "", wp)
 			Expect(err).To(BeNil())
 
-			sout, _, err := K8sExecInPod(wp, "wordpress-mysql", []string{"bash", "-c", "ping google.com -c1"})
-			Expect(err).To(BeNil())
-			fmt.Printf("---START---\n%s---END---\n", sout)
+			 // Use Assert command
+                        AssertCommand(wp, "wordpress-mysql", []string{"bash", "-c", "ping google.com -c1"}, MatchRegexp(".*"), false)
+
 
 			// check audit logs
 			logs, _, err := KarmorGetLogs(5*time.Second, 50)


### PR DESCRIPTION
**Purpose of PR?**:

Fixes #1643

**Does this PR introduce a breaking change?**
No
**If the changes in this PR are manually verified, list down the scenarios covered:**:
1. Verified that the K8sExecInPod calls were successfully replaced with AssertCommand without impacting test results.
2. Confirmed that permissions and expected outputs are consistent with the new implementation.
3. Ensured that refactored code retains functionality across all test cases.

**Additional information for reviewer?** : This PR is part of the refactoring effort to standardize test execution methods. It follows up on a previous PR where initial AssertCommand replacements were introduced.
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [x] Bug fix. Fixes #1643 
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Commit has unit tests
- [x] Commit has integration tests

<!--

The PR title message must follow convention:
`<type>(<scope>): <subject>`.

Where: <br />
- `type` is to define what type of PR is this.
  Most common types are:
    - `feat`      - for new features, not a new feature for build script
    - `fix`       - for bug fixes or improvements, not a fix for build script
    - `chore`     - changes not related to production code
    - `docs`      - changes related to documentation
    - `style`     - formatting, missing semi colons, linting fix etc; no significant production code changes
    - `test`      - adding missing tests, refactoring tests; no production code change
    - `refactor`  - refactoring production code, eg. renaming a variable or function name, there should not be any significant production code changes

- `scope` is a single word that best describes where the changes fit.
    - feature(`monitor`,`enforcer`)
    - test(`tests`, `bdd`)
    - chore(`build`)
- `subject` is a single line brief description of the changes made in the pull request.

-->