### PR TITLE
fix(operator): snitch conditional mounts

### DIFF
--- a/deployments/helm/KubeArmorOperator/templates/clusterrole-rbac.yaml
+++ b/deployments/helm/KubeArmorOperator/templates/clusterrole-rbac.yaml
@@ -247,6 +247,34 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
+  name: {{ .Values.kubearmorOperator.name }}-manage-snitch-job
+  namespace: {{ .Release.Namespace }}
+rules:
+# to handle snitch mounts dynamically  
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - list
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - list  
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - get
+  - create
+  - delete  
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
   name: {{ .Values.kubearmorOperator.name }}-tls-secrets-role
   namespace: {{ .Release.Namespace }}
 rules:

--- a/pkg/KubeArmorOperator/internal/controller/resources.go
+++ b/pkg/KubeArmorOperator/internal/controller/resources.go
@@ -322,7 +322,7 @@ func deploySnitch(nodename string, runtime string) *batchv1.Job {
 						VolumeSource: corev1.VolumeSource{
 							HostPath: &corev1.HostPathVolumeSource{
 								Path: "/etc/apparmor.d/",
-								Type: &common.HostPathDirectoryOrCreate,
+								Type: &common.HostPathDirectory,
 							},
 						},
 					},


### PR DESCRIPTION
**Purpose of PR?**:

Snitch Job would be failed to deploy if mount hostpath not exists on nodes with readonly filesystem. 

```
Warning  Failed  11s                
kubelet  Error: failed to generate container "4cb6ea54ef292997cb29e5670d63830015704ec7c1f8fe87e55968280a54e835" 
spec: failed to apply OCI options: failed to mkdir "/etc/apparmor.d/": mkdir /etc/apparmor.d/: read-only file system
```

This PR adds changes to check if snitch job failed due to mount failure in both non-exist path and read-only file system cases. If so re-deploy snitch without these conflicting mounts. 

**Does this PR introduce a breaking change?**
No
**If the changes in this PR are manually verified, list down the scenarios covered:**:

**Additional information for reviewer?** :
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [x] Bug fix.
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Commit has unit tests
- [ ] Commit has integration tests

<!--

The PR title message must follow convention:
`<type>(<scope>): <subject>`.

Where: <br />
- `type` is to define what type of PR is this.
  Most common types are:
    - `feat`      - for new features, not a new feature for build script
    - `fix`       - for bug fixes or improvements, not a fix for build script
    - `chore`     - changes not related to production code
    - `docs`      - changes related to documentation
    - `style`     - formatting, missing semi colons, linting fix etc; no significant production code changes
    - `test`      - adding missing tests, refactoring tests; no production code change
    - `refactor`  - refactoring production code, eg. renaming a variable or function name, there should not be any significant production code changes

- `scope` is a single word that best describes where the changes fit.
    - feature(`monitor`,`enforcer`)
    - test(`tests`, `bdd`)
    - chore(`build`)
- `subject` is a single line brief description of the changes made in the pull request.

-->