### PR TITLE
helm: correct tolerations indentation in operator template

### DIFF
--- a/deployments/helm/KubeArmorOperator/templates/deployment.yaml
+++ b/deployments/helm/KubeArmorOperator/templates/deployment.yaml
@@ -27,11 +27,11 @@ spec:
       {{- end }}      
       {{- if .Values.kubearmorOperator.image.imagePullSecrets }}
       imagePullSecrets:
-      {{ toYaml .Values.kubearmorOperator.image.imagePullSecrets | indent 6 }}
+        {{- toYaml .Values.kubearmorOperator.image.imagePullSecrets | nindent 8 }}
       {{- end }}
       {{- if .Values.kubearmorOperator.tolerations }}
       tolerations:
-      {{ toYaml .Values.kubearmorOperator.tolerations | indent 6 }}
+        {{- toYaml .Values.kubearmorOperator.tolerations | nindent 8 }}
       {{- end }}
       containers:
       - name: {{ .Values.kubearmorOperator.name }}


### PR DESCRIPTION
Fixes incorrect indentation of tolerations in KubeArmor Operator Helm template that caused YAML parse errors.

## Changes
- Changed `indent 6` to `nindent 8` for tolerations in `deployments/helm/KubeArmorOperator/templates/deployment.yaml`

## Testing
- ✅ Verified template renders correctly with `helm template`  
- ✅ Tested multiple toleration configurations
- ✅ Validated with `helm lint` and `kubectl --dry-run`

Fixes #2135 