### PR TITLE
fix(feeder/ci): prevent resource leaks on NewFeeder failure and enable CI coverage metrics

### DIFF
--- a/.github/workflows/ci-network-tests.yml
+++ b/.github/workflows/ci-network-tests.yml
@@ -69,6 +69,7 @@ jobs:
 
       - name: Generate KubeArmor artifacts
         run: |
+          export IS_COVERAGE=true
           GITHUB_SHA=$GITHUB_SHA ./KubeArmor/build/build_kubearmor.sh
 
       - name: Build Kubearmor-Operator
@@ -92,11 +93,11 @@ jobs:
           grep -rl "kubearmor/ubuntu-w-utils:latest" ./ | while read -r file; do sed -i 's/imagePullPolicy: Always/imagePullPolicy: Never/g' "$file"; done
 
       - name: Run KubeArmor
-        timeout-minutes: 7
+        timeout-minutes: 10
         run: |
           if [[ ${{ matrix.runtime }} == "containerd" ]]; then
-            docker save kubearmor/kubearmor-init:latest | sudo k3s ctr images import -
-            docker save kubearmor/kubearmor:latest | sudo k3s ctr images import -
+            docker save kubearmor/kubearmor-test-init:latest | sudo k3s ctr images import -
+            docker save kubearmor/kubearmor-test:latest | sudo k3s ctr images import -
             docker save kubearmor/kubearmor-operator:latest | sudo k3s ctr images import -
             docker save kubearmor/kubearmor-snitch:latest | sudo k3s ctr images import -
             
@@ -108,28 +109,43 @@ jobs:
             fi
           else
             if [ ${{ matrix.runtime }} == "crio" ]; then
-                docker save kubearmor/kubearmor-init:latest | sudo podman load
-                docker save kubearmor/kubearmor:latest | sudo podman load
-                docker save kubearmor/kubearmor-operator:latest | sudo podman load
-                docker save kubearmor/kubearmor-snitch:latest | sudo podman load
+              docker save kubearmor/kubearmor-test-init:latest | sudo podman load
+              sudo podman tag docker.io/kubearmor/kubearmor-test-init:latest kubearmor/kubearmor-test-init:latest
+
+              docker save kubearmor/kubearmor-test:latest | sudo podman load
+              sudo podman tag docker.io/kubearmor/kubearmor-test:latest kubearmor/kubearmor-test:latest
+      
+              docker save kubearmor/kubearmor-operator:latest | sudo podman load
+              sudo podman tag docker.io/kubearmor/kubearmor-operator:latest kubearmor/kubearmor-operator:latest
+
+              docker save kubearmor/kubearmor-snitch:latest | sudo podman load
+              sudo podman tag docker.io/kubearmor/kubearmor-snitch:latest kubearmor/kubearmor-snitch:latest
+
               if [ ${{ steps.filter.outputs.controller }} == 'true' ]; then
                 docker save kubearmor/kubearmor-controller:latest | sudo podman load
+                sudo podman tag docker.io/kubearmor/kubearmor-controller:latest kubearmor/kubearmor-controller:latest
+
               fi
               if [ ${{ steps.filter.outputs.multiubuntu }} == 'true' ]; then
                 docker save kubearmor/ubuntu-w-utils:latest | sudo podman load
+                sudo podman tag docker.io/kubearmor/ubuntu-w-utils:latest kubearmor/ubuntu-w-utils:latest
               fi
+              echo "Podman images"
+              sudo podman images -a
             fi
           fi
 
+          docker system prune -a -f 
+          docker buildx prune -a -f
           helm upgrade --install kubearmor-operator ./deployments/helm/KubeArmorOperator -n kubearmor --create-namespace --set kubearmorOperator.image.tag=latest  --set kubearmorOperator.annotateExisting=true
           kubectl wait --for=condition=ready --timeout=5m -n kubearmor pod -l kubearmor-app=kubearmor-operator
           kubectl get pods -A
           if [[ ${{ steps.filter.outputs.controller }} == 'true' ]]; then
