### PR TITLE
feat(operator): add karmor.yaml into kubearmor configmap

### DIFF
--- a/pkg/KubeArmorOperator/common/defaults.go
+++ b/pkg/KubeArmorOperator/common/defaults.go
@@ -8,6 +8,7 @@ import (
 	"crypto/sha512"
 	"encoding/hex"
 	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 
@@ -333,8 +334,8 @@ var CommonVolumes = []corev1.Volume{
 				},
 				Items: []corev1.KeyToPath{
 					{
-						Key:  "karmor.yaml",
-						Path: "karmor.yaml",
+						Key:  KubeArmorConfigFileName,
+						Path: KubeArmorConfigFileName,
 					},
 				},
 			},
@@ -354,8 +355,8 @@ var CommonVolumesMount = []corev1.VolumeMount{
 	},
 	{
 		Name:      "kubearmor-config",
-		MountPath: "/opt/kubearmor/karmor.yaml",
-		SubPath:   "karmor.yaml",
+		MountPath: filepath.Join("/opt/kubearmor", KubeArmorConfigFileName),
+		SubPath:   KubeArmorConfigFileName,
 	},
 }
 

--- a/pkg/KubeArmorOperator/common/defaults.go
+++ b/pkg/KubeArmorOperator/common/defaults.go
@@ -76,6 +76,8 @@ var (
 
 	// KubeArmorConfigMapName string = "kubearmor-config"
 
+	KubeArmorConfigFileName string = "karmor.yaml"
+
 	// ConfigMap Data
 	ConfigGRPC                       string = "gRPC"
 	ConfigVisibility                 string = "visibility"

--- a/pkg/KubeArmorOperator/common/defaults.go
+++ b/pkg/KubeArmorOperator/common/defaults.go
@@ -324,6 +324,22 @@ var CommonVolumes = []corev1.Volume{
 			},
 		},
 	},
+	{
+		Name: "kubearmor-config",
+		VolumeSource: corev1.VolumeSource{
+			ConfigMap: &corev1.ConfigMapVolumeSource{
+				LocalObjectReference: corev1.LocalObjectReference{
+					Name: "kubearmor-config",
+				},
+				Items: []corev1.KeyToPath{
+					{
+						Key:  "karmor.yaml",
+						Path: "karmor.yaml",
+					},
+				},
+			},
+		},
+	},
 }
 
 var CommonVolumesMount = []corev1.VolumeMount{
@@ -335,6 +351,11 @@ var CommonVolumesMount = []corev1.VolumeMount{
 		Name:      "proc-fs-mount",
 		MountPath: "/host/procfs",
 		ReadOnly:  true,
+	},
+	{
+		Name:      "kubearmor-config",
+		MountPath: "/opt/kubearmor/karmor.yaml",
+		SubPath:   "karmor.yaml",
 	},
 }
 

