### PR TITLE
fix(operator): update relay env vars with initial config

### DIFF
--- a/pkg/KubeArmorOperator/internal/controller/resources.go
+++ b/pkg/KubeArmorOperator/internal/controller/resources.go
@@ -534,6 +534,22 @@ func (clusterWatcher *ClusterWatcher) WatchRequiredResources() {
 	controller := deployments.GetKubeArmorControllerDeployment(common.Namespace)
 	relayServer := deployments.GetRelayDeployment(common.Namespace)
 
+	// update relay env vars
+	relayServer.Spec.Template.Spec.Containers[0].Env = []corev1.EnvVar{
+		{
+			Name:  "ENABLE_STDOUT_LOGS",
+			Value: common.KubearmorRelayEnvMap[common.EnableStdOutLogs],
+		},
+		{
+			Name:  "ENABLE_STDOUT_ALERTS",
+			Value: common.KubearmorRelayEnvMap[common.EnableStdOutAlerts],
+		},
+		{
+			Name:  "ENABLE_STDOUT_MSGS",
+			Value: common.KubearmorRelayEnvMap[common.EnableStdOutMsgs],
+		},
+	}
+
 	if common.EnableTls {
 		relayServer.Spec.Template.Spec.Containers[0].VolumeMounts =
 			append(relayServer.Spec.Template.Spec.Containers[0].VolumeMounts, common.KubeArmorRelayTlsVolumeMount...)


### PR DESCRIPTION
**Purpose of PR?**:

PR fixes the bug in the operator that it was ignoring the initial configurations provided using kubearmorconfig for kubearmor-relay deployment.

Fixes #1866 

**Does this PR introduce a breaking change?**
No
**If the changes in this PR are manually verified, list down the scenarios covered:**:
verified that operator consider initial configuration provided during helm install and overridden values for 
**Additional information for reviewer?** :
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [x] Bug fix. Fixes #1866
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Commit has unit tests
- [ ] Commit has integration tests

<!--

The PR title message must follow convention:
`<type>(<scope>): <subject>`.

Where: <br />
- `type` is to define what type of PR is this.
  Most common types are:
    - `feat`      - for new features, not a new feature for build script
    - `fix`       - for bug fixes or improvements, not a fix for build script
    - `chore`     - changes not related to production code
    - `docs`      - changes related to documentation
    - `style`     - formatting, missing semi colons, linting fix etc; no significant production code changes
    - `test`      - adding missing tests, refactoring tests; no production code change
    - `refactor`  - refactoring production code, eg. renaming a variable or function name, there should not be any significant production code changes

- `scope` is a single word that best describes where the changes fit.
    - feature(`monitor`,`enforcer`)
    - test(`tests`, `bdd`)
    - chore(`build`)
- `subject` is a single line brief description of the changes made in the pull request.

-->