### PR TITLE
docs/support-matrix: AWS EKS auto mode

### DIFF
--- a/getting-started/support_matrix.md
+++ b/getting-started/support_matrix.md
@@ -21,6 +21,7 @@ KubeArmor supports following types of workloads:
 | AWS        | [EKS] | Amazon Linux 2 (kernel >=5.8) | x86_64 | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | [BPFLSM] |
 | AWS        | [EKS] | Ubuntu | x86_64 | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | AppArmor |
 | AWS        | [EKS] | [Bottlerocket] | x86_64 | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | [BPFLSM] |
+| AWS        | [EKS-Auto-Mode] | [Bottlerocket] | x86_64 | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | [BPFLSM] |
 | AWS        | [Graviton] | Ubuntu | ARM | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | AppArmor |
 | AWS        | [Graviton] | Amazon Linux 2 | ARM | :heavy_check_mark: | :heavy_check_mark: | :x: | :heavy_check_mark: | SELinux |
 | RedHat     | [OpenShift] | [RHEL] <=8.4 | x86_64 | :heavy_check_mark: | :heavy_check_mark: | :x:  | :heavy_check_mark: | SELinux |
@@ -40,6 +41,7 @@ KubeArmor supports following types of workloads:
 [Network-Segmentation]: network_segmentation.md
 [GKE]: https://cloud.google.com/kubernetes-engine
 [EKS]: https://aws.amazon.com/eks/
+[EKS-Auto-Mode]: https://aws.amazon.com/eks/auto-mode/
 [AKS]: https://azure.microsoft.com/
 [COS]: https://cloud.google.com/container-optimized-os/docs/concepts/features-and-benefits
 [GKE-REL]: https://cloud.google.com/kubernetes-engine/docs/concepts/release-channels


### PR DESCRIPTION
**Purpose of PR?**:

[Amazon EKS Auto Mode](https://aws.amazon.com/eks/auto-mode/) fully automates Kubernetes cluster management for compute, storage, and networking on AWS with a single click. It simplifies Kubernetes management by automatically provisioning infrastructure, selecting optimal compute instances, dynamically scaling resources, continuously optimizing costs, managing core add-ons, patching operating systems, and integrating with AWS security services.

KubeArmor deploys seamlessly on EKS with Auto Mode on. The EKS-Auto-Mode deployment script was used from [here](https://aws.amazon.com/blogs/containers/getting-started-with-amazon-eks-auto-mode/).

```
❯ aws eks update-kubeconfig --region us-west-2 --name eks-auto-mode-demo
Added new context arn:aws:eks:us-west-2:975050082972:cluster/eks-auto-mode-demo to /home/rahul/.kube/config
❯ kgpa
No resources found
❯ karmor version
karmor version 1.3.3 linux/amd64 BuildDate=2025-02-27T07:49:50Z
current version is the latest
kubearmor not running
❯ karmor install
🛡       Installed helm release : kubearmor-operator
😄      KubeArmorConfig created
⌚️      This may take a couple of minutes
🥳      KubeArmor Snitch Deployed!
🥳      KubeArmor Daemonset Deployed!
🥳      Done Checking , ALL Services are running!
⌚️      Execution Time : 1m45.58173621s

🔧      Verifying KubeArmor functionality (this may take upto a minute)...

        🛡️       Your Cluster is Armored Up!
❯ kgpa
NAMESPACE   NAME                                   READY   STATUS      RESTARTS   AGE
kubearmor   kubearmor-bpf-containerd-98c2c-9f69w   1/1     Running     0          53s
kubearmor   kubearmor-controller-fb48f95d8-cr5v5   1/1     Running     0          46s
kubearmor   kubearmor-operator-7b897cd8fc-b7t5n    1/1     Running     0          2m4s
kubearmor   kubearmor-relay-6c4bdd7c9f-j876c       1/1     Running     0          58s
kubearmor   kubearmor-snitch-qkmrc-kqxxh           0/1     Completed   0          56s
❯ kgpa
NAMESPACE   NAME                                   READY   STATUS      RESTARTS   AGE
kubearmor   kubearmor-bpf-containerd-98c2c-9f69w   1/1     Running     0          57s
kubearmor   kubearmor-controller-fb48f95d8-cr5v5   1/1     Running     0          50s
kubearmor   kubearmor-operator-7b897cd8fc-b7t5n    1/1     Running     0          2m8s
kubearmor   kubearmor-relay-6c4bdd7c9f-j876c       1/1     Running     0          62s
kubearmor   kubearmor-snitch-qkmrc-kqxxh           0/1     Completed   0          60s
❯ k get nodes -o wide
NAME                  STATUS   ROLES    AGE    VERSION               INTERNAL-IP      EXTERNAL-IP   OS-IMAGE                                           KERNEL-VERSION   CONTAINER-RUNTIME
i-029ae703c5fea559f   Ready    <none>   109s   v1.31.4-eks-0f56d01   192.168.139.80   <none>        Bottlerocket (EKS Auto) 2025.2.22 (aws-k8s-1.31)   6.1.127          containerd://1.7.25+bottlerocket
```

Fixes #

**Does this PR introduce a breaking change?**
No ... No code changes were made.

**If the changes in this PR are manually verified, list down the scenarios covered:**:
1. Deploy EKS-Auto-mode using instructions [here](https://aws.amazon.com/blogs/containers/getting-started-with-amazon-eks-auto-mode/).
2. Download kubeconfig using `aws eks update-kubeconfig --region us-west-2 --name eks-auto-mode-demo`
3. Then use `karmor install` to install kubearmor

**Additional information for reviewer?** :
_Mention if this PR is part of any design or a continuation of previous PRs_
NA

**Checklist:**
- [x] Bug fix
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
