### PR TITLE
test(policy): add unit tests for policy.go (0% ➝ 100% coverage)

### DIFF
--- a/KubeArmor/buildinfo/buildinfo_test.go
+++ b/KubeArmor/buildinfo/buildinfo_test.go
@@ -1,0 +1,45 @@
+package buildinfo
+
+import (
+	"testing"
+)
+
+func TestPrintBuildDetails(t *testing.T) {
+
+	origGitSummary := GitSummary
+	origGitBranch := GitBranch
+	origBuildDate := BuildDate
+
+	defer func() {
+		GitSummary = origGitSummary
+		GitBranch = origGitBranch
+		BuildDate = origBuildDate
+	}()
+
+	t.Run("prints build details when GitSummary is set", func(t *testing.T) {
+
+		GitSummary = "v1.0.0"
+		GitBranch = "main"
+		BuildDate = "2025-01-01"
+
+		PrintBuildDetails()
+
+	})
+
+	t.Run("does not print when GitSummary is empty", func(t *testing.T) {
+
+		GitSummary = ""
+		GitBranch = "main"
+		BuildDate = "2025-01-01"
+
+		PrintBuildDetails()
+	})
+
+	t.Run("handles empty branch and date", func(t *testing.T) {
+		GitSummary = "v1.0.0"
+		GitBranch = ""
+		BuildDate = ""
+
+		PrintBuildDetails()
+	})
+}

