### PR TITLE
fix(monitor): check for absolute path only for process and file events

### DIFF
--- a/KubeArmor/monitor/logUpdate.go
+++ b/KubeArmor/monitor/logUpdate.go
@@ -575,9 +575,12 @@ func (mon *SystemMonitor) UpdateLogs() {
 				}
 			}
 
-			// fallback logic: in case we get relative path in log.Resource then we join cwd + resource to get pull path
-			if !strings.HasPrefix(strings.Split(log.Resource, " ")[0], "/") && log.Cwd != "/" {
-				log.Resource = filepath.Join(log.Cwd, log.Resource)
+			// fallback logic: in case we get relative path in log.Resource for file and process event
+			// then we join cwd + resource to get pull path
+			if log.Operation == "Process" || log.Operation == "File" {
+				if !strings.HasPrefix(strings.Split(log.Resource, " ")[0], "/") && log.Cwd != "/" {
+					log.Resource = filepath.Join(log.Cwd, log.Resource)
+				}
 			}
 
 			// get error message


### PR DESCRIPTION
**Purpose of PR?**:
system monitor prepend Current Working Directory (CWD) in case if relative path is received from tracing data. at this point this checks for all the events due to this we are receiving the network events with CWD prepend to resource data field.

```yaml
== Log / 2025-06-16 14:47:42.996172 ==
ClusterName: default
HostName: archlinux
NamespaceName: wordpress-mysql
PodName: wordpress-56c478db9f-rffk5
Labels: app=wordpress
ContainerName: wordpress
ContainerID: 48bc24339506e7838e8fcb1f19a99168e72639786a183519f55dc5afe5840f54
ContainerImage: docker.io/library/wordpress:4.8-apache@sha256:6216f64ab88fc51d311e38c7f69ca3f9aaba621492b4f1fa93ddf63093768845
Type: ContainerLog
Source: /bin/bash
Resource: /var/www/html/domain=AF_UNIX type=SOCK_STREAM|SOCK_NONBLOCK|SOCK_CLOEXEC protocol=HOPOPT
Operation: Network
Data: syscall=SYS_SOCKET
Result: Passed
Cwd: /var/www/html/
HostPID: 503532
HostPPID: 5289
Owner: map[Name:wordpress Namespace:wordpress-mysql Ref:Deployment]
PID: 792
PPID: 0
ParentProcessName: /var/lib/rancher/k3s/data/da3ffc1d30a49a23449847b31d95bf4c96c8551396573c18886c9d0c4a63c710/bin/containerd-shim-runc-v2
ProcessName: /bin/bash
TTY: pts0
UID: 0
```

this PR adds a check to only handle relative path for process and file event only.

```yaml
== Log / 2025-06-16 14:52:26.326583 ==
ClusterName: default
HostName: archlinux
NamespaceName: wordpress-mysql
PodName: wordpress-56c478db9f-rffk5
Labels: app=wordpress
ContainerName: wordpress
ContainerID: 48bc24339506e7838e8fcb1f19a99168e72639786a183519f55dc5afe5840f54
ContainerImage: docker.io/library/wordpress:4.8-apache@sha256:6216f64ab88fc51d311e38c7f69ca3f9aaba621492b4f1fa93ddf63093768845
Type: ContainerLog
Source: /bin/bash
Resource: domain=AF_UNIX type=SOCK_STREAM|SOCK_NONBLOCK|SOCK_CLOEXEC protocol=HOPOPT
Operation: Network
Data: syscall=SYS_SOCKET
Result: Passed
Cwd: /var/www/html/
HostPID: 521058
HostPPID: 5289
Owner: map[Name:wordpress Namespace:wordpress-mysql Ref:Deployment]
PID: 798
PPID: 0
ParentProcessName: /var/lib/rancher/k3s/data/da3ffc1d30a49a23449847b31d95bf4c96c8551396573c18886c9d0c4a63c710/bin/containerd-shim-runc-v2
ProcessName: /bin/bash
TTY: pts0
UID: 0
```

**Does this PR introduce a breaking change?**
No
**If the changes in this PR are manually verified, list down the scenarios covered:**:

**Additional information for reviewer?** :
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [x] Bug fix.
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Commit has unit tests
- [ ] Commit has integration tests

<!--

The PR title message must follow convention:
`<type>(<scope>): <subject>`.

Where: <br />
- `type` is to define what type of PR is this.
  Most common types are:
    - `feat`      - for new features, not a new feature for build script
    - `fix`       - for bug fixes or improvements, not a fix for build script
    - `chore`     - changes not related to production code
    - `docs`      - changes related to documentation
    - `style`     - formatting, missing semi colons, linting fix etc; no significant production code changes
    - `test`      - adding missing tests, refactoring tests; no production code change
    - `refactor`  - refactoring production code, eg. renaming a variable or function name, there should not be any significant production code changes

- `scope` is a single word that best describes where the changes fit.
    - feature(`monitor`,`enforcer`)
    - test(`tests`, `bdd`)
    - chore(`build`)
- `subject` is a single line brief description of the changes made in the pull request.

-->