### PR TITLE
fix: remove leftover kube-rbac-proxy container annotation

### DIFF
--- a/pkg/KubeArmorController/config/manager/manager.yaml
+++ b/pkg/KubeArmorController/config/manager/manager.yaml
@@ -21,7 +21,6 @@ spec:
     metadata:
       annotations:
         container.apparmor.security.beta.kubernetes.io/manager: unconfined
-        container.apparmor.security.beta.kubernetes.io/kube-rbac-proxy: unconfined
         kubectl.kubernetes.io/default-container: manager
       labels:
         control-plane: controller-manager


### PR DESCRIPTION
**Purpose of PR?**:

Fixes https://github.com/kubearmor/KubeArmor/issues/1973

**Does this PR introduce a breaking change?**
no

**Additional information for reviewer?** :
`kube-rbac-proxy` container of `kubearmor-controller` deployment was deprecated in https://github.com/kubearmor/KubeArmor/pull/1913. weirdly, the artifact printed in the thread doesn't include this annotation, but it was never removed and now causes issues w/ helm install.

**Manual test details**:
tested on k3s. deploying the controller with `make deploy` fails on `main` and `tags/v1.5.2`, reproducing #1973, and succeeds on this branch.
```
# before
$ make deploy
...
The Deployment "kubearmor-controller-manager" is invalid: spec.template.annotations[container.apparmor.security.beta.kubernetes.io/kube-rbac-proxy]: Invalid value: "kube-rbac-proxy": container not found
make: *** [Makefile:148: deploy] Error 1

# after
$ make deploy
...
deployment.apps/kubearmor-controller-manager created
...
```

**Checklist:**
- [x] Bug fix. Fixes #1973
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Commit has unit tests
- [ ] Commit has integration tests

<!--

The PR title message must follow convention:
`<type>(<scope>): <subject>`.

Where: <br />
- `type` is to define what type of PR is this.
  Most common types are:
    - `feat`      - for new features, not a new feature for build script
    - `fix`       - for bug fixes or improvements, not a fix for build script
    - `chore`     - changes not related to production code
    - `docs`      - changes related to documentation
    - `style`     - formatting, missing semi colons, linting fix etc; no significant production code changes
    - `test`      - adding missing tests, refactoring tests; no production code change
    - `refactor`  - refactoring production code, eg. renaming a variable or function name, there should not be any significant production code changes

- `scope` is a single word that best describes where the changes fit.
    - feature(`monitor`,`enforcer`)
    - test(`tests`, `bdd`)
    - chore(`build`)
- `subject` is a single line brief description of the changes made in the pull request.

-->