-            kubectl apply -f pkg/KubeArmorOperator/config/samples/kubearmor-test.yaml --dry-run=client -o json | \
+            kubectl apply -f pkg/KubeArmorOperator/config/samples/kubearmor-coverage.yaml --dry-run=client -o json | \
             jq '.spec.kubearmorControllerImage.imagePullPolicy = "Never"' | \
             kubectl apply -f -
           else 
-            kubectl apply -f pkg/KubeArmorOperator/config/samples/kubearmor-test.yaml
+            kubectl apply -f pkg/KubeArmorOperator/config/samples/kubearmor-coverage.yaml
           fi
 
           kubectl wait -n kubearmor --timeout=5m --for=jsonpath='{.status.phase}'=Running kubearmorconfigs/kubearmorconfig-test
@@ -141,8 +157,37 @@ jobs:
             kubectl get pods -A
           done
      
-      - name: Operator may take upto 10 sec to enable TLS, Sleep for 15Sec
-        run: |
+          sleep 10
+          DAEMONSET_NAME=$(kubectl get daemonset -n kubearmor -o jsonpath='{.items[0].metadata.name}')
+          echo "DaemonSet: $DAEMONSET_NAME"
+
+          kubectl patch daemonset $DAEMONSET_NAME -n kubearmor --type='json' -p='[
+            {
+              "op": "add",
+              "path": "/spec/template/spec/volumes/-",
+              "value": {
+                "name": "coverage-storage",
+                "hostPath": {
+                  "path": "/coverage",
+                  "type": "DirectoryOrCreate"
+                }
+              }
+            },
+            {
+              "op": "add",
+              "path": "/spec/template/spec/containers/0/volumeMounts/-",
+              "value": {
+                "mountPath": "/coverage",
+                "name": "coverage-storage"
+              }
+            },
+            {
+              "op": "add",
+              "path": "/spec/template/spec/containers/0/args/-",
+              "value": "-test.coverprofile=/coverage/coverage_k8s_${{ matrix.os }}_${{ matrix.runtime }}.out"
+            }
+          ]'
+
           sleep 15
 
       - name: Get KubeArmor POD info
@@ -161,6 +206,26 @@ jobs:
         working-directory: ./tests/k8s_env/networktests
         timeout-minutes: 30
 
+      - name: Kill KubeArmor prcoess in the pod
+        run: |
+          KUBEARMOR_PID=$(kubectl exec ${{ env.POD_NAME }} -n kubearmor -c kubearmor -- sh -c "ps aux | grep '[K]ubeArmor/kubearmor-test' | awk '{print \$1}'")
+          kubectl exec ${{ env.POD_NAME }} -n kubearmor -c kubearmor -- sh -c "kill -s SIGINT $KUBEARMOR_PID"
+          sleep 10
+        env:
+          POD_NAME: ${{ env.POD_NAME }}
+
+      - name: Extract coverage file
+        run: |
+          for i in {1..24}; do
+            if [ -f /coverage/coverage_k8s_${{ matrix.os }}_${{ matrix.runtime }}.out ]; then
+              cp /coverage/coverage_k8s_${{ matrix.os }}_${{ matrix.runtime }}.out coverage_k8s_${{ matrix.os }}_${{ matrix.runtime }}.out
+              break
+            fi
+            sleep 5
+          done
+          ls -l
+        working-directory: KubeArmor
+        
       - name: Get karmor sysdump
         if: ${{ failure() }}
         run: |
@@ -181,8 +246,13 @@ jobs:
         if: ${{ always() }}
         run: |
           go install github.com/modocache/gover@latest
-          gover
-          go tool cover -func=gover.coverprofile
+          ls -l
+          if [ -f coverage_k8s_${{ matrix.os }}_${{ matrix.runtime }}.out ]; then
+            gover
+            go tool cover -func coverage_k8s_${{ matrix.os }}_${{ matrix.runtime }}.out
+          else
+            echo "Coverage file not found, skipping coverage report."
+          fi
         working-directory: KubeArmor
         env:
           GOPATH: /home/vagrant/go
@@ -190,6 +260,14 @@ jobs:
         if: ${{ always() }}
         with:
           files: ./KubeArmor/gover.coverprofile
