### PR TITLE
fix(monitor): fix network event returned values

### DIFF
--- a/KubeArmor/monitor/systemMonitor.go
+++ b/KubeArmor/monitor/systemMonitor.go
@@ -503,7 +503,7 @@ func (mon *SystemMonitor) InitBPF() error {
 	sysTracepoints := [][2]string{{"syscalls", "sys_exit_openat"}}
 	sysKprobes := []string{"do_exit", "security_bprm_check", "security_file_open", "security_path_mknod", "security_path_unlink", "security_path_rmdir", "security_ptrace_access_check"}
 	netSyscalls := []string{"tcp_connect"}
-	netRetSyscalls := []string{"inet_csk_accept"}
+	netRetSyscalls := []string{"inet_csk_accept", "tcp_connect"}
 
 	if mon.BpfModule != nil {
 


### PR DESCRIPTION
**Purpose of PR?**:

on arm based cluster observed network event with `Result: Unknown error` this PR handles this issue by handling returned values in network related kernel functions. 

```
Resource: remoteip=127.0.0.1 port=4369 protocol=TCP
Operation: Network
Data: kprobe=tcp_connect domain=AF_INET
Result: Unknown error
Cwd: /
HostPID: 18670
HostPPID: 13035
Owner: map[Name:discovery-engine Namespace:agents Ref:Deployment]
PID: 308
PPID: 26
```

**Does this PR introduce a breaking change?**
No
**If the changes in this PR are manually verified, list down the scenarios covered:**:

tested on arm based cluster:

```
NAME                                              STATUS   ROLES    AGE   VERSION               INTERNAL-IP     EXTERNAL-IP    OS-IMAGE                             KERNEL-VERSION   CONTAINER-RUNTIME
gke-ramakant-cluster-default-pool-bc60856a-pk8v   Ready    <none>   25h   v1.32.2-gke.1182003   10.128.15.202   34.29.81.188   Container-Optimized OS from Google   6.6.72+          containerd://1.7.24
```

```
== Log / 2025-04-30 08:00:00.429695 ==
ClusterName: ramakant-cluster
HostName: gke-ramakant-cluster-default-pool-bc60856a-pk8v
NamespaceName: default
PodName: nginx-7d988b97c-nprq8
Labels: app=nginx
ContainerName: nginx
ContainerID: 12051c6b1e8987a7c994a42bc48b731b15ec960e3f751619ed49fe7e3758dc2e
ContainerImage: docker.io/library/nginx:latest@sha256:c15da6c91de8d2f436196f3a768483ad32c258ed4e1beb3d367a27ed67253e66
Type: ContainerLog
Source: /usr/bin/curl 10.44.0.17
Resource: remoteip=10.44.0.17 port=80 protocol=TCP
Operation: Network
Data: kprobe=tcp_connect domain=AF_INET
Result: Passed
Cwd: /
HostPID: 350812
HostPPID: 350806
Owner: map[Name:nginx Namespace:default Ref:Deployment]
PID: 92
PPID: 86
ParentProcessName: /usr/bin/bash
ProcessName: /usr/bin/curl
TTY: pts1
UID: 0
== Log / 2025-04-30 08:00:00.429686 ==
ClusterName: ramakant-cluster
HostName: gke-ramakant-cluster-default-pool-bc60856a-pk8v
NamespaceName: default
PodName: nginx-7d988b97c-nprq8
Labels: app=nginx
ContainerName: nginx
ContainerID: 12051c6b1e8987a7c994a42bc48b731b15ec960e3f751619ed49fe7e3758dc2e
ContainerImage: docker.io/library/nginx:latest@sha256:c15da6c91de8d2f436196f3a768483ad32c258ed4e1beb3d367a27ed67253e66
Type: ContainerLog
Source: /usr/bin/curl 10.44.0.17
Resource: domain=AF_INET type=SOCK_STREAM protocol=TCP
Operation: Network
Data: syscall=SYS_SOCKET
Result: Passed
Cwd: /
HostPID: 350812
HostPPID: 350806
Owner: map[Name:nginx Namespace:default Ref:Deployment]
PID: 92
PPID: 86
ParentProcessName: /usr/bin/bash
ProcessName: /usr/bin/curl
TTY: pts1
UID: 0
== Log / 2025-04-30 08:00:00.429894 ==
ClusterName: ramakant-cluster
HostName: gke-ramakant-cluster-default-pool-bc60856a-pk8v
NamespaceName: default
PodName: nginx1-74855c7fbb-mpg4b
Labels: app=nginx1
ContainerName: nginx
ContainerID: b0ae2cd445e68b461d7a37b297422ee218cd0cc52faab465069c91255d452a4d
ContainerImage: docker.io/library/nginx:latest@sha256:c15da6c91de8d2f436196f3a768483ad32c258ed4e1beb3d367a27ed67253e66
Type: ContainerLog
Source: /usr/sbin/nginx
Resource: remoteip=10.44.0.16 port=80 protocol=TCP
Operation: Network
Data: kprobe=tcp_accept domain=AF_INET
Result: Passed
Cwd: /
HostPID: 25250
HostPPID: 25208
Owner: map[Name:nginx1 Namespace:default Ref:Deployment]
PID: 30
PPID: 1
ParentProcessName: /usr/sbin/nginx
ProcessName: /usr/sbin/nginx
UID: 101
```

**Additional information for reviewer?** :
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [x] Bug fix.
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Commit has unit tests
- [ ] Commit has integration tests

<!--

The PR title message must follow convention:
`<type>(<scope>): <subject>`.

Where: <br />
- `type` is to define what type of PR is this.
  Most common types are:
    - `feat`      - for new features, not a new feature for build script
    - `fix`       - for bug fixes or improvements, not a fix for build script
    - `chore`     - changes not related to production code
    - `docs`      - changes related to documentation
    - `style`     - formatting, missing semi colons, linting fix etc; no significant production code changes
    - `test`      - adding missing tests, refactoring tests; no production code change
    - `refactor`  - refactoring production code, eg. renaming a variable or function name, there should not be any significant production code changes

- `scope` is a single word that best describes where the changes fit.
    - feature(`monitor`,`enforcer`)
    - test(`tests`, `bdd`)
    - chore(`build`)
- `subject` is a single line brief description of the changes made in the pull request.

-->