### PR TITLE
chore: Fix controller-gen version in operator Makefile

### DIFF
--- a/pkg/KubeArmorOperator/Makefile
+++ b/pkg/KubeArmorOperator/Makefile
@@ -146,7 +146,7 @@ generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and
 CONTROLLER_GEN = $(GOBIN)/controller-gen
 .PHONY: controller-gen
 controller-gen: ## Download controller-gen locally if necessary.
-	$(call go-get-tool,$(CONTROLLER_GEN),sigs.k8s.io/controller-tools/cmd/controller-gen@v0.4.1)
+	$(call go-get-tool,$(CONTROLLER_GEN),sigs.k8s.io/controller-tools/cmd/controller-gen@v0.16.5)
 
 client/gen:
 	@echo "--> Running code-generator to generate clients"


### PR DESCRIPTION
**Purpose of PR?**:

Running `make manifests` in `pkg/KubeArmorOperator` results in a `controller-gen` segfault if you use the old version installed by the Makefile (`v0.4.1`).

The generated manifests currently checked into the tree on `main` were generated with `v0.16.5`, but the Makefile was never updated:

https://github.com/kubearmor/KubeArmor/blob/main/pkg/KubeArmorOperator/config/crd/bases/operator.kubearmor.com_kubearmorconfigs.yaml#L6

https://github.com/kubearmor/KubeArmor/blob/main/deployments/operator/operator.yaml#L5

https://github.com/kubearmor/KubeArmor/blob/main/deployments/helm/KubeArmorOperator/crds/operator.kubearmor.com_kubearmorconfigs.yaml#L6

**Does this PR introduce a breaking change?**
No

**If the changes in this PR are manually verified, list down the scenarios covered:**:
Ran `make manifests` with the upgraded version and confirmed it doesn't segfault

**Additional information for reviewer?** :

**Checklist:**
- [x] Bug fix
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Commit has unit tests
- [ ] Commit has integration tests

<!--

The PR title message must follow convention:
`<type>(<scope>): <subject>`.

Where: <br />
- `type` is to define what type of PR is this.
  Most common types are:
    - `feat`      - for new features, not a new feature for build script
    - `fix`       - for bug fixes or improvements, not a fix for build script
    - `chore`     - changes not related to production code
    - `docs`      - changes related to documentation
    - `style`     - formatting, missing semi colons, linting fix etc; no significant production code changes
    - `test`      - adding missing tests, refactoring tests; no production code change
    - `refactor`  - refactoring production code, eg. renaming a variable or function name, there should not be any significant production code changes

- `scope` is a single word that best describes where the changes fit.
    - feature(`monitor`,`enforcer`)
    - test(`tests`, `bdd`)
    - chore(`build`)
- `subject` is a single line brief description of the changes made in the pull request.

-->