### PR TITLE
USE AsserCommand instead of K8sExecInPod

### DIFF
--- a/tests/k8s_env/ksp/ksp_test.go
+++ b/tests/k8s_env/ksp/ksp_test.go
@@ -87,7 +87,7 @@ var _ = Describe("Ksp", func() {
 			AssertCommand(
 				pods.Items[0].Name, "nginx", []string{"ls"},
 				MatchRegexp(".*"), true,
-			)			
+			)
 
 			// check audit logs
 			logs, _, err := KarmorGetLogs(5*time.Second, 50)

--- a/tests/k8s_env/ksp/ksp_test.go
+++ b/tests/k8s_env/ksp/ksp_test.go
@@ -84,9 +84,10 @@ var _ = Describe("Ksp", func() {
 			err = KarmorLogStart("all", "nginx", "", pods.Items[0].Name)
 			Expect(err).To(BeNil())
 
-			sout, _, err := K8sExecInPod(pods.Items[0].Name, "nginx", []string{"ls"})
-			Expect(err).To(BeNil())
-			fmt.Printf("---START---\n%s---END---\n", sout)
+			AssertCommand(
+				pods.Items[0].Name, "nginx", []string{"ls"},
+				MatchRegexp(".*"), true,
+			)			
 
 			// check audit logs
 			logs, _, err := KarmorGetLogs(5*time.Second, 50)
@@ -225,10 +226,10 @@ var _ = Describe("Ksp", func() {
 			err = KarmorLogStart("policy", "multiubuntu", "Process", ub4)
 			Expect(err).To(BeNil())
 
-			sout, _, err := K8sExecInPod(ub4, "multiubuntu",
-				[]string{"bash", "-c", "sleep 1"})
-			Expect(err).To(BeNil())
-			fmt.Printf("OUTPUT: %s\n", sout)
+			AssertCommand(
+				ub4, "multiubuntu", []string{"bash", "-c", "sleep 1"},
+				MatchRegexp(".*"), true,
+			)
 
 			expect := protobuf.Alert{
 				PolicyName: "ksp-group-2-audit-proc-path",
@@ -432,11 +433,10 @@ var _ = Describe("Ksp", func() {
 			AssertCommand(ub3, "multiubuntu", []string{"bash", "-c", "/home/user1/hello"},
 				MatchRegexp("hello.*Permission denied"), true,
 			)
-			sout, _, err := K8sExecInPod(ub3, "multiubuntu",
-				[]string{"bash", "-c", "/home/user1/hello"})
-			Expect(err).To(BeNil())
-			fmt.Printf("OUTPUT: %s\n", sout)
-			Expect(sout).To(MatchRegexp("hello.*Permission denied"))
+			AssertCommand(
+				ub3, "multiubuntu", []string{"bash", "-c", "/home/user1/hello"},
+				MatchRegexp("hello.*Permission denied"), true,
+			)
 
 			expect := protobuf.Alert{
 				PolicyName: "ksp-ubuntu-3-block-proc-path-owner",
@@ -820,10 +820,10 @@ var _ = Describe("Ksp", func() {
 			err = KarmorLogStart("policy", "multiubuntu", "File", ub1)
 			Expect(err).To(BeNil())
 
-			sout, _, err := K8sExecInPod(ub1, "multiubuntu",
-				[]string{"bash", "-c", "touch  /home/user1/new1"})
-			Expect(err).To(BeNil())
-			fmt.Printf("OUTPUT: %s\n", sout)
+			AssertCommand(
+				ub1, "multiubuntu", []string{"bash", "-c", "touch /home/user1/new1"},
+				MatchRegexp(".*"), true,
+			)
 
 			expect := protobuf.Alert{
 				PolicyName: "ksp-ubuntu-1-audit-file-access-owner-readonly",
@@ -1401,10 +1401,10 @@ var _ = Describe("Ksp", func() {
 			err = KarmorLogStart("system", "multiubuntu", "File", ub4)
 			Expect(err).To(BeNil())
 
-			sout, _, err := K8sExecInPod(ub4, "multiubuntu",
-				[]string{"bash", "-c", "su - user1 -c 'cat /home/user1/secret_data1.txt'"})
-			Expect(err).To(BeNil())
-			fmt.Printf("OUTPUT: %s\n", sout)
+			AssertCommand(
+				ub4, "multiubuntu", []string{"bash", "-c", "su - user1 -c 'cat /home/user1/secret_data1.txt'"},
+				MatchRegexp(".*"), true,
+			)
 			// Expect(sout).To(ContainSubstring("secret file user1"))
 
 			expectLog := protobuf.Log{
@@ -1518,10 +1518,10 @@ var _ = Describe("Ksp", func() {
 
 			// Test 3: write operation on the file by the owner should also be allowed
 			// No need for AssertCommand here since there is nothing to match
-			sout, _, err := K8sExecInPod(ub3, "multiubuntu",
-				[]string{"bash", "-c", "su - user1 -c 'echo user1 >> /home/user1/secret_data1.txt'"})
-			Expect(err).To(BeNil())
-			fmt.Printf("OUTPUT: %s\n", sout)
+			AssertCommand(
+				ub3, "multiubuntu", []string{"bash", "-c", "su - user1 -c 'echo user1 >> /home/user1/secret_data1.txt'"},
+				MatchRegexp(".*"), true,
+			)
 
 		})
 
@@ -1578,11 +1578,10 @@ var _ = Describe("Ksp", func() {
 			err = KarmorLogStart("system", "multiubuntu", "File", ub4)
 			Expect(err).To(BeNil())
 
-			sout, _, err := K8sExecInPod(ub4, "multiubuntu",
-				[]string{"bash", "-c", "./readwrite -r /secret.txt"})
-			Expect(err).To(BeNil())
-			fmt.Printf("OUTPUT: %s\n", sout)
-			Expect(sout).To(ContainSubstring("s"))
+			AssertCommand(
+				ub4, "multiubuntu", []string{"bash", "-c", "./readwrite -r /secret.txt"},
+				ContainSubstring("s"), true,
+			)
 
 			expectLog = protobuf.Log{
 				Resource: "secret.txt",
@@ -1613,10 +1612,10 @@ var _ = Describe("Ksp", func() {
 			err = KarmorLogStart("policy", "multiubuntu", "File", ub4)
 			Expect(err).To(BeNil())
 
-			sout, _, err := K8sExecInPod(ub4, "multiubuntu",
-				[]string{"bash", "-c", "./readwrite -w /credentials/password"})
-			Expect(err).To(BeNil())
-			fmt.Printf("OUTPUT: %s\n", sout)
+			AssertCommand(
+				ub4, "multiubuntu", []string{"bash", "-c", "./readwrite -w /credentials/password"},
+				MatchRegexp(".*"), true,
+			)
 
 			expect := protobuf.Alert{
 				PolicyName: "DefaultPosture",
@@ -1632,10 +1631,10 @@ var _ = Describe("Ksp", func() {
 
 			// Test 3: reading some other file should be denied as not allowed by the policy
 
-			sout, _, err = K8sExecInPod(ub4, "multiubuntu",
-				[]string{"bash", "-c", "./readwrite -r /secret.txt"})
-			Expect(err).To(BeNil())
-			fmt.Printf("OUTPUT: %s\n", sout)
+			AssertCommand(
+				ub4, "multiubuntu", []string{"bash", "-c", "./readwrite -r /secret.txt"},
+				MatchRegexp(".*"), true,
+			)
 
 			expect = protobuf.Alert{
 				PolicyName: "DefaultPosture",
@@ -1711,10 +1710,10 @@ var _ = Describe("Ksp", func() {
 			err = KarmorLogStart("policy", "multiubuntu", "File", ub4)
 			Expect(err).To(BeNil())
 
-			sout, _, err := K8sExecInPod(ub4, "multiubuntu",
-				[]string{"bash", "-c", "touch /dev/shm/new"})
-			Expect(err).To(BeNil())
-			fmt.Printf("OUTPUT: %s\n", sout)
+			AssertCommand(
+				ub4, "multiubuntu", []string{"bash", "-c", "touch /dev/shm/new"},
+				MatchRegexp(".*"), true,
+			)
 
 			expect := protobuf.Alert{
 				PolicyName: "ksp-ubuntu-4-audit-file-path-readonly",
@@ -1884,11 +1883,10 @@ var _ = Describe("Ksp", func() {
 			err = KarmorLogStart("system", "multiubuntu", "File", ub4)
 			Expect(err).To(BeNil())
 
-			sout, _, err := K8sExecInPod(ub4, "multiubuntu",
-				[]string{"bash", "-c", "cat /credentials/password"})
-			Expect(err).To(BeNil())
-			fmt.Printf("OUTPUT: %s\n", sout)
-			Expect(sout).To(ContainSubstring("password file"))
+			AssertCommand(
+				ub4, "multiubuntu", []string{"bash", "-c", "cat /credentials/password"},
+				ContainSubstring("password file"), true,
+			)
 		})
 
 	})

--- a/tests/k8s_env/networktests/network_test.go
+++ b/tests/k8s_env/networktests/network_test.go
@@ -3,7 +3,6 @@
 package networktests
 
 import (
-	"fmt"
 	"strings"
 	"time"
 
@@ -57,23 +56,23 @@ var _ = Describe("Network Tests", func() {
 				// Apply policy
 				err := K8sApplyFile("res/ksp-ubuntu-1-audit-net-icmp.yaml")
 				Expect(err).To(BeNil())
-	
+
 				// Start KubeArmor Logs
 				err = KarmorLogStart("policy", "multiubuntu", "Network", ub1)
 				Expect(err).To(BeNil())
-	
+
 				AssertCommand(
 					ub1, "multiubuntu", []string{"bash", "-c", "ping -c 1 127.0.0.1"},
 					MatchRegexp("PING.*127.0.0.1"), true,
-				)			
-	
+				)
+
 				expect := protobuf.Alert{
 					PolicyName: "ksp-ubuntu-1-audit-net-icmp",
 					Severity:   "8",
 					Action:     "Audit",
 					Result:     "Passed",
 				}
-	
+
 				// check policy alert
 				res, err := KarmorGetTargetAlert(5*time.Second, &expect)
 				Expect(err).To(BeNil())

--- a/tests/k8s_env/networktests/network_test.go
+++ b/tests/k8s_env/networktests/network_test.go
@@ -57,24 +57,23 @@ var _ = Describe("Network Tests", func() {
 				// Apply policy
 				err := K8sApplyFile("res/ksp-ubuntu-1-audit-net-icmp.yaml")
 				Expect(err).To(BeNil())
-
+	
 				// Start KubeArmor Logs
 				err = KarmorLogStart("policy", "multiubuntu", "Network", ub1)
 				Expect(err).To(BeNil())
-
-				sout, _, err := K8sExecInPod(ub1, "multiubuntu",
-					[]string{"bash", "-c", "ping -c 1 127.0.0.1"})
-				Expect(err).To(BeNil())
-				fmt.Printf("OUTPUT: %s\n", sout)
-				Expect(sout).To(MatchRegexp("PING.*127.0.0.1"))
-
+	
+				AssertCommand(
+					ub1, "multiubuntu", []string{"bash", "-c", "ping -c 1 127.0.0.1"},
+					MatchRegexp("PING.*127.0.0.1"), true,
+				)			
+	
 				expect := protobuf.Alert{
 					PolicyName: "ksp-ubuntu-1-audit-net-icmp",
 					Severity:   "8",
 					Action:     "Audit",
 					Result:     "Passed",
 				}
-
+	
 				// check policy alert
 				res, err := KarmorGetTargetAlert(5*time.Second, &expect)
 				Expect(err).To(BeNil())
@@ -172,11 +171,9 @@ var _ = Describe("Network Tests", func() {
 				err = KarmorLogStart("policy", "multiubuntu", "Network", ub1)
 				Expect(err).To(BeNil())
 
-				sout, _, err := K8sExecInPod(ub1, "multiubuntu",
-					[]string{"bash", "-c", "arping -c 1 127.0.0.1"})
-				Expect(err).To(BeNil())
-				fmt.Printf("OUTPUT: %s\n", sout)
-				Expect(sout).To(MatchRegexp("ARPING 127.0.0.1"))
+				AssertCommand(ub1, "multiubuntu", []string{"bash", "-c", "arping -c 1 127.0.0.1"},
+					MatchRegexp("ARPING 127.0.0.1"), true,
+				)
 
 				expect := protobuf.Alert{
 					PolicyName: "ksp-ubuntu-1-audit-net-raw",

--- a/tests/k8s_env/smoke/smoke_test.go
+++ b/tests/k8s_env/smoke/smoke_test.go
@@ -69,7 +69,6 @@ var _ = Describe("Smoke", func() {
 
 			AssertCommand(wp, "wordpress-mysql", []string{"bash", "-c", "apt"}, MatchRegexp("apt.*Permission denied"), true)
 
-
 			// check policy violation alert
 			expect := protobuf.Alert{
 				PolicyName: "ksp-wordpress-block-process",
@@ -95,7 +94,6 @@ var _ = Describe("Smoke", func() {
 			time.Sleep(5 * time.Second)
 
 			AssertCommand(wp, "wordpress-mysql", []string{"bash", "-c", "cat /var/www/html/wp-config.php"}, MatchRegexp("wp-config.php.*Permission denied"), true)
-
 
 			// check policy violation alert
 			expect := protobuf.Alert{
@@ -148,7 +146,6 @@ var _ = Describe("Smoke", func() {
 
 			AssertCommand(wp, "wordpress-mysql", []string{"bash", "-c", "cat /run/secrets/kubernetes.io/serviceaccount/token"}, MatchRegexp("token.*Permission denied"), true)
 
-
 			// check policy violation alert
 			expect := protobuf.Alert{
 				PolicyName: "ksp-wordpress-block-sa",
@@ -188,7 +185,7 @@ var _ = Describe("Smoke", func() {
 			AssertCommand(wp, "wordpress-mysql", []string{"bash", "-c", "cat /run/secrets/kubernetes.io/serviceaccount/token"}, Not(MatchRegexp("Permission denied")), true)
 
 			AssertCommand(wp, "wordpress-mysql", []string{"bash", "-c", "cat /etc/passwd"}, Not(MatchRegexp("Permission denied")), true)
-			
+
 			AssertCommand(wp, "wordpress-mysql", []string{"bash", "-c", "head /etc/passwd"}, Not(MatchRegexp("Permission denied")), true)
 
 			// check for no policy violation alert

--- a/tests/k8s_env/syscalls/syscalls_test.go
+++ b/tests/k8s_env/syscalls/syscalls_test.go
@@ -4,7 +4,7 @@
 package syscalls
 
 import (
-	"fmt"
+
 	"time"
 
 	"github.com/kubearmor/KubeArmor/protobuf"
@@ -58,10 +58,8 @@ var _ = Describe("Syscalls", func() {
 			err = KarmorLogStart("policy", "syscalls", "Syscall", ubuntu)
 			Expect(err).To(BeNil())
 
-			_, _, err = K8sExecInPod(ubuntu, "syscalls", []string{"bash", "-c", "touch /dummy"})
-			Expect(err).To(BeNil())
-			_, _, err = K8sExecInPod(ubuntu, "syscalls", []string{"bash", "-c", "unlink /dummy"})
-			Expect(err).To(BeNil())
+			AssertCommand(ubuntu, "syscalls", []string{"bash", "-c", "touch /dummy"}, MatchRegexp(".*"), true)
+			AssertCommand(ubuntu, "syscalls", []string{"bash", "-c", "unlink /dummy"}, MatchRegexp(".*"), true)
 
 			// check policy alert
 			expect := protobuf.Alert{
@@ -86,13 +84,9 @@ var _ = Describe("Syscalls", func() {
 			err = KarmorLogStart("policy", "syscalls", "Syscall", ubuntu)
 			Expect(err).To(BeNil())
 
-			_, _, err = K8sExecInPod(ubuntu, "syscalls", []string{"bash", "-c", "cp /usr/bin/unlink /bin/unlink"})
-			Expect(err).To(BeNil())
-
-			_, _, err = K8sExecInPod(ubuntu, "syscalls", []string{"bash", "-c", "touch /dummy"})
-			Expect(err).To(BeNil())
-			_, _, err = K8sExecInPod(ubuntu, "syscalls", []string{"bash", "-c", "/bin/unlink /dummy"})
-			Expect(err).To(BeNil())
+			AssertCommand(ubuntu, "syscalls", []string{"bash", "-c", "cp /usr/bin/unlink /bin/unlink"}, MatchRegexp(".*"), true)
+			AssertCommand(ubuntu, "syscalls", []string{"bash", "-c", "touch /dummy"}, MatchRegexp(".*"), true)
+			AssertCommand(ubuntu, "syscalls", []string{"bash", "-c", "/bin/unlink /dummy"}, MatchRegexp(".*"), true)
 
 			// check policy alert
 			expect := protobuf.Alert{
@@ -117,16 +111,13 @@ var _ = Describe("Syscalls", func() {
 			err = KarmorLogStart("policy", "syscalls", "Syscall", ubuntu)
 			Expect(err).To(BeNil())
 
-			_, _, err = K8sExecInPod(ubuntu, "syscalls", []string{"bash", "-c", "mkdir -p /foo/bar"})
-			Expect(err).To(BeNil())
+			AssertCommand(ubuntu, "syscalls", []string{"bash", "-c", "mkdir -p /foo/bar"}, MatchRegexp(".*"), true)
 
-			_, _, err = K8sExecInPod(ubuntu, "syscalls", []string{"bash", "-c", "cp /usr/bin/unlink /foo/bar/unlink"})
-			Expect(err).To(BeNil())
+			AssertCommand(ubuntu, "syscalls", []string{"bash", "-c", "cp /usr/bin/unlink /foo/bar/unlink"}, MatchRegexp(".*"), true)
 
-			_, _, err = K8sExecInPod(ubuntu, "syscalls", []string{"bash", "-c", "touch /dummy"})
-			Expect(err).To(BeNil())
-			_, _, err = K8sExecInPod(ubuntu, "syscalls", []string{"bash", "-c", "/foo/bar/unlink /dummy"})
-			Expect(err).To(BeNil())
+			AssertCommand(ubuntu, "syscalls", []string{"bash", "-c", "touch /dummy"}, MatchRegexp(".*"), true)
+
+			AssertCommand(ubuntu, "syscalls", []string{"bash", "-c", "/foo/bar/unlink /dummy"}, MatchRegexp(".*"), true)
 
 			// check policy alert
 			expect := protobuf.Alert{
@@ -150,13 +141,11 @@ var _ = Describe("Syscalls", func() {
 			err = KarmorLogStart("policy", "syscalls", "Syscall", ubuntu)
 			Expect(err).To(BeNil())
 
-			_, _, err = K8sExecInPod(ubuntu, "syscalls", []string{"bash", "-c", "cp /usr/bin/unlink /unlink"})
-			Expect(err).To(BeNil())
+			AssertCommand(ubuntu, "syscalls", []string{"bash", "-c", "cp /usr/bin/unlink /unlink"}, MatchRegexp(".*"), true)
 
-			_, _, err = K8sExecInPod(ubuntu, "syscalls", []string{"bash", "-c", "touch /dummy"})
-			Expect(err).To(BeNil())
-			_, _, err = K8sExecInPod(ubuntu, "syscalls", []string{"bash", "-c", "/unlink /dummy"})
-			Expect(err).To(BeNil())
+			AssertCommand(ubuntu, "syscalls", []string{"bash", "-c", "touch /dummy"}, MatchRegexp(".*"), true)
+			AssertCommand(ubuntu, "syscalls", []string{"bash", "-c", "/unlink /dummy"}, MatchRegexp(".*"), true)
+
 
 			// check policy alert
 			expect := protobuf.Alert{
@@ -183,10 +172,9 @@ var _ = Describe("Syscalls", func() {
 			err = KarmorLogStart("policy", "syscalls", "Syscall", ubuntu)
 			Expect(err).To(BeNil())
 
-			_, _, err = K8sExecInPod(ubuntu, "syscalls", []string{"bash", "-c", "touch /home/dummy"})
-			Expect(err).To(BeNil())
-			_, _, err = K8sExecInPod(ubuntu, "syscalls", []string{"bash", "-c", "unlink /home/dummy"})
-			Expect(err).To(BeNil())
+			AssertCommand(ubuntu, "syscalls", []string{"bash", "-c", "touch /home/dummy"}, MatchRegexp(".*"), true)
+			AssertCommand(ubuntu, "syscalls", []string{"bash", "-c", "unlink /home/dummy"}, MatchRegexp(".*"), true)
+
 
 			// check policy alert
 			expect := protobuf.Alert{
@@ -210,10 +198,8 @@ var _ = Describe("Syscalls", func() {
 			err = KarmorLogStart("policy", "syscalls", "Syscall", ubuntu)
 			Expect(err).To(BeNil())
 
-			_, _, err = K8sExecInPod(ubuntu, "syscalls", []string{"bash", "-c", "touch /dummy"})
-			Expect(err).To(BeNil())
-			_, _, err = K8sExecInPod(ubuntu, "syscalls", []string{"bash", "-c", "unlink /dummy"})
-			Expect(err).To(BeNil())
+			AssertCommand(ubuntu, "syscalls", []string{"bash", "-c", "touch /dummy"}, MatchRegexp(".*"), true)
+			AssertCommand(ubuntu, "syscalls", []string{"bash", "-c", "unlink /dummy"}, MatchRegexp(".*"), true)
 
 			// check policy alert
 			expect := protobuf.Alert{
@@ -233,17 +219,14 @@ var _ = Describe("Syscalls", func() {
 			err := K8sApply([]string{"manifests/matchpaths/unlink-dir-recursive-fromsource-path.yaml"})
 			Expect(err).To(BeNil())
 
-			_, _, err = K8sExecInPod(ubuntu, "syscalls", []string{"bash", "-c", "cp /usr/bin/unlink /bin/unlink"})
-			Expect(err).To(BeNil())
+			AssertCommand(ubuntu, "syscalls", []string{"bash", "-c", "cp /usr/bin/unlink /bin/unlink"}, MatchRegexp(".*"), true)
 
 			// Start Kubearmor Logs
 			err = KarmorLogStart("policy", "syscalls", "Syscall", ubuntu)
 			Expect(err).To(BeNil())
 
-			_, _, err = K8sExecInPod(ubuntu, "syscalls", []string{"bash", "-c", "touch /home/dummy"})
-			Expect(err).To(BeNil())
-			_, _, err = K8sExecInPod(ubuntu, "syscalls", []string{"bash", "-c", "/bin/unlink /home/dummy"})
-			Expect(err).To(BeNil())
+			AssertCommand(ubuntu, "syscalls", []string{"bash", "-c", "touch /home/dummy"}, MatchRegexp(".*"), true)
+			AssertCommand(ubuntu, "syscalls", []string{"bash", "-c", "/bin/unlink /home/dummy"}, MatchRegexp(".*"), true)
 
 			// check policy alert
 			expect := protobuf.Alert{
@@ -267,10 +250,9 @@ var _ = Describe("Syscalls", func() {
 			err = KarmorLogStart("policy", "syscalls", "Syscall", ubuntu)
 			Expect(err).To(BeNil())
 
-			_, _, err = K8sExecInPod(ubuntu, "syscalls", []string{"bash", "-c", "touch /home/dummy"})
-			Expect(err).To(BeNil())
-			_, _, err = K8sExecInPod(ubuntu, "syscalls", []string{"bash", "-c", "unlink /home/dummy"})
-			Expect(err).To(BeNil())
+			AssertCommand(ubuntu, "syscalls", []string{"bash", "-c", "touch /home/dummy"}, MatchRegexp(".*"), true)
+			AssertCommand(ubuntu, "syscalls", []string{"bash", "-c", "unlink /home/dummy"}, MatchRegexp(".*"), true)
+
 
 			// check policy alert
 			expect := protobuf.Alert{
@@ -290,17 +272,14 @@ var _ = Describe("Syscalls", func() {
 			err := K8sApply([]string{"manifests/matchpaths/unlink-dir-recursive-fromsource-dir.yaml"})
 			Expect(err).To(BeNil())
 
-			_, _, err = K8sExecInPod(ubuntu, "syscalls", []string{"bash", "-c", "cp /usr/bin/unlink /bin/unlink"})
-			Expect(err).To(BeNil())
+			AssertCommand(ubuntu, "syscalls", []string{"bash", "-c", "cp /usr/bin/unlink /bin/unlink"}, MatchRegexp(".*"), true)
 
 			// Start Kubearmor Logs
 			err = KarmorLogStart("policy", "syscalls", "Syscall", ubuntu)
 			Expect(err).To(BeNil())
 
-			_, _, err = K8sExecInPod(ubuntu, "syscalls", []string{"bash", "-c", "touch /home/dummy"})
-			Expect(err).To(BeNil())
-			_, _, err = K8sExecInPod(ubuntu, "syscalls", []string{"bash", "-c", "/bin/unlink /home/dummy"})
-			Expect(err).To(BeNil())
+			AssertCommand(ubuntu, "syscalls", []string{"bash", "-c", "touch /home/dummy"}, MatchRegexp(".*"), true)
+			AssertCommand(ubuntu, "syscalls", []string{"bash", "-c", "/bin/unlink /home/dummy"}, MatchRegexp(".*"), true)
 
 			// check policy alert
 			expect := protobuf.Alert{
@@ -327,10 +306,9 @@ var _ = Describe("Syscalls", func() {
 			err = KarmorLogStart("policy", "syscalls", "Syscall", ubuntu)
 			Expect(err).To(BeNil())
 
-			_, _, err = K8sExecInPod(ubuntu, "syscalls", []string{"bash", "-c", "touch /home/dummy"})
-			Expect(err).To(BeNil())
-			_, _, err = K8sExecInPod(ubuntu, "syscalls", []string{"bash", "-c", "unlink /home/dummy"})
-			Expect(err).To(BeNil())
+			AssertCommand(ubuntu, "syscalls", []string{"bash", "-c", "touch /home/dummy"}, MatchRegexp(".*"), true)
+			AssertCommand(ubuntu, "syscalls", []string{"bash", "-c", "unlink /home/dummy"}, MatchRegexp(".*"), true)
+
 
 			// check policy alert
 			expect := protobuf.Alert{
@@ -356,10 +334,9 @@ var _ = Describe("Syscalls", func() {
 			err = KarmorLogStart("policy", "syscalls", "Syscall", ubuntu)
 			Expect(err).To(BeNil())
 
-			_, _, err = K8sExecInPod(ubuntu, "syscalls", []string{"bash", "-c", "touch /home/dummy"})
-			Expect(err).To(BeNil())
-			_, _, err = K8sExecInPod(ubuntu, "syscalls", []string{"bash", "-c", "unlink /home/dummy"})
-			Expect(err).To(BeNil())
+			AssertCommand(ubuntu, "syscalls", []string{"bash", "-c", "touch /home/dummy"}, MatchRegexp(".*"), true)
+			AssertCommand(ubuntu, "syscalls", []string{"bash", "-c", "unlink /home/dummy"}, MatchRegexp(".*"), true)
+
 
 			// check policy alert
 			expect := protobuf.Alert{
@@ -385,10 +362,10 @@ var _ = Describe("Syscalls", func() {
 			err = KarmorLogStart("policy", "syscalls", "Syscall", ubuntu)
 			Expect(err).To(BeNil())
 
-			_, _, err = K8sExecInPod(ubuntu, "syscalls", []string{"bash", "-c", "touch /home/dummy"})
-			Expect(err).To(BeNil())
-			_, _, err = K8sExecInPod(ubuntu, "syscalls", []string{"bash", "-c", "unlink /home/dummy"})
-			Expect(err).To(BeNil())
+			
+			AssertCommand(ubuntu, "syscalls", []string{"bash", "-c", "touch /home/dummy"}, MatchRegexp(".*"), true)
+			AssertCommand(ubuntu, "syscalls", []string{"bash", "-c", "unlink /home/dummy"}, MatchRegexp(".*"), true)
+
 
 			// check policy alert
 			expect := protobuf.Alert{
@@ -414,10 +391,9 @@ var _ = Describe("Syscalls", func() {
 			err = KarmorLogStart("policy", "syscalls", "Syscall", ubuntu)
 			Expect(err).To(BeNil())
 
-			_, _, err = K8sExecInPod(ubuntu, "syscalls", []string{"bash", "-c", "touch /home/dummy"})
-			Expect(err).To(BeNil())
-			_, _, err = K8sExecInPod(ubuntu, "syscalls", []string{"bash", "-c", "unlink /home/dummy"})
-			Expect(err).To(BeNil())
+			AssertCommand(ubuntu, "syscalls", []string{"bash", "-c", "touch /home/dummy"}, MatchRegexp(".*"), false)
+			AssertCommand(ubuntu, "syscalls", []string{"bash", "-c", "unlink /home/dummy"}, MatchRegexp(".*"), false)
+
 
 			// check policy alert
 			expect := protobuf.Alert{
@@ -445,10 +421,9 @@ var _ = Describe("Syscalls", func() {
 			err = KarmorLogStart("policy", "syscalls", "Syscall", ubuntu)
 			Expect(err).To(BeNil())
 
-			_, _, err = K8sExecInPod(ubuntu, "syscalls", []string{"bash", "-c", "touch /home/dummy"})
-			Expect(err).To(BeNil())
-			_, _, err = K8sExecInPod(ubuntu, "syscalls", []string{"bash", "-c", "unlink /home/dummy"})
-			Expect(err).To(BeNil())
+			AssertCommand(ubuntu, "syscalls", []string{"bash", "-c", "touch /home/dummy"}, MatchRegexp(".*"), false)
+			AssertCommand(ubuntu, "syscalls", []string{"bash", "-c", "unlink /home/dummy"}, MatchRegexp(".*"), false)
+
 
 			// check policy alert
 			expect := protobuf.Alert{
@@ -474,10 +449,10 @@ var _ = Describe("Syscalls", func() {
 			err = KarmorLogStart("policy", "syscalls", "Syscall", ubuntu)
 			Expect(err).To(BeNil())
 
-			_, _, err = K8sExecInPod(ubuntu, "syscalls", []string{"bash", "-c", "touch /home/dummy"})
-			Expect(err).To(BeNil())
-			_, _, err = K8sExecInPod(ubuntu, "syscalls", []string{"bash", "-c", "unlink /home/dummy"})
-			Expect(err).To(BeNil())
+			
+			AssertCommand(ubuntu, "syscalls", []string{"bash", "-c", "touch /home/dummy"}, MatchRegexp(".*"), false)
+			AssertCommand(ubuntu, "syscalls", []string{"bash", "-c", "unlink /home/dummy"}, MatchRegexp(".*"), false)
+
 
 			// check policy alert
 			expect := protobuf.Alert{
@@ -503,10 +478,9 @@ var _ = Describe("Syscalls", func() {
 			err = KarmorLogStart("policy", "syscalls", "Syscall", ubuntu)
 			Expect(err).To(BeNil())
 
-			_, _, err = K8sExecInPod(ubuntu, "syscalls", []string{"bash", "-c", "touch /home/dummy"})
-			Expect(err).To(BeNil())
-			_, _, err = K8sExecInPod(ubuntu, "syscalls", []string{"bash", "-c", "unlink /home/dummy"})
-			Expect(err).To(BeNil())
+			
+			AssertCommand(ubuntu, "syscalls", []string{"bash", "-c", "touch /home/dummy"}, MatchRegexp(".*"), false)
+			AssertCommand(ubuntu, "syscalls", []string{"bash", "-c", "unlink /home/dummy"}, MatchRegexp(".*"), false)
 
 			// check policy alert
 			expect := protobuf.Alert{
@@ -532,10 +506,8 @@ var _ = Describe("Syscalls", func() {
 			err = KarmorLogStart("policy", "syscalls", "Syscall", ubuntu)
 			Expect(err).To(BeNil())
 
-			_, _, err = K8sExecInPod(ubuntu, "syscalls", []string{"bash", "-c", "touch /home/dummy"})
-			Expect(err).To(BeNil())
-			_, _, err = K8sExecInPod(ubuntu, "syscalls", []string{"bash", "-c", "unlink /home/dummy"})
-			Expect(err).To(BeNil())
+			AssertCommand(ubuntu, "syscalls", []string{"bash", "-c", "touch /home/dummy"}, MatchRegexp(".*"), false)
+			AssertCommand(ubuntu, "syscalls", []string{"bash", "-c", "unlink /home/dummy"}, MatchRegexp(".*"), false)
 
 			// check policy alert
 			expect := protobuf.Alert{
@@ -560,13 +532,15 @@ var _ = Describe("Syscalls", func() {
 			Expect(err).To(BeNil())
 
 			// execute mount inside the pod
-			sout, _, err := K8sExecInPod(ubuntu, "syscalls",
-				[]string{"bash", "-c", "mkdir /mnt/test"})
-			Expect(err).To(BeNil())
-			sout, _, err = K8sExecInPod(ubuntu, "syscalls",
-				[]string{"bash", "-c", "mount /home /mnt/test"})
-			Expect(err).To(BeNil())
-			fmt.Printf("OUTPUT: %s\n", sout)
+			AssertCommand(
+				ubuntu, "syscalls", []string{"bash", "-c", "mkdir /mnt/test"},
+				MatchRegexp(".*"), true,
+			)
+			
+			AssertCommand(
+				ubuntu, "syscalls", []string{"bash", "-c", "mount /home /mnt/test"},
+				MatchRegexp(".*"), true,
+			)
 
 			expect := protobuf.Alert{
 				PolicyName: "DefaultPosture",
@@ -589,10 +563,10 @@ var _ = Describe("Syscalls", func() {
 			Expect(err).To(BeNil())
 
 			// execute umount inside the pod
-			sout, _, err := K8sExecInPod(ubuntu, "syscalls",
-				[]string{"bash", "-c", "umount /mnt"})
-			Expect(err).To(BeNil())
-			fmt.Printf("OUTPUT: %s\n", sout)
+			AssertCommand(
+				ubuntu, "syscalls", []string{"bash", "-c", "umount /mnt"},
+				MatchRegexp(".*"), true,
+			)
 
 			expect := protobuf.Alert{
 				PolicyName: "DefaultPosture",

--- a/tests/k8s_env/syscalls/syscalls_test.go
+++ b/tests/k8s_env/syscalls/syscalls_test.go
@@ -4,7 +4,6 @@
 package syscalls
 
 import (
-
 	"time"
 
 	"github.com/kubearmor/KubeArmor/protobuf"
@@ -146,7 +145,6 @@ var _ = Describe("Syscalls", func() {
 			AssertCommand(ubuntu, "syscalls", []string{"bash", "-c", "touch /dummy"}, MatchRegexp(".*"), true)
 			AssertCommand(ubuntu, "syscalls", []string{"bash", "-c", "/unlink /dummy"}, MatchRegexp(".*"), true)
 
-
 			// check policy alert
 			expect := protobuf.Alert{
 				PolicyName: "audit-unlink-fromsource-path",
@@ -174,7 +172,6 @@ var _ = Describe("Syscalls", func() {
 
 			AssertCommand(ubuntu, "syscalls", []string{"bash", "-c", "touch /home/dummy"}, MatchRegexp(".*"), true)
 			AssertCommand(ubuntu, "syscalls", []string{"bash", "-c", "unlink /home/dummy"}, MatchRegexp(".*"), true)
-
 
 			// check policy alert
 			expect := protobuf.Alert{
@@ -253,7 +250,6 @@ var _ = Describe("Syscalls", func() {
 			AssertCommand(ubuntu, "syscalls", []string{"bash", "-c", "touch /home/dummy"}, MatchRegexp(".*"), true)
 			AssertCommand(ubuntu, "syscalls", []string{"bash", "-c", "unlink /home/dummy"}, MatchRegexp(".*"), true)
 
-
 			// check policy alert
 			expect := protobuf.Alert{
 				PolicyName: "audit-unlink-dir-recursive-fromsource-recursive-dir",
@@ -309,7 +305,6 @@ var _ = Describe("Syscalls", func() {
 			AssertCommand(ubuntu, "syscalls", []string{"bash", "-c", "touch /home/dummy"}, MatchRegexp(".*"), true)
 			AssertCommand(ubuntu, "syscalls", []string{"bash", "-c", "unlink /home/dummy"}, MatchRegexp(".*"), true)
 
-
 			// check policy alert
 			expect := protobuf.Alert{
 				PolicyName: "audit-unlink-global-information",
@@ -337,7 +332,6 @@ var _ = Describe("Syscalls", func() {
 			AssertCommand(ubuntu, "syscalls", []string{"bash", "-c", "touch /home/dummy"}, MatchRegexp(".*"), true)
 			AssertCommand(ubuntu, "syscalls", []string{"bash", "-c", "unlink /home/dummy"}, MatchRegexp(".*"), true)
 
-
 			// check policy alert
 			expect := protobuf.Alert{
 				PolicyName: "audit-unlink-local-information",
@@ -362,10 +356,8 @@ var _ = Describe("Syscalls", func() {
 			err = KarmorLogStart("policy", "syscalls", "Syscall", ubuntu)
 			Expect(err).To(BeNil())
 
-			
 			AssertCommand(ubuntu, "syscalls", []string{"bash", "-c", "touch /home/dummy"}, MatchRegexp(".*"), true)
 			AssertCommand(ubuntu, "syscalls", []string{"bash", "-c", "unlink /home/dummy"}, MatchRegexp(".*"), true)
-
 
 			// check policy alert
 			expect := protobuf.Alert{
@@ -393,7 +385,6 @@ var _ = Describe("Syscalls", func() {
 
 			AssertCommand(ubuntu, "syscalls", []string{"bash", "-c", "touch /home/dummy"}, MatchRegexp(".*"), false)
 			AssertCommand(ubuntu, "syscalls", []string{"bash", "-c", "unlink /home/dummy"}, MatchRegexp(".*"), false)
-
 
 			// check policy alert
 			expect := protobuf.Alert{
@@ -424,7 +415,6 @@ var _ = Describe("Syscalls", func() {
 			AssertCommand(ubuntu, "syscalls", []string{"bash", "-c", "touch /home/dummy"}, MatchRegexp(".*"), false)
 			AssertCommand(ubuntu, "syscalls", []string{"bash", "-c", "unlink /home/dummy"}, MatchRegexp(".*"), false)
 
-
 			// check policy alert
 			expect := protobuf.Alert{
 				PolicyName: "audit-unlink-global-information",
@@ -449,10 +439,8 @@ var _ = Describe("Syscalls", func() {
 			err = KarmorLogStart("policy", "syscalls", "Syscall", ubuntu)
 			Expect(err).To(BeNil())
 
-			
 			AssertCommand(ubuntu, "syscalls", []string{"bash", "-c", "touch /home/dummy"}, MatchRegexp(".*"), false)
 			AssertCommand(ubuntu, "syscalls", []string{"bash", "-c", "unlink /home/dummy"}, MatchRegexp(".*"), false)
-
 
 			// check policy alert
 			expect := protobuf.Alert{
@@ -478,7 +466,6 @@ var _ = Describe("Syscalls", func() {
 			err = KarmorLogStart("policy", "syscalls", "Syscall", ubuntu)
 			Expect(err).To(BeNil())
 
-			
 			AssertCommand(ubuntu, "syscalls", []string{"bash", "-c", "touch /home/dummy"}, MatchRegexp(".*"), false)
 			AssertCommand(ubuntu, "syscalls", []string{"bash", "-c", "unlink /home/dummy"}, MatchRegexp(".*"), false)
 
@@ -536,7 +523,7 @@ var _ = Describe("Syscalls", func() {
 				ubuntu, "syscalls", []string{"bash", "-c", "mkdir /mnt/test"},
 				MatchRegexp(".*"), true,
 			)
-			
+
 			AssertCommand(
 				ubuntu, "syscalls", []string{"bash", "-c", "mount /home /mnt/test"},
 				MatchRegexp(".*"), true,

--- a/tests/k8s_env/throttling/throttling_test.go
+++ b/tests/k8s_env/throttling/throttling_test.go
@@ -74,11 +74,11 @@ var _ = Describe("Smoke", func() {
 			// wait for policy creation
 			time.Sleep(5 * time.Second)
 
-			sout, _, err := K8sExecInPod(wp, "wordpress-mysql",
-				[]string{"bash", "-c", "count=0; while [ $count -lt 5 ]; do apt; count=$((count + 1)); done;"})
-			Expect(err).To(BeNil())
-			fmt.Printf("OUTPUT: %s\n", sout)
-			Expect(sout).To(MatchRegexp("apt.*Permission denied"))
+			AssertCommand(
+				wp, "wordpress-mysql",
+				[]string{"bash", "-c", "count=0; while [ $count -lt 5 ]; do apt; count=$((count + 1)); done;"},
+				MatchRegexp("apt.*Permission denied"), true,
+			)
 
 			// check policy violation alert
 			_, alerts, err := KarmorGetLogs(5*time.Second, 1)
@@ -93,11 +93,11 @@ var _ = Describe("Smoke", func() {
 			Expect(err).To(BeNil())
 
 			// check for throttling, alerts should not be genrated
-			sout, _, err = K8sExecInPod(wp, "wordpress-mysql",
-				[]string{"bash", "-c", "apt update"})
-			Expect(err).To(BeNil())
-			fmt.Printf("---START---\n%s---END---\n", sout)
-			Expect(sout).To(MatchRegexp("apt.*Permission denied"))
+			AssertCommand(
+				wp, "wordpress-mysql",
+				[]string{"bash", "-c", "apt update"},
+				MatchRegexp("apt.*Permission denied"), true,
+			)
 
 			_, alerts, err = KarmorGetLogs(5*time.Second, 1)
 			Expect(err).To(BeNil())

--- a/tests/k8s_env/visibility/visibility_test.go
+++ b/tests/k8s_env/visibility/visibility_test.go
@@ -4,7 +4,6 @@
 package visibility
 
 import (
-	"fmt"
 	"time"
 
 	"github.com/kubearmor/KubeArmor/tests/util"
@@ -62,7 +61,6 @@ var _ = Describe("Visibility", func() {
 
 			AssertCommand(wp, "wordpress-mysql", []string{"bash", "-c", "ping google.com -c1"}, MatchRegexp(".*"), true)
 
-
 			// check audit logs
 			logs, _, err := KarmorGetLogs(5*time.Second, 50)
 			Expect(err).To(BeNil())
@@ -89,7 +87,6 @@ var _ = Describe("Visibility", func() {
 			Expect(err).To(BeNil())
 
 			AssertCommand(wp, "wordpress-mysql", []string{"bash", "-c", "ping google.com -c1"}, MatchRegexp(".*"), true)
-
 
 			// check audit logs
 			logs, _, err := KarmorGetLogs(5*time.Second, 50)

--- a/tests/k8s_env/visibility/visibility_test.go
+++ b/tests/k8s_env/visibility/visibility_test.go
@@ -60,9 +60,8 @@ var _ = Describe("Visibility", func() {
 			err = KarmorLogStart("all", "wordpress-mysql", "", wp)
 			Expect(err).To(BeNil())
 
-			sout, _, err := K8sExecInPod(wp, "wordpress-mysql", []string{"bash", "-c", "ping google.com -c1"})
-			Expect(err).To(BeNil())
-			fmt.Printf("---START---\n%s---END---\n", sout)
+			AssertCommand(wp, "wordpress-mysql", []string{"bash", "-c", "ping google.com -c1"}, MatchRegexp(".*"), true)
+
 
 			// check audit logs
 			logs, _, err := KarmorGetLogs(5*time.Second, 50)
@@ -89,9 +88,8 @@ var _ = Describe("Visibility", func() {
 			err = KarmorLogStart("all", "wordpress-mysql", "", wp)
 			Expect(err).To(BeNil())
 
-			sout, _, err := K8sExecInPod(wp, "wordpress-mysql", []string{"bash", "-c", "ping google.com -c1"})
-			Expect(err).To(BeNil())
-			fmt.Printf("---START---\n%s---END---\n", sout)
+			AssertCommand(wp, "wordpress-mysql", []string{"bash", "-c", "ping google.com -c1"}, MatchRegexp(".*"), true)
+
 
 			// check audit logs
 			logs, _, err := KarmorGetLogs(5*time.Second, 50)
@@ -115,9 +113,7 @@ var _ = Describe("Visibility", func() {
 			err = KarmorLogStart("all", "wordpress-mysql", "", wp)
 			Expect(err).To(BeNil())
 
-			sout, _, err := K8sExecInPod(wp, "wordpress-mysql", []string{"bash", "-c", "ping google.com -c1"})
-			Expect(err).To(BeNil())
-			fmt.Printf("---START---\n%s---END---\n", sout)
+			AssertCommand(wp, "wordpress-mysql", []string{"bash", "-c", "ping google.com -c1"}, MatchRegexp(".*"), true)
 
 			// check audit logs
 			logs, _, err := KarmorGetLogs(5*time.Second, 50)


### PR DESCRIPTION
**Purpose of PR?**:

Fixes #1643 

**Does this PR introduce a breaking change?**
 NO
**If the changes in this PR are manually verified, list down the scenarios covered:**:
  changed K8sExecInPod calls  to AssertCommand  calls
**Additional information for reviewer?** :
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [ ] Bug fix. Fixes #<issue number>
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Commit has unit tests
- [ ] Commit has integration tests

<!--

The PR title message must follow convention:
`<type>(<scope>): <subject>`.

Where: <br />
- `type` is to define what type of PR is this.
  Most common types are:
    - `feat`      - for new features, not a new feature for build script
    - `fix`       - for bug fixes or improvements, not a fix for build script
    - `chore`     - changes not related to production code
    - `docs`      - changes related to documentation
    - `style`     - formatting, missing semi colons, linting fix etc; no significant production code changes
    - `test`      - adding missing tests, refactoring tests; no production code change
    - `refactor`  - refactoring production code, eg. renaming a variable or function name, there should not be any significant production code changes

- `scope` is a single word that best describes where the changes fit.
    - feature(`monitor`,`enforcer`)
    - test(`tests`, `bdd`)
    - chore(`build`)
- `subject` is a single line brief description of the changes made in the pull request.

-->