### PR TITLE
Correct tolerations placement in deployment

### DIFF
--- a/deployments/helm/KubeArmorOperator/templates/deployment.yaml
+++ b/deployments/helm/KubeArmorOperator/templates/deployment.yaml
@@ -29,7 +29,7 @@ spec:
       imagePullSecrets:
       {{ toYaml .Values.kubearmorOperator.image.imagePullSecrets | indent 6 }}
       {{- end }}
-      {{- if .Values.kubearmorOperator.image.tolerations }}
+      {{- if .Values.kubearmorOperator.tolerations }}
       tolerations:
       {{ toYaml .Values.kubearmorOperator.tolerations | indent 6 }}
       {{- end }}


### PR DESCRIPTION
Fix improper tolerations configuration in kubearmorOperator Deployment

The tolerations setting was placed incorrectly in the Deployment spec.  This update relocates it to the correct section, allowing for intended  functionality when deploying the operator.

**Purpose of PR?**:

Fixes #[1966](https://github.com/kubearmor/KubeArmor/issues/1966)

**Does this PR introduce a breaking change?**
 This does not introduce a breaking change

**Checklist:**
- [ ] Bug fix. Fixes #1966

<!--

The PR title message must follow convention:
`<type>(<scope>): <subject>`.

Where: <br />
- `type` is to define what type of PR is this.
  Most common types are:
    - `feat`      - for new features, not a new feature for build script
    - `fix`       - for bug fixes or improvements, not a fix for build script
    - `chore`     - changes not related to production code
    - `docs`      - changes related to documentation
    - `style`     - formatting, missing semi colons, linting fix etc; no significant production code changes
    - `test`      - adding missing tests, refactoring tests; no production code change
    - `refactor`  - refactoring production code, eg. renaming a variable or function name, there should not be any significant production code changes

- `scope` is a single word that best describes where the changes fit.
    - feature(`monitor`,`enforcer`)
    - test(`tests`, `bdd`)
    - chore(`build`)
- `subject` is a single line brief description of the changes made in the pull request.

-->