### PR TITLE
fix(build): inject Build Info into systemd package #1928

### DIFF
--- a/KubeArmor/.goreleaser.yaml
+++ b/KubeArmor/.goreleaser.yaml
@@ -10,6 +10,11 @@ builds:
       - arm64
     env:
       - CGO_ENABLED=0
+    ldflags:
+      - "-X main.BuildDate={{.Date}}"
+      - "-X main.GitCommit={{.Commit}}"
+      - "-X main.GitBranch={{.Branch}}"
+      - "-X main.GitSummary={{.Summary}}"
 
 release:
   replace_existing_artifacts: true


### PR DESCRIPTION
**Purpose of PR?**:

This PR ensures that Build Info is included in the KubeArmor systemd package, which was previously missing.

Fixes #1921 

**Does this PR introduce a breaking change?**

No


**Checklist:**
- [ ] Bug fix. Fixes #1921 
 
 