### PR TITLE
[bug] Fixed the panic for uninitialized docker daemon

### DIFF
--- a/KubeArmor/core/dockerHandler.go
+++ b/KubeArmor/core/dockerHandler.go
@@ -264,7 +264,8 @@ func (dm *KubeArmorDaemon) GetAlreadyDeployedDockerContainers() {
 		var err error
 		Docker, err = NewDockerHandler()
 		if err != nil {
-			dm.Logger.Errf("Failed to create new Docker client: %s", err)
+			dm.Logger.Errf("Failed to create new Docker client: %s", err.Error())
+			return
 		}
 	}
 
@@ -747,7 +748,8 @@ func (dm *KubeArmorDaemon) MonitorDockerEvents() {
 		var err error
 		Docker, err = NewDockerHandler()
 		if err != nil {
-			dm.Logger.Errf("Failed to create new Docker client: %s", err)
+			dm.Logger.Errf("Failed to create new Docker client: %s", err.Error())
+			return
 		}
 	}
 


### PR DESCRIPTION
**Purpose of PR?**:

Fixes #1948 

**Does this PR introduce a breaking change?** No

**If the changes in this PR are manually verified, list down the scenarios covered:**:

**Additional information for reviewer?** :
cc @daemon1024 I am not able to reproduce the error, please can you verify whether this change is able to avoid panic or help me in reproducing this panic

**Checklist:**
- [x] Bug fix. Fixes #<issue number>
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Commit has unit tests
- [ ] Commit has integration tests

<!--

The PR title message must follow convention:
`<type>(<scope>): <subject>`.

Where: <br />
- `type` is to define what type of PR is this.
  Most common types are:
    - `feat`      - for new features, not a new feature for build script
    - `fix`       - for bug fixes or improvements, not a fix for build script
    - `chore`     - changes not related to production code
    - `docs`      - changes related to documentation
    - `style`     - formatting, missing semi colons, linting fix etc; no significant production code changes
    - `test`      - adding missing tests, refactoring tests; no production code change
    - `refactor`  - refactoring production code, eg. renaming a variable or function name, there should not be any significant production code changes

- `scope` is a single word that best describes where the changes fit.
    - feature(`monitor`,`enforcer`)
    - test(`tests`, `bdd`)
    - chore(`build`)
- `subject` is a single line brief description of the changes made in the pull request.

-->