+
+      - name: Upload coverage file
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-k8s-${{ matrix.os }}-${{ matrix.runtime }}
+          path: KubeArmor/coverage_k8s_${{ matrix.os }}_${{ matrix.runtime }}.out
+
       - name: Run cleanup
         if: ${{ always() }}
         run: ./.github/workflows/cleanup.sh

--- a/.github/workflows/ci-test-ubi-image.yml
+++ b/.github/workflows/ci-test-ubi-image.yml
@@ -68,6 +68,7 @@ jobs:
 
       - name: Generate KubeArmor artifacts
         run: |
+          export IS_COVERAGE=true
           GITHUB_SHA=$GITHUB_SHA ./KubeArmor/build/build_kubearmor.sh
 
       - name: Build Kubearmor-Operator
@@ -87,22 +88,32 @@ jobs:
       - name: Run KubeArmor
         timeout-minutes: 7
         run: |
-          docker save kubearmor/kubearmor-init:latest | sudo podman load
-          docker save kubearmor/kubearmor-ubi:latest | sudo podman load
+          docker save kubearmor/kubearmor-test-init:latest | sudo podman load
+          sudo podman tag docker.io/kubearmor/kubearmor-test-init:latest kubearmor/kubearmor-test-init:latest
+
+          docker save kubearmor/kubearmor-ubi-test:latest | sudo podman load
+          sudo podman tag docker.io/kubearmor/kubearmor-ubi-test:latest kubearmor/kubearmor-ubi-test:latest
+
           docker save kubearmor/kubearmor-operator:latest | sudo podman load
+          sudo podman tag docker.io/kubearmor/kubearmor-operator:latest kubearmor/kubearmor-operator:latest
+
           docker save kubearmor/kubearmor-snitch:latest | sudo podman load
-          
-          if [ ${{ steps.filter.outputs.controller }} == 'true' ]; then 
+          sudo podman tag docker.io/kubearmor/kubearmor-snitch:latest kubearmor/kubearmor-snitch:latest
+
+          if [ ${{ steps.filter.outputs.controller }} == 'true' ]; then
             docker save kubearmor/kubearmor-controller:latest | sudo podman load
+            sudo podman tag docker.io/kubearmor/kubearmor-controller:latest kubearmor/kubearmor-controller:latest
           fi
           if [[ ${{ steps.filter.outputs.multiubuntu }} == 'true' ]]; then
             docker save kubearmor/ubuntu-w-utils:latest | sudo podman load
-          fi          
+            sudo podman tag docker.io/kubearmor/ubuntu-w-utils:latest kubearmor/ubuntu-w-utils:latest
+          fi
           
-          helm upgrade --install kubearmor-operator ./deployments/helm/KubeArmorOperator -n kubearmor --create-namespace --set kubearmorOperator.image.tag=latest
-          kubectl get pods -A
+          docker system prune -a -f 
+          docker buildx prune -a -f
+          helm upgrade --install kubearmor-operator ./deployments/helm/KubeArmorOperator -n kubearmor --create-namespace --set kubearmorOperator.image.tag=latest --set kubearmorOperator.annotateExisting=true
           kubectl wait --for=condition=ready --timeout=5m -n kubearmor pod -l kubearmor-app=kubearmor-operator
-
+          kubectl get pods -A
           if [[ ${{ steps.filter.outputs.controller }} == 'true' ]]; then
             kubectl apply -f pkg/KubeArmorOperator/config/samples/kubearmor-ubi-test.yaml --dry-run=client -o json | \
             jq '.spec.kubearmorControllerImage.imagePullPolicy = "Never"' | \
@@ -119,23 +130,92 @@ jobs:
             kubectl rollout status --timeout=5m deployment -n kubearmor -l kubearmor-app=kubearmor-controller -n kubearmor
             kubectl get pods -A
           done
-      
-      - name: Operator may take upto 10 sec to enable TLS, Sleep for 15Sec
-        run: |
-          sleep 15
 
