### PR TITLE
feat(visibility): Add flag to drop `Resource` field from process visibility logs

### DIFF
--- a/KubeArmor/config/config.go
+++ b/KubeArmor/config/config.go
@@ -5,11 +5,10 @@
 package config
 
 import (
+	"flag"
 	"fmt"
 	"os"
 	"strings"
-
-	"flag"
 
 	kg "github.com/kubearmor/KubeArmor/KubeArmor/log"
 	"github.com/spf13/viper"
@@ -68,6 +67,8 @@ type KubearmorConfig struct {
 
 	ProcFsMount string // path where procfs is hosted
 
+	DropResourceFromProcessLogs bool // optionally drop resource field from process logs
+
 	MachineIDPath string // path to machine-id
 }
 
@@ -119,6 +120,7 @@ const (
 	ConfigAnnotateResources              string = "annotateResources"
 	ConfigProcFsMount                    string = "procfsMount"
 	ConfigArgMatching                    string = "matchArgs"
+	ConfigDropResourceFromProcessLogs    string = "dropResourceFromProcessLogs"
 	ConfigMachineIDPath                  string = "machineIDPath"
 	UseOCIHooks                          string = "useOCIHooks"
 )
@@ -187,6 +189,8 @@ func readCmdLineParams() {
 	matchArgs := flag.Bool(ConfigArgMatching, true, "enabling Argument matching")
 
 	useOCIHooks := flag.Bool(UseOCIHooks, false, "Use OCI hooks to get new containers instead of using container runtime socket")
+
+	dropResourceFromProcessLogs := flag.Bool(ConfigDropResourceFromProcessLogs, false, "drop resource field from process logs")
 
 	flags := []string{}
 	flag.VisitAll(func(f *flag.Flag) {
@@ -260,6 +264,8 @@ func readCmdLineParams() {
 	viper.SetDefault(ConfigMachineIDPath, *machineIDPath)
 
 	viper.SetDefault(UseOCIHooks, *useOCIHooks)
+
+	viper.SetDefault(ConfigDropResourceFromProcessLogs, *dropResourceFromProcessLogs)
 }
 
 // LoadConfig Load configuration
@@ -345,6 +351,8 @@ func LoadConfig() error {
 	GlobalCfg.ProcFsMount = viper.GetString(ConfigProcFsMount)
 
 	GlobalCfg.MachineIDPath = viper.GetString(ConfigMachineIDPath)
+
+	GlobalCfg.DropResourceFromProcessLogs = viper.GetBool(ConfigDropResourceFromProcessLogs)
 
 	LoadDynamicConfig()
 

--- a/KubeArmor/core/kubeUpdate.go
+++ b/KubeArmor/core/kubeUpdate.go
@@ -2870,6 +2870,7 @@ func (dm *KubeArmorDaemon) WatchConfigMap() cache.InformerSynced {
 				cfg.GlobalCfg.HostVisibility = cm.Data[cfg.ConfigHostVisibility]
 				cfg.GlobalCfg.Visibility = cm.Data[cfg.ConfigVisibility]
 				cfg.GlobalCfg.Cluster = cm.Data[cfg.ConfigCluster]
+				cfg.GlobalCfg.DropResourceFromProcessLogs = (cm.Data[cfg.ConfigDropResourceFromProcessLogs] == "true")
 				dm.NodeLock.Lock()
 				dm.Node.ClusterName = cm.Data[cfg.ConfigCluster]
 				dm.NodeLock.Unlock()
@@ -2925,6 +2926,7 @@ func (dm *KubeArmorDaemon) WatchConfigMap() cache.InformerSynced {
 				cfg.GlobalCfg.HostVisibility = cm.Data[cfg.ConfigHostVisibility]
 				cfg.GlobalCfg.Visibility = cm.Data[cfg.ConfigVisibility]
 				cfg.GlobalCfg.Cluster = cm.Data[cfg.ConfigCluster]
+				cfg.GlobalCfg.DropResourceFromProcessLogs = (cm.Data[cfg.ConfigDropResourceFromProcessLogs] == "true")
 				dm.Node.ClusterName = cm.Data[cfg.ConfigCluster]
 				if _, ok := cm.Data[cfg.ConfigDefaultPostureLogs]; ok {
 					cfg.GlobalCfg.DefaultPostureLogs = (cm.Data[cfg.ConfigDefaultPostureLogs] == "true")

--- a/KubeArmor/feeder/feeder.go
+++ b/KubeArmor/feeder/feeder.go
@@ -527,6 +527,64 @@ func (fd *Feeder) PushMessage(level, message string) {
 	}
 }
 
+func MarshalVisibilityLog(log tp.Log) *pb.Log {
+	pbLog := pb.Log{}
+
+	pbLog.Timestamp = log.Timestamp
+	pbLog.UpdatedTime = log.UpdatedTime
+
+	pbLog.ClusterName = cfg.GlobalCfg.Cluster
+
+	pbLog.NamespaceName = log.NamespaceName
+
+	var owner *pb.Podowner
+	if log.Owner != nil && (log.Owner.Ref != "" || log.Owner.Name != "" || log.Owner.Namespace != "") {
+		owner = &pb.Podowner{
+			Ref:       log.Owner.Ref,
+			Name:      log.Owner.Name,
+			Namespace: log.Owner.Namespace,
+		}
+	}
+
+	if pbLog.Owner == nil && owner != nil {
+		pbLog.Owner = owner
+	}
+
+	pbLog.PodName = log.PodName
+	pbLog.Labels = log.Labels
+
+	pbLog.ContainerID = log.ContainerID
+	pbLog.ContainerName = log.ContainerName
+	pbLog.ContainerImage = log.ContainerImage
+
+	pbLog.HostPPID = log.HostPPID
+	pbLog.HostPID = log.HostPID
+
+	pbLog.PPID = log.PPID
+	pbLog.PID = log.PID
+	pbLog.UID = log.UID
+
+	pbLog.ParentProcessName = log.ParentProcessName
+	pbLog.ProcessName = log.ProcessName
+
+	pbLog.Type = log.Type
+	pbLog.TTY = log.TTY
+	pbLog.Source = log.Source
+	pbLog.Operation = log.Operation
+	if !(pbLog.Operation == "Process" && cfg.GlobalCfg.DropResourceFromProcessLogs) {
+		pbLog.Resource = strings.ToValidUTF8(log.Resource, "")
+	}
+	pbLog.Cwd = log.Cwd
+
+	if len(log.Data) > 0 {
+		pbLog.Data = log.Data
+	}
+
+	pbLog.Result = log.Result
+
+	return &pbLog
+}
+
 // PushLog Function
 func (fd *Feeder) PushLog(log tp.Log) {
 	/* if enforcer == BPFLSM and log.Enforcer == ebpfmonitor ( block and default Posture Alerts from System
@@ -704,12 +762,7 @@ func (fd *Feeder) PushLog(log tp.Log) {
 			}
 		}
 	} else { // ContainerLog || HostLog
-		pbLog := pb.Log{}
-
-		pbLog.Timestamp = log.Timestamp
-		pbLog.UpdatedTime = log.UpdatedTime
-
-		pbLog.ClusterName = cfg.GlobalCfg.Cluster
+		pbLog := MarshalVisibilityLog(log)
 		pbLog.HostName = fd.Node.NodeName
 		pbLog.NodeID = fd.Node.NodeID
 
@@ -753,12 +806,10 @@ func (fd *Feeder) PushLog(log tp.Log) {
 			pbLog.Resource = strings.ToValidUTF8(log.Resource, "")
 		}
 		pbLog.Cwd = log.Cwd
-
 		pbLog.ExecEvent = &pb.ExecEvent{
 			ExecID:         log.ExecEvent.ExecID,
 			ExecutableName: log.ExecEvent.ExecutableName,
 		}
-
 		if len(log.Data) > 0 {
 			pbLog.Data = log.Data
 		}
@@ -771,7 +822,7 @@ func (fd *Feeder) PushLog(log tp.Log) {
 		lenlog := len(fd.EventStructs.LogStructs)
 		for uid := range fd.EventStructs.LogStructs {
 			select {
-			case fd.EventStructs.LogStructs[uid].Broadcast <- &pbLog:
+			case fd.EventStructs.LogStructs[uid].Broadcast <- pbLog:
 			default:
 				counter++
 				if counter == lenlog {

--- a/KubeArmor/feeder/feeder.go
+++ b/KubeArmor/feeder/feeder.go
@@ -576,6 +576,11 @@ func MarshalVisibilityLog(log tp.Log) *pb.Log {
 	}
 	pbLog.Cwd = log.Cwd
 
+	pbLog.ExecEvent = &pb.ExecEvent{
+		ExecID:         log.ExecEvent.ExecID,
+		ExecutableName: log.ExecEvent.ExecutableName,
+	}
+
 	if len(log.Data) > 0 {
 		pbLog.Data = log.Data
 	}

--- a/KubeArmor/feeder/feeder.go
+++ b/KubeArmor/feeder/feeder.go
@@ -749,7 +749,9 @@ func (fd *Feeder) PushLog(log tp.Log) {
 		pbLog.TTY = log.TTY
 		pbLog.Source = log.Source
 		pbLog.Operation = log.Operation
-		pbLog.Resource = strings.ToValidUTF8(log.Resource, "")
+		if !(pbLog.Operation == "Process" && cfg.GlobalCfg.DropResourceFromProcessLogs) {
+			pbLog.Resource = strings.ToValidUTF8(log.Resource, "")
+		}
 		pbLog.Cwd = log.Cwd
 
 		pbLog.ExecEvent = &pb.ExecEvent{

--- a/KubeArmor/feeder/feeder_test.go
+++ b/KubeArmor/feeder/feeder_test.go
@@ -57,6 +57,7 @@ func TestMarshalVisibilityLog(t *testing.T) {
 		PPID:              914,
 		ParentProcessName: "/usr/bin/dockerd",
 		ProcessName:       "/usr/bin/runc",
+		ExecEvent:         tp.ExecEvent{},
 	}
 
 	expectedMarshaledLog := &pb.Log{
@@ -73,6 +74,7 @@ func TestMarshalVisibilityLog(t *testing.T) {
 		PPID:              914,
 		ParentProcessName: "/usr/bin/dockerd",
 		ProcessName:       "/usr/bin/runc",
+		ExecEvent:         &pb.ExecEvent{},
 	}
 
 	t.Run("WithResource", func(t *testing.T) {

--- a/KubeArmor/feeder/feeder_test.go
+++ b/KubeArmor/feeder/feeder_test.go
@@ -4,11 +4,13 @@
 package feeder
 
 import (
+	"reflect"
 	"sync"
 	"testing"
 
 	cfg "github.com/kubearmor/KubeArmor/KubeArmor/config"
 	tp "github.com/kubearmor/KubeArmor/KubeArmor/types"
+	pb "github.com/kubearmor/KubeArmor/protobuf"
 )
 
 func TestFeeder(t *testing.T) {
@@ -36,4 +38,66 @@ func TestFeeder(t *testing.T) {
 		return
 	}
 	t.Log("[PASS] Destroyed logger")
+}
+
+func TestMarshalVisibilityLog(t *testing.T) {
+	// example visibility log - hostname field excluded since it is set
+	// in the feeder and this test just checks marshaling
+	visibilityLog := tp.Log{
+		ClusterName:       "default",
+		Type:              "HostLog",
+		Source:            "/usr/bin/dockerd",
+		Resource:          "/usr/bin/runc --version",
+		Operation:         "Process",
+		Data:              "syscall=SYS_EXECVE",
+		Result:            "Passed",
+		HostPID:           193088,
+		HostPPID:          914,
+		PID:               193088,
+		PPID:              914,
+		ParentProcessName: "/usr/bin/dockerd",
+		ProcessName:       "/usr/bin/runc",
+	}
+
+	expectedMarshaledLog := &pb.Log{
+		ClusterName:       "default",
+		Type:              "HostLog",
+		Source:            "/usr/bin/dockerd",
+		Resource:          "/usr/bin/runc --version",
+		Operation:         "Process",
+		Data:              "syscall=SYS_EXECVE",
+		Result:            "Passed",
+		HostPID:           193088,
+		HostPPID:          914,
+		PID:               193088,
+		PPID:              914,
+		ParentProcessName: "/usr/bin/dockerd",
+		ProcessName:       "/usr/bin/runc",
+	}
+
+	t.Run("WithResource", func(t *testing.T) {
+		originalDropResource := cfg.GlobalCfg.DropResourceFromProcessLogs
+		defer func() { cfg.GlobalCfg.DropResourceFromProcessLogs = originalDropResource }()
+		cfg.GlobalCfg.DropResourceFromProcessLogs = false
+
+		marshaledLog := MarshalVisibilityLog(visibilityLog)
+		if !reflect.DeepEqual(marshaledLog, expectedMarshaledLog) {
+			t.Errorf("[FAIL] Expected marshaled log: %+v\nGot: %+v", expectedMarshaledLog, marshaledLog)
+		}
+	})
+
+	t.Run("WithoutResource", func(t *testing.T) {
+		originalDropResource := cfg.GlobalCfg.DropResourceFromProcessLogs
+		defer func() { cfg.GlobalCfg.DropResourceFromProcessLogs = originalDropResource }()
+		cfg.GlobalCfg.DropResourceFromProcessLogs = true
+
+		expectedWithoutResource := &pb.Log{}
+		*expectedWithoutResource = *expectedMarshaledLog
+		expectedWithoutResource.Resource = ""
+
+		marshaledLog := MarshalVisibilityLog(visibilityLog)
+		if !reflect.DeepEqual(marshaledLog, expectedWithoutResource) {
+			t.Errorf("[FAIL] Expected marshaled log: %+v\nGot: %+v", expectedWithoutResource, marshaledLog)
+		}
+	})
 }

--- a/deployments/helm/KubeArmorOperator/README.md
+++ b/deployments/helm/KubeArmorOperator/README.md
@@ -62,6 +62,9 @@ spec:
     # default visibility configuration
     defaultVisibility: [comma separated: process|file|network] # DEFAULT - process,network
 
+    # optionally drop the Resource field (full cmdline) from process visibility logs
+    dropResourceFromProcessLogs: false                         # DEFAULT - false
+
     # enabling NRI
     # Naming convention for kubearmor daemonset in case of NRI will be effective only when initally NRI is available & enabled. 
     # In case snitch service account token is already present before its deployment, the naming convention won't show NRI, 

--- a/deployments/helm/KubeArmorOperator/crds/operator.kubearmor.com_kubearmorconfigs.yaml
+++ b/deployments/helm/KubeArmorOperator/crds/operator.kubearmor.com_kubearmorconfigs.yaml
@@ -91,6 +91,8 @@ spec:
                 type: string
               defaultVisibility:
                 type: string
+              dropResourceFromProcessLogs:
+                type: boolean
               enableNRI:
                 type: boolean
               enableStdOutAlerts:

--- a/deployments/operator/operator.yaml
+++ b/deployments/operator/operator.yaml
@@ -90,6 +90,8 @@ spec:
                 type: string
               defaultVisibility:
                 type: string
+              dropResourceFromProcessLogs:
+                type: boolean
               enableNRI:
                 type: boolean
               enableStdOutAlerts:

--- a/pkg/KubeArmorOperator/api/operator.kubearmor.com/v1/kubearmorconfig_types.go
+++ b/pkg/KubeArmorOperator/api/operator.kubearmor.com/v1/kubearmorconfig_types.go
@@ -120,6 +120,8 @@ type KubeArmorConfigSpec struct {
 	MatchArgs bool `json:"matchArgs,omitempty"`
 
 	ControllerPort int `json:"controllerPort,omitempty"`
+
+	DropResourceFromProcessLogs bool `json:"dropResourceFromProcessLogs,omitempty"`
 }
 
 // KubeArmorConfigStatus defines the observed state of KubeArmorConfig

--- a/pkg/KubeArmorOperator/common/defaults.go
+++ b/pkg/KubeArmorOperator/common/defaults.go
@@ -83,18 +83,19 @@ var (
 	EnableOCIHooks bool = false
 
 	// ConfigMap Data
-	ConfigGRPC                       string = "gRPC"
-	ConfigVisibility                 string = "visibility"
-	ConfigCluster                    string = "cluster"
-	ConfigDefaultFilePosture         string = "defaultFilePosture"
-	ConfigDefaultCapabilitiesPosture string = "defaultCapabilitiesPosture"
-	ConfigDefaultNetworkPosture      string = "defaultNetworkPosture"
-	ConfigDefaultPostureLogs         string = "defaultPostureLogs"
-	ConfigAlertThrottling            string = "alertThrottling"
-	ConfigMaxAlertPerSec             string = "maxAlertPerSec"
-	ConfigThrottleSec                string = "throttleSec"
-	ConfigEnableNRI                  string = "enableNRI"
-	ConfigArgMatching                string = "matchArgs"
+	ConfigGRPC                        string = "gRPC"
+	ConfigVisibility                  string = "visibility"
+	ConfigCluster                     string = "cluster"
+	ConfigDefaultFilePosture          string = "defaultFilePosture"
+	ConfigDefaultCapabilitiesPosture  string = "defaultCapabilitiesPosture"
+	ConfigDefaultNetworkPosture       string = "defaultNetworkPosture"
+	ConfigDefaultPostureLogs          string = "defaultPostureLogs"
+	ConfigAlertThrottling             string = "alertThrottling"
+	ConfigMaxAlertPerSec              string = "maxAlertPerSec"
+	ConfigThrottleSec                 string = "throttleSec"
+	ConfigEnableNRI                   string = "enableNRI"
+	ConfigArgMatching                 string = "matchArgs"
+	ConfigDropResourceFromProcessLogs string = "dropResourceFromProcessLogs"
 
 	GlobalImagePullSecrets []corev1.LocalObjectReference = []corev1.LocalObjectReference{}
 	GlobalTolerations      []corev1.Toleration           = []corev1.Toleration{}
@@ -201,17 +202,18 @@ var (
 var Pointer2True bool = true
 
 var ConfigMapData = map[string]string{
-	ConfigGRPC:                       "32767",
-	ConfigCluster:                    "default",
-	ConfigDefaultFilePosture:         "audit",
-	ConfigDefaultCapabilitiesPosture: "audit",
-	ConfigDefaultNetworkPosture:      "audit",
-	ConfigVisibility:                 "process,network,capabilities",
-	ConfigDefaultPostureLogs:         "true",
-	ConfigAlertThrottling:            "true",
-	ConfigMaxAlertPerSec:             "10",
-	ConfigThrottleSec:                "30",
-	ConfigArgMatching:                "true",
+	ConfigGRPC:                        "32767",
+	ConfigCluster:                     "default",
+	ConfigDefaultFilePosture:          "audit",
+	ConfigDefaultCapabilitiesPosture:  "audit",
+	ConfigDefaultNetworkPosture:       "audit",
+	ConfigDropResourceFromProcessLogs: "false",
+	ConfigVisibility:                  "process,network,capabilities",
+	ConfigDefaultPostureLogs:          "true",
+	ConfigAlertThrottling:             "true",
+	ConfigMaxAlertPerSec:              "10",
+	ConfigThrottleSec:                 "30",
+	ConfigArgMatching:                 "true",
 }
 
 var ConfigDefaultSeccompEnabled = "false"

--- a/pkg/KubeArmorOperator/config/crd/bases/operator.kubearmor.com_kubearmorconfigs.yaml
+++ b/pkg/KubeArmorOperator/config/crd/bases/operator.kubearmor.com_kubearmorconfigs.yaml
@@ -91,6 +91,8 @@ spec:
                 type: string
               defaultVisibility:
                 type: string
+              dropResourceFromProcessLogs:
+                type: boolean
               enableNRI:
                 type: boolean
               enableStdOutAlerts:

--- a/pkg/KubeArmorOperator/internal/controller/cluster.go
+++ b/pkg/KubeArmorOperator/internal/controller/cluster.go
@@ -1317,6 +1317,11 @@ func UpdateConfigMapData(config *opv1.KubeArmorConfigSpec) bool {
 		}
 		configMapData += fmt.Sprintf("%s: %s\n", common.ConfigDefaultNetworkPosture, config.DefaultNetworkPosture)
 	}
+	DropResourceFromProcessLogs := strconv.FormatBool(config.DropResourceFromProcessLogs)
+	if common.ConfigMapData[common.ConfigDropResourceFromProcessLogs] != DropResourceFromProcessLogs {
+		common.ConfigMapData[common.ConfigDropResourceFromProcessLogs] = DropResourceFromProcessLogs
+		updated = true
+	}
 	if config.DefaultVisibility != "" {
 		if common.ConfigMapData[common.ConfigVisibility] != config.DefaultVisibility {
 			common.ConfigMapData[common.ConfigVisibility] = config.DefaultVisibility

--- a/tests/k8s_env/configmap/kubearmor_config_test.go
+++ b/tests/k8s_env/configmap/kubearmor_config_test.go
@@ -322,7 +322,6 @@ var _ = Describe("KubeArmor-Config", func() {
 			Expect(len(logs)).NotTo(Equal(0))
 
 			// Confirm Resource field is present in logs
-			fmt.Printf("got logs: %+v", logs)
 			for _, log := range logs {
 				Expect(log.Resource).NotTo(Equal(""))
 			}
@@ -352,7 +351,6 @@ var _ = Describe("KubeArmor-Config", func() {
 			Expect(len(logs)).NotTo(Equal(0))
 
 			// Confirm Resource field is dropped in logs
-			fmt.Printf("got logs: %+v", logs)
 			for _, log := range logs {
 				Expect(log.Resource).To(Equal(""))
 			}

--- a/tests/k8s_env/configmap/kubearmor_config_test.go
+++ b/tests/k8s_env/configmap/kubearmor_config_test.go
@@ -250,6 +250,113 @@ var _ = Describe("KubeArmor-Config", func() {
 
 		})
 
+		It("default posture will be unchanged after global configs changed", func() {
+
+			// apply a allow based policy
+			err := K8sApplyFile("manifests/ksp-fullyAnnotated-allow.yaml")
+			Expect(err).To(BeNil())
+
+			err = KarmorLogStart("policy", "fullyannotated", "Network", fullyAnnotated)
+			Expect(err).To(BeNil())
+
+			// initialy namespace defaults posture is block (annotated fully)
+			sout, _, err := K8sExecInPodWithContainer(fullyAnnotated, "fullyannotated", "ubuntu-1", []string{"bash", "-c", "curl google.com"})
+			Expect(err).To(BeNil())
+			fmt.Printf("---START---\n%s---END---\n", sout)
+			Expect(sout).To(MatchRegexp(".*has moved"))
+
+			// should get an alert with success
+			// check policy violation alert
+
+			target := protobuf.Alert{
+				PolicyName:    "DefaultPosture",
+				Action:        "Audit",
+				Result:        "Passed",
+				NamespaceName: "fullyannotated",
+			}
+
+			res, err := KarmorGetTargetAlert(5*time.Second, &target)
+			Expect(err).To(BeNil())
+			Expect(res.Found).To(BeTrue())
+
+			// change global default posture to block using configmap
+			cm := NewDefaultConfigMapData()
+			cm.DefaultFilePosture = "block"
+			cm.DefaultCapabilitiesPosture = "block"
+			cm.DefaultNetworkPosture = "block"
+			err = cm.CreateKAConfigMap() // will create a configMap with default posture as block
+			Expect(err).To(BeNil())
+
+			// wait for policy updation due to defaultPosture change
+			time.Sleep(5 * time.Second)
+
+			// defaults posture should still be audit for network
+			sout, _, err = K8sExecInPodWithContainer(fullyAnnotated, "fullyannotated", "ubuntu-1", []string{"bash", "-c", "curl google.com"})
+			Expect(err).To(BeNil())
+			fmt.Printf("---START---\n%s---END---\n", sout)
+			Expect(sout).To(MatchRegexp(".*has moved"))
+
+		})
+
+		It("respects DropResourceFromProcessLogs flag", func() {
+			// DropResourceFromProcessLogs is disabled (false) by default
+			cm := NewDefaultConfigMapData()
+			cm.Visibility = "process"
+			err := cm.CreateKAConfigMap()
+			Expect(err).To(BeNil())
+
+			// Wait for config to update
+			time.Sleep(5 * time.Second)
+
+			// Start logging for process events
+			err = KarmorLogStart("all", "fullyannotated", "Process", fullyAnnotated)
+			Expect(err).To(BeNil())
+
+			// Execute a process in the pod
+			K8sExecInPodWithContainer(fullyAnnotated, "fullyannotated", "ubuntu-1", []string{"bash", "-c", "ps"})
+			Expect(err).To(BeNil())
+
+			// Get process logs
+			logs, _, err := KarmorGetLogs(5*time.Second, 50)
+			Expect(err).To(BeNil())
+			Expect(len(logs)).NotTo(Equal(0))
+
+			// Confirm Resource field is present in logs
+			fmt.Printf("got logs: %+v", logs)
+			for _, log := range logs {
+				Expect(log.Resource).NotTo(Equal(""))
+			}
+
+			// now test with DropResourceFromProcessLogs enabled
+			cm = NewDefaultConfigMapData()
+			cm.Visibility = "process"
+			cm.DropResourceFromProcessLogs = "true"
+			err = cm.CreateKAConfigMap()
+			Expect(err).To(BeNil())
+
+			// Wait for config to update
+			time.Sleep(5 * time.Second)
+
+			// Stop and start logs to drain queue
+			KarmorLogStop()
+			err = KarmorLogStart("all", "fullyannotated", "Process", fullyAnnotated)
+			Expect(err).To(BeNil())
+
+			// Execute a process in the pod
+			K8sExecInPodWithContainer(fullyAnnotated, "fullyannotated", "ubuntu-1", []string{"bash", "-c", "ps"})
+			Expect(err).To(BeNil())
+
+			// Get process logs
+			logs, _, err = KarmorGetLogs(5*time.Second, 50)
+			Expect(err).To(BeNil())
+			Expect(len(logs)).NotTo(Equal(0))
+
+			// Confirm Resource field is dropped in logs
+			fmt.Printf("got logs: %+v", logs)
+			for _, log := range logs {
+				Expect(log.Resource).To(Equal(""))
+			}
+		})
 	})
 
 })

--- a/tests/util/kartutil.go
+++ b/tests/util/kartutil.go
@@ -43,15 +43,16 @@ var kcClient *kc.SecurityV1Client
 
 // ConfigMapData hosts the structure which is used to configure Config Map Data
 type ConfigMapData struct {
-	GRPC                       string
-	Visibility                 string
-	Cluster                    string
-	DefaultFilePosture         string
-	DefaultCapabilitiesPosture string
-	DefaultNetworkPosture      string
-	AlertThrottling            string
-	MaxAlertPerSec             string
-	ThrottleSec                string
+	GRPC                        string
+	Visibility                  string
+	Cluster                     string
+	DefaultFilePosture          string
+	DefaultCapabilitiesPosture  string
+	DefaultNetworkPosture       string
+	AlertThrottling             string
+	MaxAlertPerSec              string
+	ThrottleSec                 string
+	DropResourceFromProcessLogs string
 }
 
 // GetK8sClient function return instance of k8s client
@@ -110,6 +111,7 @@ func NewDefaultConfigMapData() *ConfigMapData {
 	data.AlertThrottling = "false"
 	data.MaxAlertPerSec = "10"
 	data.ThrottleSec = "30"
+	data.DropResourceFromProcessLogs = "false"
 
 	return data
 }
@@ -129,15 +131,16 @@ func (data *ConfigMapData) CreateKAConfigMap() error {
 			},
 		},
 		Data: map[string]string{
-			"gRPC":                       data.GRPC,
-			"cluster":                    data.Cluster,
-			"visibility":                 data.Visibility,
-			"defaultFilePosture":         data.DefaultFilePosture,
-			"defaultCapabilitiesPosture": data.DefaultCapabilitiesPosture,
-			"defaultNetworkPosture":      data.DefaultNetworkPosture,
-			"alertThrottling":            data.AlertThrottling,
-			"maxAlertPerSec":             data.MaxAlertPerSec,
-			"throttleSec":                data.ThrottleSec,
+			"gRPC":                        data.GRPC,
+			"cluster":                     data.Cluster,
+			"visibility":                  data.Visibility,
+			"defaultFilePosture":          data.DefaultFilePosture,
+			"defaultCapabilitiesPosture":  data.DefaultCapabilitiesPosture,
+			"defaultNetworkPosture":       data.DefaultNetworkPosture,
+			"alertThrottling":             data.AlertThrottling,
+			"maxAlertPerSec":              data.MaxAlertPerSec,
+			"throttleSec":                 data.ThrottleSec,
+			"dropResourceFromProcessLogs": data.DropResourceFromProcessLogs,
 		},
 	}
 


### PR DESCRIPTION
**Purpose of PR**:
The `Resource` field contains a full `cmdline` for process logs which could contain sensitive information e.g. if engineers execute commands with database passwords included inline on hosts/containers with KubeArmor visibility enabled. Add a flag to optionally drop the `Resource` field for logs with `Operation: Process`.

**Does this PR introduce a breaking change?**
No

**If the changes in this PR are manually verified, list down the scenarios covered:**
Manually tested on a local k3s cluster by following the instructions [here](https://github.com/kubearmor/KubeArmor/blob/main/contribution/testing_operator_controller_guide.md) and loading the images into the cluster with `docker save` + `k3s ctr`. Confirmed that updating `spec.dropResourceFromProcessLogs` in the `KubeArmorConfig` CR correctly resulted in the field being dropped from `Process` logs in `kubearmor-relay` stdout.

**Checklist:**
- [ ] Bug fix. Fixes #<issue number>
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [x] Commit has unit tests
- [x] Commit has integration tests