### PR TITLE
docs: fix test script paths in testing guide

### DIFF
--- a/contribution/testing_guide.md
+++ b/contribution/testing_guide.md
@@ -103,7 +103,7 @@ $ kubectl -n [namespace name] exec -it [pod name] -- bash -c [command]
 
     ```text
     $ cd KubeArmor/tests
-    ~/KubeArmor/tests$ ./test-scenarios-local.sh
+    ~/KubeArmor/tests$ ./k8s_env/test-scenarios-local.sh
     ```
 
     Check the test report
@@ -118,7 +118,7 @@ $ kubectl -n [namespace name] exec -it [pod name] -- bash -c [command]
 
     ```text
     $ cd KubeArmor/tests
-    ~/KubeArmor/tests$ ./test-scenarios-in-runtime.sh
+    ~/KubeArmor/tests$ ./k8s_env/test-scenarios-in-runtime.sh
     ```
 
     Check the test report


### PR DESCRIPTION
## Changes
Fixed incorrect script paths in `contribution/testing_guide.md`:

**Original issue:**
```diff
- ~/KubeArmor/tests$ ./test-scenarios-local.sh
+ ~/KubeArmor/tests$ ./k8s_env/test-scenarios-local.sh

Bonus fix discovered:
- ~/KubeArmor/tests$ ./test-scenarios-in-runtime.sh  
+ ~/KubeArmor/tests$ ./k8s_env/test-scenarios-in-runtime.sh
Both scripts are located in the k8s_env directory, not in tests root.

```
fixes [#2142](https://github.com/kubearmor/KubeArmor/issues/2142#issue-3290592400)