--- a/KubeArmor/go.mod
+++ b/KubeArmor/go.mod
@@ -37,6 +37,7 @@ require (
 	github.com/kubearmor/KubeArmor/protobuf v0.0.0-20250701060635-600e11526ec1
 	github.com/opencontainers/runtime-spec v1.2.1
 	github.com/spf13/viper v1.20.1
+	github.com/stretchr/testify v1.10.0
 	go.uber.org/zap v1.27.0
 	golang.org/x/exp v0.0.0-20250620022241-b7579e27df2b
 	golang.org/x/sys v0.33.0
@@ -111,6 +112,7 @@ require (
 	github.com/opencontainers/selinux v1.12.0 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/client_golang v1.22.0 // indirect
 	github.com/prometheus/client_model v0.6.1 // indirect
 	github.com/prometheus/common v0.62.0 // indirect
@@ -122,6 +124,7 @@ require (
 	github.com/spf13/afero v1.12.0 // indirect
 	github.com/spf13/cast v1.7.1 // indirect
 	github.com/spf13/pflag v1.0.6 // indirect
+	github.com/stretchr/objx v0.5.2 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect
 	github.com/tetratelabs/wazero v1.8.2-0.20241030035603-dc08732e57d5 // indirect
 	github.com/x448/float16 v0.8.4 // indirect

--- a/KubeArmor/policy/policy_test.go
+++ b/KubeArmor/policy/policy_test.go
@@ -1,0 +1,469 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2021 Authors of KubeArmor
+
+package policy
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	tp "github.com/kubearmor/KubeArmor/KubeArmor/types"
+	pb "github.com/kubearmor/KubeArmor/protobuf"
+)
+
+// Mock functions for testing
+func mockUpdateContainerPolicySuccess(event tp.K8sKubeArmorPolicyEvent) pb.PolicyStatus {
+	return pb.PolicyStatus_Applied
+}
+
+func mockUpdateContainerPolicyFailure(event tp.K8sKubeArmorPolicyEvent) pb.PolicyStatus {
+	return pb.PolicyStatus_Invalid // Using Invalid instead of Failed
+}
+
+func mockUpdateHostPolicySuccess(event tp.K8sKubeArmorHostPolicyEvent) pb.PolicyStatus {
+	return pb.PolicyStatus_Applied
+}
+
+func mockUpdateHostPolicyFailure(event tp.K8sKubeArmorHostPolicyEvent) pb.PolicyStatus {
+	return pb.PolicyStatus_Invalid // Using Invalid instead of Failed
+}
+
+// Test data generators
+func createValidContainerPolicyData() []byte {
+	event := tp.K8sKubeArmorPolicyEvent{
+		Object: tp.K8sKubeArmorPolicy{
+			Metadata: metav1.ObjectMeta{
+				Name: "test-container-policy",
+			},
+		},
+	}
+	data, _ := json.Marshal(event)
+	return data
+}
+
+func createEmptyContainerPolicyData() []byte {
+	event := tp.K8sKubeArmorPolicyEvent{
+		Object: tp.K8sKubeArmorPolicy{
+			Metadata: metav1.ObjectMeta{
+				Name: "",
+			},
+		},
+	}
+	data, _ := json.Marshal(event)
+	return data
+}
+
+func createValidHostPolicyData() []byte {
+	event := tp.K8sKubeArmorHostPolicyEvent{
+		Object: tp.K8sKubeArmorHostPolicy{
+			Metadata: metav1.ObjectMeta{
+				Name: "test-host-policy",
+			},
+		},
+	}
+	data, _ := json.Marshal(event)
+	return data
+}
+
+func createEmptyHostPolicyData() []byte {
+	event := tp.K8sKubeArmorHostPolicyEvent{
+		Object: tp.K8sKubeArmorHostPolicy{
+			Metadata: metav1.ObjectMeta{
+				Name: "",
+			},
+		},
+	}
+	data, _ := json.Marshal(event)
+	return data
+}
+
+func TestPolicyServer_ContainerPolicy(t *testing.T) {
+	testCases := []struct {
+		name                   string
+		containerPolicyEnabled bool
+		updateFunction         func(tp.K8sKubeArmorPolicyEvent) pb.PolicyStatus
+		policyData             []byte
+		invalidJSON            bool
+		expectedStatus         pb.PolicyStatus
+		expectedError          bool
+	}{
+		{
+			name:                   "Container policy disabled",
+			containerPolicyEnabled: false,
+			updateFunction:         mockUpdateContainerPolicySuccess,
+			policyData:             createValidContainerPolicyData(),
+			expectedStatus:         pb.PolicyStatus_NotEnabled,
+			expectedError:          false,
+		},
+		{
+			name:                   "Valid container policy - success",
+			containerPolicyEnabled: true,
+			updateFunction:         mockUpdateContainerPolicySuccess,
+			policyData:             createValidContainerPolicyData(),
+			expectedStatus:         pb.PolicyStatus_Applied,
+			expectedError:          false,
+		},
+		{
+			name:                   "Valid container policy - failure",
+			containerPolicyEnabled: true,
+			updateFunction:         mockUpdateContainerPolicyFailure,
+			policyData:             createValidContainerPolicyData(),
+			expectedStatus:         pb.PolicyStatus_Invalid,
+			expectedError:          false,
+		},
+		{
+			name:                   "Empty container policy name",
+			containerPolicyEnabled: true,
+			updateFunction:         mockUpdateContainerPolicySuccess,
+			policyData:             createEmptyContainerPolicyData(),
+			expectedStatus:         pb.PolicyStatus_Invalid,
+			expectedError:          false,
+		},
+		{
+			name:                   "Invalid JSON data",
+			containerPolicyEnabled: true,
+			updateFunction:         mockUpdateContainerPolicySuccess,
+			policyData:             []byte("invalid json"),
+			invalidJSON:            true,
+			expectedStatus:         pb.PolicyStatus_Invalid,
+			expectedError:          false,
+		},
+		{
+			name:                   "Nil policy data",
+			containerPolicyEnabled: true,
+			updateFunction:         mockUpdateContainerPolicySuccess,
+			policyData:             nil,
+			invalidJSON:            true,
+			expectedStatus:         pb.PolicyStatus_Invalid,
+			expectedError:          false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			server := &PolicyServer{
+				UpdateContainerPolicy:  tc.updateFunction,
+				ContainerPolicyEnabled: tc.containerPolicyEnabled,
+			}
+
+			ctx := context.Background()
+			req := &pb.Policy{
+				Policy: tc.policyData,
+			}
+
+			resp, err := server.ContainerPolicy(ctx, req)
+
+			// Check error expectation
+			if tc.expectedError && err == nil {
+				t.Errorf("Expected error but got none")
+			}
+			if !tc.expectedError && err != nil {
+				t.Errorf("Unexpected error: %v", err)
+			}
+
+			// Check response
+			if resp == nil {
+				t.Fatalf("Response is nil")
+			}
+
+			if resp.Status != tc.expectedStatus {
+				t.Errorf("Expected status %v, got %v", tc.expectedStatus, resp.Status)
+			}
+		})
+	}
+}
+
+func TestPolicyServer_HostPolicy(t *testing.T) {
+	testCases := []struct {
+		name              string
+		hostPolicyEnabled bool
+		updateFunction    func(tp.K8sKubeArmorHostPolicyEvent) pb.PolicyStatus
+		policyData        []byte
+		invalidJSON       bool
+		expectedStatus    pb.PolicyStatus
+		expectedError     bool
+	}{
+		{
+			name:              "Host policy disabled",
+			hostPolicyEnabled: false,
+			updateFunction:    mockUpdateHostPolicySuccess,
+			policyData:        createValidHostPolicyData(),
+			expectedStatus:    pb.PolicyStatus_NotEnabled,
+			expectedError:     false,
+		},
+		{
+			name:              "Valid host policy - success",
+			hostPolicyEnabled: true,
+			updateFunction:    mockUpdateHostPolicySuccess,
+			policyData:        createValidHostPolicyData(),
+			expectedStatus:    pb.PolicyStatus_Applied,
+			expectedError:     false,
+		},
+		{
+			name:              "Valid host policy - failure",
+			hostPolicyEnabled: true,
+			updateFunction:    mockUpdateHostPolicyFailure,
+			policyData:        createValidHostPolicyData(),
+			expectedStatus:    pb.PolicyStatus_Invalid,
+			expectedError:     false,
+		},
+		{
+			name:              "Empty host policy name",
+			hostPolicyEnabled: true,
+			updateFunction:    mockUpdateHostPolicySuccess,
+			policyData:        createEmptyHostPolicyData(),
+			expectedStatus:    pb.PolicyStatus_Invalid,
+			expectedError:     false,
+		},
+		{
+			name:              "Invalid JSON data",
+			hostPolicyEnabled: true,
+			updateFunction:    mockUpdateHostPolicySuccess,
+			policyData:        []byte("invalid json"),
+			invalidJSON:       true,
+			expectedStatus:    pb.PolicyStatus_Invalid,
+			expectedError:     false,
+		},
+		{
+			name:              "Nil policy data",
+			hostPolicyEnabled: true,
+			updateFunction:    mockUpdateHostPolicySuccess,
+			policyData:        nil,
+			invalidJSON:       true,
+			expectedStatus:    pb.PolicyStatus_Invalid,
+			expectedError:     false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			server := &PolicyServer{
+				UpdateHostPolicy:  tc.updateFunction,
+				HostPolicyEnabled: tc.hostPolicyEnabled,
+			}
+
+			ctx := context.Background()
+			req := &pb.Policy{
+				Policy: tc.policyData,
+			}
+
+			resp, err := server.HostPolicy(ctx, req)
+
+			// Check error expectation
+			if tc.expectedError && err == nil {
+				t.Errorf("Expected error but got none")
+			}
+			if !tc.expectedError && err != nil {
+				t.Errorf("Unexpected error: %v", err)
+			}
+
+			// Check response
+			if resp == nil {
+				t.Fatalf("Response is nil")
+			}
+
+			if resp.Status != tc.expectedStatus {
+				t.Errorf("Expected status %v, got %v", tc.expectedStatus, resp.Status)
+			}
+		})
+	}
+}
+
+func TestPolicyServer_PolicyEnabledFlags(t *testing.T) {
+	flagTestCases := []struct {
+		name                   string
+		containerPolicyEnabled bool
+		hostPolicyEnabled      bool
+	}{
+		{"Both policies enabled", true, true},
+		{"Only container policy enabled", true, false},
+		{"Only host policy enabled", false, true},
+		{"Both policies disabled", false, false},
+	}
+
+	for _, tc := range flagTestCases {
+		t.Run(tc.name, func(t *testing.T) {
+			server := &PolicyServer{
+				ContainerPolicyEnabled: tc.containerPolicyEnabled,
+				HostPolicyEnabled:      tc.hostPolicyEnabled,
+			}
+
+			if server.ContainerPolicyEnabled != tc.containerPolicyEnabled {
+				t.Errorf("Expected ContainerPolicyEnabled %v, got %v",
+					tc.containerPolicyEnabled, server.ContainerPolicyEnabled)
+			}
+
+			if server.HostPolicyEnabled != tc.hostPolicyEnabled {
+				t.Errorf("Expected HostPolicyEnabled %v, got %v",
+					tc.hostPolicyEnabled, server.HostPolicyEnabled)
+			}
+		})
+	}
+}
+
+func TestPolicyServer_UpdateFunctions(t *testing.T) {
+	updateFunctionTests := []struct {
+		name                    string
+		containerFunc           func(tp.K8sKubeArmorPolicyEvent) pb.PolicyStatus
+		hostFunc                func(tp.K8sKubeArmorHostPolicyEvent) pb.PolicyStatus
+		expectedContainerStatus pb.PolicyStatus
+		expectedHostStatus      pb.PolicyStatus
+	}{
+		{
+			name:                    "Success functions",
+			containerFunc:           mockUpdateContainerPolicySuccess,
+			hostFunc:                mockUpdateHostPolicySuccess,
+			expectedContainerStatus: pb.PolicyStatus_Applied,
+			expectedHostStatus:      pb.PolicyStatus_Applied,
+		},
+		{
+			name:                    "Failure functions",
+			containerFunc:           mockUpdateContainerPolicyFailure,
+			hostFunc:                mockUpdateHostPolicyFailure,
+			expectedContainerStatus: pb.PolicyStatus_Invalid,
+			expectedHostStatus:      pb.PolicyStatus_Invalid,
+		},
+	}
+
+	for _, tc := range updateFunctionTests {
+		t.Run(tc.name, func(t *testing.T) {
+			server := &PolicyServer{
+				UpdateContainerPolicy:  tc.containerFunc,
+				UpdateHostPolicy:       tc.hostFunc,
+				ContainerPolicyEnabled: true,
+				HostPolicyEnabled:      true,
+			}
+
+			// Test container policy function
+			containerEvent := tp.K8sKubeArmorPolicyEvent{
+				Object: tp.K8sKubeArmorPolicy{
+					Metadata: metav1.ObjectMeta{Name: "test"},
+				},
+			}
+			containerStatus := server.UpdateContainerPolicy(containerEvent)
+			if containerStatus != tc.expectedContainerStatus {
+				t.Errorf("Expected container status %v, got %v",
+					tc.expectedContainerStatus, containerStatus)
+			}
+
+			// Test host policy function
+			hostEvent := tp.K8sKubeArmorHostPolicyEvent{
+				Object: tp.K8sKubeArmorHostPolicy{
+					Metadata: metav1.ObjectMeta{Name: "test"},
+				},
+			}
+			hostStatus := server.UpdateHostPolicy(hostEvent)
+			if hostStatus != tc.expectedHostStatus {
+				t.Errorf("Expected host status %v, got %v",
+					tc.expectedHostStatus, hostStatus)
+			}
+		})
+	}
+}
+
+func TestPolicyServer_ContextHandling(t *testing.T) {
+	contextTests := []struct {
+		name string
+		ctx  context.Context
+	}{
+		{"Background context", context.Background()},
+		{"TODO context", context.TODO()},
+		{"Context with value", context.WithValue(context.Background(), "key", "value")},
+	}
+
+	server := &PolicyServer{
+		UpdateContainerPolicy:  mockUpdateContainerPolicySuccess,
+		UpdateHostPolicy:       mockUpdateHostPolicySuccess,
+		ContainerPolicyEnabled: true,
+		HostPolicyEnabled:      true,
+	}
+
+	for _, tc := range contextTests {
+		t.Run(tc.name+" - ContainerPolicy", func(t *testing.T) {
+			req := &pb.Policy{Policy: createValidContainerPolicyData()}
+			resp, err := server.ContainerPolicy(tc.ctx, req)
+
+			if err != nil {
+				t.Errorf("Unexpected error: %v", err)
+			}
+			if resp == nil {
+				t.Fatal("Response is nil")
+			}
+			if resp.Status != pb.PolicyStatus_Applied {
+				t.Errorf("Expected status Applied, got %v", resp.Status)
+			}
+		})
+
+		t.Run(tc.name+" - HostPolicy", func(t *testing.T) {
+			req := &pb.Policy{Policy: createValidHostPolicyData()}
+			resp, err := server.HostPolicy(tc.ctx, req)
+
+			if err != nil {
+				t.Errorf("Unexpected error: %v", err)
+			}
+			if resp == nil {
+				t.Fatal("Response is nil")
+			}
+			if resp.Status != pb.PolicyStatus_Applied {
+				t.Errorf("Expected status Applied, got %v", resp.Status)
+			}
+		})
+	}
+}
+
+func TestPolicyServer_EdgeCases(t *testing.T) {
+	edgeCases := []struct {
+		name           string
+		setupServer    func() *PolicyServer
+		testContainer  bool
+		testHost       bool
+		expectedStatus pb.PolicyStatus
+	}{
+		{
+			name: "Nil update functions",
+			setupServer: func() *PolicyServer {
+				return &PolicyServer{
+					UpdateContainerPolicy:  nil,
+					UpdateHostPolicy:       nil,
+					ContainerPolicyEnabled: false,
+					HostPolicyEnabled:      false,
+				}
+			},
+			testContainer:  true,
+			testHost:       true,
+			expectedStatus: pb.PolicyStatus_NotEnabled,
+		},
+	}
+
+	for _, tc := range edgeCases {
+		t.Run(tc.name, func(t *testing.T) {
+			server := tc.setupServer()
+			ctx := context.Background()
+
+			if tc.testContainer {
+				req := &pb.Policy{Policy: createValidContainerPolicyData()}
+				resp, err := server.ContainerPolicy(ctx, req)
+				if err != nil {
+					t.Errorf("Unexpected error: %v", err)
+				}
+				if resp.Status != tc.expectedStatus {
+					t.Errorf("Expected status %v, got %v", tc.expectedStatus, resp.Status)
+				}
+			}
+
+			if tc.testHost {
+				req := &pb.Policy{Policy: createValidHostPolicyData()}
+				resp, err := server.HostPolicy(ctx, req)
+				if err != nil {
+					t.Errorf("Unexpected error: %v", err)
+				}
+				if resp.Status != tc.expectedStatus {
+					t.Errorf("Expected status %v, got %v", tc.expectedStatus, resp.Status)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
**Purpose of PR?**:
Added unit tests for `policy.go` to improve test coverage and ensure reliability of core logic.

Part of Issues #2130 

**Does this PR introduce a breaking change?**
``` No ```

**If the changes in this PR are manually verified, list down the scenarios covered:**:
 
-  PolicyServer logic for both container and host policies
- Handling of valid and invalid policy data (including empty names, invalid JSON, and nil data)
- Behavior when policy features are enabled/disabled
- Use of mock update functions to simulate both success and failure


**Additional information for reviewer?** :
| Before Coverage | After Coverage |
|--------|-------|
| ![Before](https://github.com/user-attachments/assets/0d5af0b2-8a98-4d11-ae4c-b959f42521ba) | ![After](https://github.com/user-attachments/assets/25cdd3f5-4472-4e4d-99d1-decb963ee4d4) |

**Checklist:**
- [ ] Bug fix. Fixes #<issue number>
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [x] Commit has unit tests
- [ ] Commit has integration tests

<!--

The PR title message must follow convention:
`<type>(<scope>): <subject>`.

Where: <br />
- `type` is to define what type of PR is this.
  Most common types are:
    - `feat`      - for new features, not a new feature for build script
    - `fix`       - for bug fixes or improvements, not a fix for build script
    - `chore`     - changes not related to production code
    - `docs`      - changes related to documentation
    - `style`     - formatting, missing semi colons, linting fix etc; no significant production code changes
    - `test`      - adding missing tests, refactoring tests; no production code change
    - `refactor`  - refactoring production code, eg. renaming a variable or function name, there should not be any significant production code changes

- `scope` is a single word that best describes where the changes fit.
    - feature(`monitor`,`enforcer`)
    - test(`tests`, `bdd`)
    - chore(`build`)
- `subject` is a single line brief description of the changes made in the pull request.

-->