--- a/pkg/KubeArmorOperator/common/defaults.go
+++ b/pkg/KubeArmorOperator/common/defaults.go
@@ -326,11 +326,11 @@ var CommonVolumes = []corev1.Volume{
 		},
 	},
 	{
-		Name: "kubearmor-config",
+		Name: deployments.KubeArmorConfigMapName,
 		VolumeSource: corev1.VolumeSource{
 			ConfigMap: &corev1.ConfigMapVolumeSource{
 				LocalObjectReference: corev1.LocalObjectReference{
-					Name: "kubearmor-config",
+					Name: deployments.KubeArmorConfigMapName,
 				},
 				Items: []corev1.KeyToPath{
 					{
@@ -354,7 +354,7 @@ var CommonVolumesMount = []corev1.VolumeMount{
 		ReadOnly:  true,
 	},
 	{
-		Name:      "kubearmor-config",
+		Name:      deployments.KubeArmorConfigMapName,
 		MountPath: filepath.Join("/opt/kubearmor", KubeArmorConfigFileName),
 		SubPath:   KubeArmorConfigFileName,
 	},

--- a/pkg/KubeArmorOperator/internal/controller/cluster.go
+++ b/pkg/KubeArmorOperator/internal/controller/cluster.go
@@ -1296,35 +1296,35 @@ func UpdateConfigMapData(config *opv1.KubeArmorConfigSpec) bool {
 			common.ConfigMapData[common.ConfigDefaultFilePosture] = string(config.DefaultFilePosture)
 			updated = true
 		}
-		configMapData += fmt.Sprintf("defaultFilePosture: %s\n", config.DefaultFilePosture)
+		configMapData += fmt.Sprintf("%s: %s\n", common.ConfigDefaultFilePosture, config.DefaultFilePosture)
 	}
 	if config.DefaultCapabilitiesPosture != "" {
 		if common.ConfigMapData[common.ConfigDefaultCapabilitiesPosture] != string(config.DefaultCapabilitiesPosture) {
 			common.ConfigMapData[common.ConfigDefaultCapabilitiesPosture] = string(config.DefaultCapabilitiesPosture)
 			updated = true
 		}
-		configMapData += fmt.Sprintf("defaultCapabilitiesPosture: %s\n", config.DefaultCapabilitiesPosture)
+		configMapData += fmt.Sprintf("%s: %s\n", common.ConfigDefaultCapabilitiesPosture, config.DefaultCapabilitiesPosture)
 	}
 	if config.DefaultNetworkPosture != "" {
 		if common.ConfigMapData[common.ConfigDefaultNetworkPosture] != string(config.DefaultNetworkPosture) {
 			common.ConfigMapData[common.ConfigDefaultNetworkPosture] = string(config.DefaultNetworkPosture)
 			updated = true
 		}
-		configMapData += fmt.Sprintf("defaultNetworkPosture: %s\n", config.DefaultNetworkPosture)
+		configMapData += fmt.Sprintf("%s: %s\n", common.ConfigDefaultNetworkPosture, config.DefaultNetworkPosture)
 	}
 	if config.DefaultVisibility != "" {
 		if common.ConfigMapData[common.ConfigVisibility] != config.DefaultVisibility {
 			common.ConfigMapData[common.ConfigVisibility] = config.DefaultVisibility
 			updated = true
 		}
-		configMapData += fmt.Sprintf("defaultVisibility: %s\n", config.DefaultVisibility)
+		configMapData += fmt.Sprintf("%s: %s\n", common.ConfigVisibility, config.DefaultVisibility)
 	}
 	AlertThrottlingEnabled := strconv.FormatBool(config.AlertThrottling)
 	if common.ConfigMapData[common.ConfigAlertThrottling] != AlertThrottlingEnabled {
 		common.ConfigMapData[common.ConfigAlertThrottling] = AlertThrottlingEnabled
 		updated = true
 	}
-	configMapData += fmt.Sprintf("alertThrottling: %t\n", config.AlertThrottling)
+	configMapData += fmt.Sprintf("%s: %t\n", common.ConfigAlertThrottling, config.AlertThrottling)
 
 	MaxAlertPerSec := strconv.FormatInt(int64(config.MaxAlertPerSec), 10)
 	if config.MaxAlertPerSec == 0 {
@@ -1334,7 +1334,7 @@ func UpdateConfigMapData(config *opv1.KubeArmorConfigSpec) bool {
 		common.ConfigMapData[common.ConfigMaxAlertPerSec] = MaxAlertPerSec
 		updated = true
 	}
-	configMapData += fmt.Sprintf("maxAlertPerSec: %s\n", MaxAlertPerSec)
+	configMapData += fmt.Sprintf("%s: %s\n", common.ConfigMaxAlertPerSec, MaxAlertPerSec)
 
 	ThrottleSec := strconv.FormatInt(int64(config.ThrottleSec), 10)
 	if config.ThrottleSec == 0 {
@@ -1349,7 +1349,7 @@ func UpdateConfigMapData(config *opv1.KubeArmorConfigSpec) bool {
 		common.ConfigMapData[common.ConfigThrottleSec] = ThrottleSec
 		updated = true
 	}
-	configMapData += fmt.Sprintf("throttleSec: %s\n", ThrottleSec)
+	configMapData += fmt.Sprintf("%s: %s\n", common.ConfigThrottleSec, ThrottleSec)
 
 	common.ConfigMapData[common.KubeArmorConfigFileName] = configMapData
 

--- a/pkg/KubeArmorOperator/internal/controller/cluster.go
+++ b/pkg/KubeArmorOperator/internal/controller/cluster.go
@@ -1289,35 +1289,43 @@ func UpdateRecommendedPolicyConfig(config *opv1.KubeArmorConfigSpec) bool {
 
 func UpdateConfigMapData(config *opv1.KubeArmorConfigSpec) bool {
 	updated := false
+	configMapData := ""
+
 	if config.DefaultFilePosture != "" {
 		if common.ConfigMapData[common.ConfigDefaultFilePosture] != string(config.DefaultFilePosture) {
 			common.ConfigMapData[common.ConfigDefaultFilePosture] = string(config.DefaultFilePosture)
 			updated = true
 		}
+		configMapData += fmt.Sprintf("defaultFilePosture: %s\n", config.DefaultFilePosture)
 	}
 	if config.DefaultCapabilitiesPosture != "" {
 		if common.ConfigMapData[common.ConfigDefaultCapabilitiesPosture] != string(config.DefaultCapabilitiesPosture) {
 			common.ConfigMapData[common.ConfigDefaultCapabilitiesPosture] = string(config.DefaultCapabilitiesPosture)
 			updated = true
 		}
+		configMapData += fmt.Sprintf("defaultCapabilitiesPosture: %s\n", config.DefaultCapabilitiesPosture)
 	}
 	if config.DefaultNetworkPosture != "" {
 		if common.ConfigMapData[common.ConfigDefaultNetworkPosture] != string(config.DefaultNetworkPosture) {
 			common.ConfigMapData[common.ConfigDefaultNetworkPosture] = string(config.DefaultNetworkPosture)
 			updated = true
 		}
+		configMapData += fmt.Sprintf("defaultNetworkPosture: %s\n", config.DefaultNetworkPosture)
 	}
 	if config.DefaultVisibility != "" {
 		if common.ConfigMapData[common.ConfigVisibility] != config.DefaultVisibility {
 			common.ConfigMapData[common.ConfigVisibility] = config.DefaultVisibility
 			updated = true
 		}
+		configMapData += fmt.Sprintf("defaultVisibility: %s\n", config.DefaultVisibility)
 	}
 	AlertThrottlingEnabled := strconv.FormatBool(config.AlertThrottling)
 	if common.ConfigMapData[common.ConfigAlertThrottling] != AlertThrottlingEnabled {
 		common.ConfigMapData[common.ConfigAlertThrottling] = AlertThrottlingEnabled
 		updated = true
 	}
+	configMapData += fmt.Sprintf("alertThrottling: %t\n", config.AlertThrottling)
+
 	MaxAlertPerSec := strconv.FormatInt(int64(config.MaxAlertPerSec), 10)
 	if config.MaxAlertPerSec == 0 {
 		MaxAlertPerSec = common.DefaultMaxAlertPerSec
@@ -1326,6 +1334,7 @@ func UpdateConfigMapData(config *opv1.KubeArmorConfigSpec) bool {
 		common.ConfigMapData[common.ConfigMaxAlertPerSec] = MaxAlertPerSec
 		updated = true
 	}
+	configMapData += fmt.Sprintf("maxAlertPerSec: %s\n", MaxAlertPerSec)
 
 	ThrottleSec := strconv.FormatInt(int64(config.ThrottleSec), 10)
 	if config.ThrottleSec == 0 {
@@ -1340,6 +1349,10 @@ func UpdateConfigMapData(config *opv1.KubeArmorConfigSpec) bool {
 		common.ConfigMapData[common.ConfigThrottleSec] = ThrottleSec
 		updated = true
 	}
+	configMapData += fmt.Sprintf("throttleSec: %s\n", ThrottleSec)
+
+	common.ConfigMapData[common.KubeArmorConfigFileName] = configMapData
+
 	return updated
 }
 


### PR DESCRIPTION
**Purpose of PR?**:

Introduces a new field `karmor.yaml` in the ConfigMap `kubearmor-config` created by KubeArmor Operator. This field can be mounted into KubeArmor Pods so that the configuration can be done by Viper, deprecating Config Watcher in KubeArmor

Fixes https://github.com/kubearmor/KubeArmor/issues/1920

**Does this PR introduce a breaking change?**

Configuration using `karmor.yaml` will eventually replace the other fields in the config map

**If the changes in this PR are manually verified, list down the scenarios covered:**:
Verified both fields in config map are having same values

**Additional information for reviewer?** :
Continuation of https://github.com/kubearmor/KubeArmor/pull/1862


**Checklist:**
- [ ] Bug fix. Fixes #<issue number>
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Commit has unit tests
- [ ] Commit has integration tests

<!--

The PR title message must follow convention:
`<type>(<scope>): <subject>`.

Where: <br />
- `type` is to define what type of PR is this.
  Most common types are:
    - `feat`      - for new features, not a new feature for build script
    - `fix`       - for bug fixes or improvements, not a fix for build script
    - `chore`     - changes not related to production code
    - `docs`      - changes related to documentation
    - `style`     - formatting, missing semi colons, linting fix etc; no significant production code changes
    - `test`      - adding missing tests, refactoring tests; no production code change
    - `refactor`  - refactoring production code, eg. renaming a variable or function name, there should not be any significant production code changes

- `scope` is a single word that best describes where the changes fit.
    - feature(`monitor`,`enforcer`)
    - test(`tests`, `bdd`)
    - chore(`build`)
- `subject` is a single line brief description of the changes made in the pull request.

-->