+          sleep 10
+          DAEMONSET_NAME=$(kubectl get daemonset -n kubearmor -o jsonpath='{.items[0].metadata.name}')
+          echo "DaemonSet: $DAEMONSET_NAME"
+
+          kubectl patch daemonset $DAEMONSET_NAME -n kubearmor --type='json' -p='[
+            {
+              "op": "add",
+              "path": "/spec/template/spec/volumes/-",
+              "value": {
+                "name": "coverage-storage",
+                "hostPath": {
+                  "path": "/coverage",
+                  "type": "DirectoryOrCreate"
+                }
+              }
+            },
+            {
+              "op": "add",
+              "path": "/spec/template/spec/containers/0/volumeMounts/-",
+              "value": {
+                "mountPath": "/coverage",
+                "name": "coverage-storage"
+              }
+            },
+            {
+              "op": "add",
+              "path": "/spec/template/spec/containers/0/args/-",
+              "value": "-test.coverprofile=/coverage/coverage_k8s_${{ matrix.os }}_${{ matrix.runtime }}.out"
+            }
+          ]'
+
+          sleep 15
+          
       - name: make changes in multiubuntu-deployment
         working-directory: ./tests/k8s_env
         if: steps.filter.outputs.multiubuntu == 'true'
         run: |
           grep -rl "kubearmor/ubuntu-w-utils:latest" ./ | while read -r file; do sed -i 's/imagePullPolicy: Always/imagePullPolicy: Never/g' "$file"; done
-      
+
+      - name: Get KubeArmor POD info
+        run: |
+          DAEMONSET_NAME=$(kubectl get daemonset -n kubearmor -o jsonpath='{.items[0].metadata.name}')
+          LABEL_SELECTOR=$(kubectl get daemonset $DAEMONSET_NAME -n kubearmor -o jsonpath='{.spec.selector.matchLabels}' | jq -r 'to_entries[] | "\(.key)=\(.value)"' | paste -sd, -)
+          POD_NAME=$(kubectl get pods -n kubearmor -l "$LABEL_SELECTOR" -o jsonpath='{.items[0].metadata.name}')
+          echo "Pod: $POD_NAME"
+          echo "POD_NAME=$POD_NAME" >> $GITHUB_ENV
+
       - name: Test KubeArmor using Ginkgo
         run: |
           go install -mod=mod github.com/onsi/ginkgo/v2/ginkgo
           make
         working-directory: ./tests/k8s_env
         timeout-minutes: 30
+
+      - name: Kill KubeArmor process in the pod
+        run: |
+          echo "Listing all processes in the pod"
+          kubectl exec ${{ env.POD_NAME }} -n kubearmor -c kubearmor -- ps aux
+
+          KUBEARMOR_PID=$(kubectl exec ${{ env.POD_NAME }} -n kubearmor -c kubearmor -- \
+            sh -c "ps aux | grep '[k]ubearmor-test' | awk '{print \$2}'")
+
+          if [ -n "$KUBEARMOR_PID" ]; then
+            echo "Killing KubeArmor PID: $KUBEARMOR_PID"
+            kubectl exec ${{ env.POD_NAME }} -n kubearmor -c kubearmor -- \
+              sh -c "kill -2 $KUBEARMOR_PID"
+          else
+            echo "No KubeArmor process found to kill."
+          fi
+
+          sleep 10
+        env:
+          POD_NAME: ${{ env.POD_NAME }}
+
+      - name: Extract coverage file
+        run: |
+          for i in {1..24}; do
+            if [ -f /coverage/coverage_k8s_${{ matrix.os }}_${{ matrix.runtime }}.out ]; then
+              cp /coverage/coverage_k8s_${{ matrix.os }}_${{ matrix.runtime }}.out coverage_k8s_${{ matrix.os }}_${{ matrix.runtime }}.out
+              break
+            fi
+            sleep 5
+          done
+          ls -l
+        working-directory: KubeArmor
 
       - name: Get karmor sysdump
         if: ${{ failure() }}
@@ -157,8 +237,13 @@ jobs:
         if: ${{ always() }}
         run: |
           go install github.com/modocache/gover@latest
