### PR TITLE
relay/karmor : enhance relay RBAC permissions for telemetry visibility

### DIFF
--- a/deployments/get/objects.go
+++ b/deployments/get/objects.go
@@ -220,7 +220,17 @@ func GetRelayClusterRole() *rbacv1.ClusterRole {
 		Rules: []rbacv1.PolicyRule{
 			{
 				APIGroups: []string{""},
-				Resources: []string{"pods", "services"},
+				Resources: []string{"pods", "services", "namespaces", "nodes", "events"},
+				Verbs:     []string{"list", "watch"},
+			},
+			{
+				APIGroups: []string{"apps"},
+				Resources: []string{"deployments", "replicasets", "daemonsets", "statefulsets"},
+				Verbs:     []string{"list", "watch"},
+			},
+			{
+				APIGroups: []string{"security.kubearmor.com"},
+				Resources: []string{"kubearmorpolicies", "kubearmorclusterpolicies", "kubearmorhostpolicies"},
 				Verbs:     []string{"list", "watch"},
 			},
 		},


### PR DESCRIPTION
## Problem
KubeArmor policies enforced security correctly but telemetry logs were missing from `karmor logs` output.

## Solution  
Enhanced `kubearmor-relay` ClusterRole with missing RBAC permissions needed for telemetry enrichment and forwarding.

## Changes
- Added core resource permissions: `namespaces`, `nodes`, `events`
- Added apps permissions: `deployments`, `replicasets`, `daemonsets`, `statefulsets`
- Added security policy permissions: `kubearmorpolicies`, `kubearmorclusterpolicies`, `kubearmorhostpolicies`

## Result
✅ Policy enforcement continues to work  
✅ Telemetry logs now appear in `karmor logs`  
✅ Users can monitor security violations in real-time

After fix: KubeArmor telemetry logs now flowing properly- 

<img width="1038" height="877" alt="Screenshot from 2025-08-09 10-54-56" src="https://github.com/user-attachments/assets/389709e0-9a11-4c79-9636-d251197f3ba3" />


Fixes [#1911 ](https://github.com/kubearmor/KubeArmor/issues/1911#issue-2726797413) and [issue](https://github.com/kubearmor/kubearmor-client/issues/515)