### PR TITLE
chore(k3s): removed the auto-detection of docker runtime from k3s installation script

### DIFF
--- a/contribution/k3s/install_k3s.sh
+++ b/contribution/k3s/install_k3s.sh
@@ -3,9 +3,10 @@
 # Copyright 2021 Authors of KubeArmor
 
 if [ "$RUNTIME" == "" ]; then
-    if [ -S /var/run/docker.sock ]; then
-        RUNTIME="docker"
-    elif [ -S /var/run/crio/crio.sock ]; then
+    # TODO: Enable the support for docker here. Currently docker runtime in k3s env is leading to the issue:
+    # https://github.com/kubearmor/KubeArmor/issues/1971
+    # Once this issue is fixed, we can support docker again in k3s
+    if [ -S /var/run/crio/crio.sock ]; then
         RUNTIME="crio"
     else # default
         RUNTIME="containerd"


### PR DESCRIPTION
**Purpose of PR?**: Till #1971 is not fixed, we can stop the support for docker runtime in k3s env, once the issue is fixed we can re-support the docker and remove the TODO

Fixes: A temporary fix for: #1971

**Does this PR introduce a breaking change?** No

**If the changes in this PR are manually verified, list down the scenarios covered:**: Yes I tested running in k3s enviornment with docker.sock present and it was running the containerd pod

![Screenshot from 2025-02-19 18-38-56](https://github.com/user-attachments/assets/430b0875-1baf-4647-9837-7c88cfe845bb)


**Additional information for reviewer?** :
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [ ] Bug fix. Fixes #<issue number>
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Commit has unit tests
- [ ] Commit has integration tests

<!--

The PR title message must follow convention:
`<type>(<scope>): <subject>`.

Where: <br />
- `type` is to define what type of PR is this.
  Most common types are:
    - `feat`      - for new features, not a new feature for build script
    - `fix`       - for bug fixes or improvements, not a fix for build script
    - `chore`     - changes not related to production code
    - `docs`      - changes related to documentation
    - `style`     - formatting, missing semi colons, linting fix etc; no significant production code changes
    - `test`      - adding missing tests, refactoring tests; no production code change
    - `refactor`  - refactoring production code, eg. renaming a variable or function name, there should not be any significant production code changes

- `scope` is a single word that best describes where the changes fit.
    - feature(`monitor`,`enforcer`)
    - test(`tests`, `bdd`)
    - chore(`build`)
- `subject` is a single line brief description of the changes made in the pull request.

-->