-          gover
-          go tool cover -func=gover.coverprofile
+          ls -l
+          if [ -f coverage_k8s_${{ matrix.os }}_${{ matrix.runtime }}.out ]; then
+            gover
+            go tool cover -func coverage_k8s_${{ matrix.os }}_${{ matrix.runtime }}.out
+          else
+            echo "Coverage file not found, skipping coverage report."
+          fi
         working-directory: KubeArmor
         env:
           GOPATH: /home/vagrant/go
@@ -166,8 +251,14 @@ jobs:
         if: ${{ always() }}
         with:
           files: ./KubeArmor/gover.coverprofile
+
+      - name: Upload coverage file
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-k8s-${{ matrix.os }}-${{ matrix.runtime }}
+          path: KubeArmor/coverage_k8s_${{ matrix.os }}_${{ matrix.runtime }}.out
+
       - name: Run cleanup
         if: ${{ always() }}
         run: ./.github/workflows/cleanup.sh
-    
-

--- a/KubeArmor/feeder/feeder.go
+++ b/KubeArmor/feeder/feeder.go
@@ -250,9 +250,16 @@ type Feeder struct {
 }
 
 // NewFeeder Function
-func NewFeeder(node *tp.Node, nodeLock **sync.RWMutex) *Feeder {
+func NewFeeder(node *tp.Node, nodeLock **sync.RWMutex) (feeder *Feeder) {
 	fd := &Feeder{}
 
+	defer func() {
+		if feeder == nil {
+			if err := fd.DestroyFeeder(); err != nil {
+				kg.Errf("Failed to destroy feeder: %v", err)
+			}
+		}
+	}()
 	// base feeder //
 
 	// node

--- a/KubeArmor/feeder/feeder_test.go
+++ b/KubeArmor/feeder/feeder_test.go
@@ -4,36 +4,227 @@
 package feeder
 
 import (
+	"fmt"
+	"net"
+	"os"
+	"strconv"
 	"sync"
 	"testing"
 
 	cfg "github.com/kubearmor/KubeArmor/KubeArmor/config"
 	tp "github.com/kubearmor/KubeArmor/KubeArmor/types"
+	pb "github.com/kubearmor/KubeArmor/protobuf"
 )
 
-func TestFeeder(t *testing.T) {
-	// node
-	node := tp.Node{}
-	nodeLock := new(sync.RWMutex)
+var baseCfg cfg.KubearmorConfig
 
-	// load configuration
+func cloneConfig() cfg.KubearmorConfig {
+	c := baseCfg
+
+	if baseCfg.ConfigUntrackedNs != nil {
+		c.ConfigUntrackedNs = make([]string, len(baseCfg.ConfigUntrackedNs))
+		copy(c.ConfigUntrackedNs, baseCfg.ConfigUntrackedNs)
+	}
+
+	if baseCfg.LsmOrder != nil {
+		c.LsmOrder = make([]string, len(baseCfg.LsmOrder))
+		copy(c.LsmOrder, baseCfg.LsmOrder)
+	}
+
+	return c
+}
+
+func destroyFeederIfExists(fd *Feeder, t *testing.T) {
+	if fd != nil {
+		if err := fd.DestroyFeeder(); err != nil {
+			t.Logf("Failed to destroy feeder: %v", err)
+		}
+	}
+}
+
+// setup once for this package
+func TestMain(m *testing.M) {
 	if err := cfg.LoadConfig(); err != nil {
-		t.Log("[FAIL] Failed to load configuration")
-		return
+		fmt.Fprintf(os.Stderr, "Failed to load configuration: %v\n", err)
+		os.Exit(1)
+	}
+	baseCfg = cfg.GlobalCfg
+
+	exitCode := m.Run()
+
+	os.Exit(exitCode)
+}
+
+func TestNewFeeder(t *testing.T) {
+	tests := []struct {
+		name      string
+		setup     func(t *testing.T)
+		expectNil bool
+	}{
+		{
+			name: "DefaultConfigSuccess",
+			setup: func(t *testing.T) {
+				cfg.GlobalCfg = cloneConfig()
+				cfg.GlobalCfg.GRPC = "55555"
+			},
+			expectNil: false,
+		},
+		{
+			name: "WithValidLogPath",
+			setup: func(t *testing.T) {
+				cfg.GlobalCfg = cloneConfig()
+				cfg.GlobalCfg.GRPC = "55555"
+
+				tmpFile, err := os.CreateTemp("", "feeder-log-*.log")
+				if err != nil {
+					t.Fatalf("Failed to create temp log file: %v", err)
+				}
+				logPath := tmpFile.Name()
+				cfg.GlobalCfg.LogPath = logPath
+
+				tmpFile.Close()
+
+				t.Cleanup(func() {
+					if err := os.Remove(logPath); err != nil {
+						t.Logf("Failed to delete temp log file: %v", err)
+					}
+				})
+			},
+			expectNil: false,
+		},
+		{
+			name: "WithInvalidLogPath",
+			setup: func(t *testing.T) {
+				cfg.GlobalCfg = cloneConfig()
+				cfg.GlobalCfg.GRPC = "55555"
+				// directory cannot be opened as file
+				dir := t.TempDir()
+				cfg.GlobalCfg.LogPath = dir
+			},
+			expectNil: true,
+		},
+		{
+			name: "TLSCredentialsFailure",
+			setup: func(t *testing.T) {
+				cfg.GlobalCfg = cloneConfig()
+				cfg.GlobalCfg.TLSEnabled = true
+				cfg.GlobalCfg.GRPC = "55555"
+				cfg.GlobalCfg.TLSCertPath = "/invalid/cert.pem"
+			},
+			expectNil: true,
+		},
+		{
+			name: "GRPCPortInUseFailure",
+			setup: func(t *testing.T) {
+				cfg.GlobalCfg = cloneConfig()
+
+				listener, err := net.Listen("tcp", ":0")
+				if err != nil {
+					t.Fatalf("Failed to bind test port: %v", err)
+				}
+				addr := listener.Addr().(*net.TCPAddr)
+
+				cfg.GlobalCfg.GRPC = strconv.Itoa(addr.Port)
+
+				t.Cleanup(func() {
+					listener.Close()
+				})
+			},
+			expectNil: true,
+		},
 	}
 
-	// create logger
-	logger := NewFeeder(&node, &nodeLock)
-	if logger == nil {
-		t.Log("[FAIL] Failed to create logger")
-		return
-	}
-	t.Log("[PASS] Created logger")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.setup(t)
 
-	// destroy logger
-	if err := logger.DestroyFeeder(); err != nil {
-		t.Log("[FAIL] Failed to destroy logger")
-		return
+			node := tp.Node{}
+			nodeLock := new(sync.RWMutex)
+
+			feeder := NewFeeder(&node, &nodeLock)
+			defer destroyFeederIfExists(feeder, t)
+
+			if tt.expectNil && feeder != nil {
+				t.Fatalf("expected feeder to be nil")
+			}
+
+			if !tt.expectNil && feeder == nil {
+				t.Fatalf("expected feeder to be created")
+			}
+		})
 	}
-	t.Log("[PASS] Destroyed logger")
+}
+
+func TestEventStructs_AddAndRemove(t *testing.T) {
+	tests := []struct {
+		name       string
+		addFunc    func(*EventStructs, string, int) (string, any)
+		removeFunc func(*EventStructs, string)
+		getLen     func(*EventStructs) int
+	}{
+		{
+			name: "AddRemoveMsgStruct",
+			addFunc: func(es *EventStructs, filter string, size int) (string, any) {
+				return es.AddMsgStruct(filter, size)
+			},
+			removeFunc: func(es *EventStructs, uid string) {
+				es.RemoveMsgStruct(uid)
+			},
+			getLen: func(es *EventStructs) int {
+				return len(es.MsgStructs)
+			},
+		},
+		{
+			name: "AddRemoveAlertStruct",
+			addFunc: func(es *EventStructs, filter string, size int) (string, any) {
+				return es.AddAlertStruct(filter, size)
+			},
+			removeFunc: func(es *EventStructs, uid string) {
+				es.RemoveAlertStruct(uid)
+			},
+			getLen: func(es *EventStructs) int {
+				return len(es.AlertStructs)
+			},
+		},
+		{
+			name: "AddRemoveLogStruct",
+			addFunc: func(es *EventStructs, filter string, size int) (string, any) {
+				return es.AddLogStruct(filter, size)
+			},
+			removeFunc: func(es *EventStructs, uid string) {
+				es.RemoveLogStruct(uid)
+			},
+			getLen: func(es *EventStructs) int {
+				return len(es.LogStructs)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			es := &EventStructs{
+				MsgStructs:   make(map[string]EventStruct[pb.Message]),
+				AlertStructs: make(map[string]EventStruct[pb.Alert]),
+				LogStructs:   make(map[string]EventStruct[pb.Log]),
+			}
+
+			uid, ch := tt.addFunc(es, "test-filter", 5)
+			if uid == "" {
+				t.Fatalf("expected non-empty uid")
+			}
+			if ch == nil {
+				t.Fatalf("expected non-nil channel")
+			}
+
+			if got := tt.getLen(es); got != 1 {
+				t.Fatalf("expected 1 entry, got %d", got)
+			}
+
+			tt.removeFunc(es, uid)
+			if got := tt.getLen(es); got != 0 {
+				t.Fatalf("expected 0 entries after remove, got %d", got)
+			}
+		})
+	}
 }

--- a/pkg/KubeArmorOperator/config/samples/kubearmor-ubi-test.yaml
+++ b/pkg/KubeArmorOperator/config/samples/kubearmor-ubi-test.yaml
@@ -15,10 +15,10 @@ spec:
   defaultNetworkPosture: block
   defaultVisibility: process,file,network,capabilities
   kubearmorImage:
-    image: kubearmor/kubearmor-ubi:latest
+    image: kubearmor/kubearmor-ubi-test:latest
     imagePullPolicy: Never
   kubearmorInitImage:
-    image: kubearmor/kubearmor-init:latest
+    image: kubearmor/kubearmor-test-init:latest
     imagePullPolicy: Never
   kubearmorRelayImage:
     image: docker.io/kubearmor/kubearmor-relay-server:latest


### PR DESCRIPTION
### Description

#### 1. Resource leak in NewFeeder():
Closes gRPC listener and log file if NewFeeder() fails during initialization.
Previously, errors during initialization left ports and file descriptors open, causing conflicts on consecutive runs.

#### 2. CI Coverage Metrics:
Fixes coverage generation in CI-Network-Tests and CI-Test-UBI-Image workflows and uploads coverage file.
- **Before the fix**: No coverage was recorded (0.0%) because KubeArmor binaries were not built with coverage flags, and coverage files were not collected. [Before Fix](https://github.com/kubearmor/KubeArmor/actions/runs/18398000563/job/52421012173#step:19:1)
- **After the fix**: Proper coverage files are generated, collected, and uploaded by mounting the coverage path.
[After Fix](https://github.com/kubearmor/KubeArmor/actions/runs/18461098410/job/52601429161#step:20:37)

**Purpose of PR?**:
Fixes #2158 (resource leak) and ensures coverage metrics are correctly reported in CI.

**Does this PR introduce a breaking change?**
No

**If the changes in this PR are manually verified, list down the scenarios covered:**

 For Resource leak: 
* Created a test where the first `NewFeeder()` intentionally fails after the listener is created. Verified that the listener is closed and the port is freed.
* Verified that subsequent `NewFeeder()` calls succeed without `"Failed to listen a port"` errors.
* Checked that log file handles are also properly released.

CI Coverage Metrics:
* Coverage metrics are generated, collected, and uploaded correctly in both ci-network-tests and ci-test-ubi-image CI workflows.


**Additional information for reviewer?**
The CI Fixes were added later

**Checklist:**

* [x] Bug fix. Fixes #<issue number>
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] This change requires a documentation update
* [x] PR Title follows the convention of `<type>(<scope>): <subject>`
* [x] Commit has unit tests
* [ ] Commit has integration tests

