### PR TITLE
feat(deploy) Allow setting additional values in operator chart

### DIFF
--- a/deployments/helm/KubeArmorOperator/README.md
+++ b/deployments/helm/KubeArmorOperator/README.md
@@ -23,6 +23,11 @@ helm upgrade --install kubearmor-operator . -n kubearmor --create-namespace
 | kubearmorOperator.image.repository | string | kubearmor/kubearmor-operator | image repository to pull KubeArmorOperator from |
 | kubearmorOperator.image.tag | string | latest | KubeArmorOperator image tag |
 | kubearmorOperator.imagePullPolicy | string | IfNotPresent | pull policy for operator image |
+| kubearmorOperator.podLabels | object | {} | additional pod labels |
+| kubearmorOperator.podAnnotations | object | {} | additional pod annotations |
+| kubearmorOperator.resources | object | {} | operator container resources |
+| kubearmorOperator.podSecurityContext | object | {} | pod security context |
+| kubearmorOperator.securityContext | object | {} | operator container security context |
 | kubearmorConfig | object | [values.yaml](values.yaml) | KubeArmor default configurations |
 | autoDeploy | bool | false | Auto deploy KubeArmor with default configurations |
 

--- a/deployments/helm/KubeArmorOperator/templates/deployment.yaml
+++ b/deployments/helm/KubeArmorOperator/templates/deployment.yaml
@@ -13,7 +13,18 @@ spec:
     metadata:
       labels:
         kubearmor-app: {{ .Values.kubearmorOperator.name }}
+      {{- with .Values.kubearmorOperator.podLabels }}
+        {{- . | toYaml | nindent 8 }}
+      {{- end }}
+      {{- with .Values.kubearmorOperator.podAnnotations }}
+      annotations:
+        {{- . | toYaml | nindent 8 }}
+      {{- end }}
     spec:
+      {{- with .Values.kubearmorOperator.podSecurityContext }}
+      securityContext:
+            {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
       - name: {{ .Values.kubearmorOperator.name }}
         env:
@@ -34,6 +45,14 @@ spec:
         {{- if .Values.kubearmorOperator.args -}}
         {{- toYaml .Values.kubearmorOperator.args | trim | nindent 8 }}
         {{- end }}
+        {{- end }}
+        {{- with .Values.kubearmorOperator.securityContext }}
+        securityContext:
+              {{- toYaml . | nindent 10 }}
+        {{- end }}
+        {{- with .Values.kubearmorOperator.resources }}
+        resources:
+          {{- toYaml . | nindent 10 }}
         {{- end }}
 
       serviceAccountName: {{ .Values.kubearmorOperator.name }}

--- a/deployments/helm/KubeArmorOperator/values.yaml
+++ b/deployments/helm/KubeArmorOperator/values.yaml
@@ -36,6 +36,12 @@ kubearmorOperator:
   args:
     - "--initDeploy=true"
 
+  resources: {}
+  podLabels: {}
+  podAnnotations: {}
+  podSecurityContext: {}
+  securityContext: {}
+
 kubearmorConfig:
   defaultCapabilitiesPosture: audit
   defaultFilePosture: audit


### PR DESCRIPTION
**Purpose of PR?**:


This PR allows defining adidional values in the operator helm chart. (resources/podLabels/podAnnotations/podSecurityContext/securityContext)

Fixes -

**Does this PR introduce a breaking change?**
no

**If the changes in this PR are manually verified, list down the scenarios covered:**:
Installed helm chart without and with new values

**Additional information for reviewer?** :
-


**Checklist:**
- [ ] Bug fix. Fixes #<issue number>
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Commit has unit tests
- [ ] Commit has integration tests
