### PR TITLE
refactor(core): fix LSP warnings with idiomatic code

### DIFF
--- a/KubeArmor/common/common.go
+++ b/KubeArmor/common/common.go
@@ -15,7 +15,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"regexp"
-	"sort"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -48,7 +48,7 @@ const (
 )
 
 // Clone Function
-func Clone(src, dst interface{}) error {
+func Clone(src, dst any) error {
 	arr, _ := json.Marshal(src)
 	return json.Unmarshal(arr, dst)
 }
@@ -59,7 +59,7 @@ func RemoveStringElement(slice []string, size int) []string {
 }
 
 // ContainsElement Function
-func ContainsElement(slice interface{}, element interface{}) bool {
+func ContainsElement(slice any, element any) bool {
 	switch reflect.TypeOf(slice).Kind() {
 	case reflect.Slice:
 		s := reflect.ValueOf(slice)
@@ -93,7 +93,7 @@ func MatchesRegex(key, element string, array []string) bool {
 }
 
 // ObjCommaCanBeExpanded Function
-func ObjCommaCanBeExpanded(objptr interface{}) bool {
+func ObjCommaCanBeExpanded(objptr any) bool {
 	ovptr := reflect.ValueOf(objptr)
 	if ovptr.Kind() != reflect.Ptr {
 		return false
@@ -128,7 +128,7 @@ func ObjCommaExpand(v reflect.Value) []string {
 }
 
 // ObjCommaExpandFirstDupOthers Function
-func ObjCommaExpandFirstDupOthers(objptr interface{}) {
+func ObjCommaExpandFirstDupOthers(objptr any) {
 	if ObjCommaCanBeExpanded(objptr) {
 		old := reflect.ValueOf(objptr).Elem()
 		new := reflect.New(reflect.TypeOf(objptr).Elem()).Elem()
@@ -566,7 +566,7 @@ func MatchExpIdentities(selector tp.SelectorType, superIdentities []string) bool
 }
 
 // WriteToFile writes given string to file as JSON
-func WriteToFile(val interface{}, destFile string) error {
+func WriteToFile(val any, destFile string) error {
 	j, err := json.Marshal(val)
 	if err != nil {
 		return err
@@ -649,9 +649,7 @@ func GetLabelsFromString(labelString string) (map[string]string, []string) {
 		labelsMap[key] = value
 	}
 
-	sort.Slice(labelsSlice, func(i, j int) bool {
-		return labelsSlice[i] < labelsSlice[j]
-	})
+	slices.Sort(labelsSlice)
 
 	return labelsMap, labelsSlice
 }

--- a/KubeArmor/core/containerdHandler.go
+++ b/KubeArmor/core/containerdHandler.go
@@ -454,8 +454,7 @@ func (dm *KubeArmorDaemon) UpdateContainerdContainer(ctx context.Context, contai
 
 					// add identities and labels if non-k8s
 					if !dm.K8sEnabled {
-						labelsSlice := strings.Split(container.Labels, ",")
-						for _, label := range labelsSlice {
+						for label := range strings.SplitSeq(container.Labels, ",") {
 							key, value, ok := strings.Cut(label, "=")
 							if !ok {
 								continue

--- a/KubeArmor/core/crioHandler.go
+++ b/KubeArmor/core/crioHandler.go
@@ -19,6 +19,7 @@ import (
 	tp "github.com/kubearmor/KubeArmor/KubeArmor/types"
 	spec "github.com/opencontainers/runtime-spec/specs-go"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 	pb "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
@@ -50,7 +51,7 @@ var Crio *CrioHandler
 func NewCrioHandler() *CrioHandler {
 	ch := &CrioHandler{}
 
-	conn, err := grpc.Dial(cfg.GlobalCfg.CRISocket, grpc.WithInsecure())
+	conn, err := grpc.NewClient(cfg.GlobalCfg.CRISocket, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		return nil
 	}

--- a/KubeArmor/core/k8sHandler.go
+++ b/KubeArmor/core/k8sHandler.go
@@ -183,7 +183,7 @@ func (kh *K8sHandler) InitInclusterAPIClient() error {
 // ============== //
 
 // DoRequest Function
-func (kh *K8sHandler) DoRequest(cmd string, data interface{}, path string) ([]byte, error) {
+func (kh *K8sHandler) DoRequest(cmd string, data any, path string) ([]byte, error) {
 	URL := ""
 
 	if kl.IsInK8sCluster() {
@@ -261,14 +261,14 @@ func (kh *K8sHandler) PatchResourceWithAppArmorAnnotations(namespaceName, deploy
 		spec = spec + `}}}}}`
 	}
 
-	if kind == "StatefulSet" {
+	switch kind {
+	case "StatefulSet":
 		_, err := kh.K8sClient.AppsV1().StatefulSets(namespaceName).Patch(context.Background(), deploymentName, types.StrategicMergePatchType, []byte(spec), metav1.PatchOptions{})
 		if err != nil {
 			return err
 		}
 		return nil
-
-	} else if kind == "ReplicaSet" {
+	case "ReplicaSet":
 		rs, err := kh.K8sClient.AppsV1().ReplicaSets(namespaceName).Get(context.Background(), deploymentName, metav1.GetOptions{})
 		if err != nil {
 			return err
@@ -293,24 +293,23 @@ func (kh *K8sHandler) PatchResourceWithAppArmorAnnotations(namespaceName, deploy
 		}
 
 		return nil
-	} else if kind == "DaemonSet" {
+	case "DaemonSet":
 		_, err := kh.K8sClient.AppsV1().DaemonSets(namespaceName).Patch(context.Background(), deploymentName, types.MergePatchType, []byte(spec), metav1.PatchOptions{})
 		if err != nil {
 			return err
 		}
 		return nil
-
-	} else if kind == "Deployment" {
+	case "Deployment":
 		_, err := kh.K8sClient.AppsV1().Deployments(namespaceName).Patch(context.Background(), deploymentName, types.StrategicMergePatchType, []byte(spec), metav1.PatchOptions{})
 		if err != nil {
 			return err
 		}
-	} else if kind == "CronJob" {
+	case "CronJob":
 		_, err := kh.K8sClient.BatchV1().CronJobs(namespaceName).Patch(context.Background(), deploymentName, types.StrategicMergePatchType, []byte(spec), metav1.PatchOptions{})
 		if err != nil {
 			return err
 		}
-	} else if kind == "Pod" {
+	case "Pod":
 		// this condition wont be triggered, handled by controller
 		return nil
 

--- a/KubeArmor/core/unorchestratedUpdates.go
+++ b/KubeArmor/core/unorchestratedUpdates.go
@@ -7,7 +7,7 @@ import (
 	"encoding/json"
 	"os"
 	"regexp"
-	"sort"
+	"slices"
 	"strings"
 
 	"github.com/fsnotify/fsnotify"
@@ -191,7 +191,8 @@ func (dm *KubeArmorDaemon) handlePolicyEvent(eventType string, createEndPoint bo
 	}
 
 	var privilegedProfiles map[string]struct{}
-	if eventType == "ADDED" {
+	switch eventType {
+	case "ADDED":
 		dm.RuntimeEnforcer.UpdateAppArmorProfiles(containername, "ADDED", appArmorAnnotations, privilegedProfiles)
 
 		newPoint.SecurityPolicies = append(newPoint.SecurityPolicies, secPolicy)
@@ -234,7 +235,7 @@ func (dm *KubeArmorDaemon) handlePolicyEvent(eventType string, createEndPoint bo
 				}
 			}
 		}
-	} else if eventType == "MODIFIED" {
+	case "MODIFIED":
 		dm.EndPoints[endpointIdx] = newPoint
 		if cfg.GlobalCfg.Policy {
 			// update security policies
@@ -251,7 +252,7 @@ func (dm *KubeArmorDaemon) handlePolicyEvent(eventType string, createEndPoint bo
 				}
 			}
 		}
-	} else { // DELETED
+	default: // DELETED
 		// update security policies after policy deletion
 		if endpointIdx >= 0 {
 			dm.EndPoints[endpointIdx] = newPoint
@@ -332,9 +333,7 @@ func (dm *KubeArmorDaemon) ParseAndUpdateContainerSecurityPolicy(event tp.K8sKub
 		}
 	}
 
-	sort.Slice(secPolicy.Spec.Selector.Identities, func(i, j int) bool {
-		return secPolicy.Spec.Selector.Identities[i] < secPolicy.Spec.Selector.Identities[j]
-	})
+	slices.Sort(secPolicy.Spec.Selector.Identities)
 
 	// add severities, tags, messages, and actions
 
@@ -743,16 +742,18 @@ func (dm *KubeArmorDaemon) ParseAndUpdateContainerSecurityPolicy(event tp.K8sKub
 
 	// backup/remove container policies
 	if !dm.K8sEnabled && (cfg.GlobalCfg.KVMAgent || cfg.GlobalCfg.Policy) {
-		if event.Type == "ADDED" || event.Type == "MODIFIED" {
+		switch event.Type {
+		case "ADDED", "MODIFIED":
 			// backup SecurityPolicy to file
 			dm.backupKubeArmorContainerPolicy(secPolicy)
-		} else if event.Type == "DELETED" {
+		case "DELETED":
 			dm.removeBackUpPolicy(secPolicy.Metadata["policyName"])
 		}
 	}
-	if event.Type == "ADDED" {
+	switch event.Type {
+	case "ADDED":
 		return pb.PolicyStatus_Applied
-	} else if event.Type == "DELETED" {
+	case "DELETED":
 		return pb.PolicyStatus_Deleted
 	}
 

--- a/KubeArmor/enforcer/SELinuxEnforcer.go
+++ b/KubeArmor/enforcer/SELinuxEnforcer.go
@@ -293,7 +293,7 @@ func (se *SELinuxEnforcer) InstallSELinuxModulesIfNeeded() bool {
 		return false
 	}
 
-	for _, line := range strings.Split(res, "\n") {
+	for line := range strings.SplitSeq(res, "\n") {
 		// fields: ModuleName Priority Language
 		words := strings.Fields(line)
 
@@ -332,7 +332,7 @@ func (se *SELinuxEnforcer) RestoreSELinuxLabels(profilePath string) bool {
 
 	res := true
 
-	for _, line := range strings.Split(string(profile), "\n") {
+	for line := range strings.SplitSeq(string(profile), "\n") {
 		// fields: SubjectLabel SubjectPath ObjectLabel ObjectPath Permissive Directory Recursive
 
 		words := strings.Fields(line)
@@ -484,7 +484,7 @@ func (se *SELinuxEnforcer) UpdateSELinuxLabels(profilePath string) bool {
 
 	res := true
 
-	for _, line := range strings.Split(string(profile), "\n") {
+	for line := range strings.SplitSeq(string(profile), "\n") {
 		// fields: SubjectLabel SubjectPath ObjectLabel ObjectPath Permissive Directory Recursive
 
 		words := strings.Fields(line)

--- a/KubeArmor/enforcer/SELinuxHostProfile.go
+++ b/KubeArmor/enforcer/SELinuxHostProfile.go
@@ -149,7 +149,7 @@ func (se *SELinuxEnforcer) AllowedHostNetworkMatchProtocols(proto tp.NetworkProt
 		icmp := "n"
 		raw := "n"
 
-		for _, proto := range strings.Split(proto.Protocol, ",") {
+		for proto := range strings.SplitSeq(proto.Protocol, ",") {
 			if proto == "tcp" {
 				tcp = "t"
 			} else if proto == "udp" {
@@ -344,7 +344,7 @@ func (se *SELinuxEnforcer) BlockedHostNetworkMatchProtocols(proto tp.NetworkProt
 		icmp := "r"
 		raw := "i"
 
-		for _, proto := range strings.Split(proto.Protocol, ",") {
+		for proto := range strings.SplitSeq(proto.Protocol, ",") {
 			if proto == "tcp" {
 				tcp = "n"
 			} else if proto == "udp" {

--- a/KubeArmor/enforcer/appArmorEnforcer.go
+++ b/KubeArmor/enforcer/appArmorEnforcer.go
@@ -237,11 +237,11 @@ func (ae *AppArmorEnforcer) RegisterAppArmorProfile(podName, profileName string,
 	// generate a profile with basic allows if a privileged container
 	var newProfile string
 	if privileged {
-		newProfile = strings.Replace(ae.ApparmorDefaultPrivileged, "apparmor-default", profileName, -1)
+		newProfile = strings.ReplaceAll(ae.ApparmorDefaultPrivileged, "apparmor-default", profileName)
 		ae.AppArmorPrivilegedProfiles[profileName] = struct{}{}
 		ae.Logger.Printf("Added an AppArmor profile for a privileged container (%s, %s)", podName, profileName)
 	} else {
-		newProfile = strings.Replace(ae.ApparmorDefault, "apparmor-default", profileName, -1)
+		newProfile = strings.ReplaceAll(ae.ApparmorDefault, "apparmor-default", profileName)
 	}
 
 	newFile, err := os.Create(filepath.Clean("/etc/apparmor.d/" + profileName))
@@ -320,9 +320,9 @@ func (ae *AppArmorEnforcer) UnregisterAppArmorProfile(podName, profileName strin
 
 	var newProfile string
 	if privileged {
-		newProfile = strings.Replace(ae.ApparmorDefaultPrivileged, "apparmor-default", profileName, -1)
+		newProfile = strings.ReplaceAll(ae.ApparmorDefaultPrivileged, "apparmor-default", profileName)
 	} else {
-		newProfile = strings.Replace(ae.ApparmorDefault, "apparmor-default", profileName, -1)
+		newProfile = strings.ReplaceAll(ae.ApparmorDefault, "apparmor-default", profileName)
 	}
 
 	newFile, err := os.Create(filepath.Clean("/etc/apparmor.d/" + profileName))

--- a/KubeArmor/enforcer/bpflsm/rulesHandling.go
+++ b/KubeArmor/enforcer/bpflsm/rulesHandling.go
@@ -484,7 +484,7 @@ func fuseProcAndFileRules(procList, fileList map[InnerKey][2]uint8) {
 	}
 }
 
-func (be *BPFEnforcer) resolveConflicts(newPosture, oldPosture bool, newRuleList, oldRuleList map[InnerKey][2]uint8, cmap *ebpf.Map) {
+func (be *BPFEnforcer) resolveConflicts(_, _ bool, newRuleList, oldRuleList map[InnerKey][2]uint8, cmap *ebpf.Map) {
 	// We delete existing elements which are not in the fresh rule set
 	for key := range oldRuleList {
 		if _, ok := newRuleList[key]; !ok {

--- a/KubeArmor/feeder/feeder.go
+++ b/KubeArmor/feeder/feeder.go
@@ -448,7 +448,7 @@ func (fd *Feeder) Print(message string) {
 }
 
 // Printf Function
-func (fd *Feeder) Printf(message string, args ...interface{}) {
+func (fd *Feeder) Printf(message string, args ...any) {
 	str := fmt.Sprintf(message, args...)
 	fd.PushMessage("INFO", str)
 	kg.Print(str)
@@ -461,7 +461,7 @@ func (fd *Feeder) Debug(message string) {
 }
 
 // Debugf Function
-func (fd *Feeder) Debugf(message string, args ...interface{}) {
+func (fd *Feeder) Debugf(message string, args ...any) {
 	str := fmt.Sprintf(message, args...)
 	fd.PushMessage("DEBUG", str)
 	kg.Debug(str)
@@ -474,7 +474,7 @@ func (fd *Feeder) Err(message string) {
 }
 
 // Errf Function
-func (fd *Feeder) Errf(message string, args ...interface{}) {
+func (fd *Feeder) Errf(message string, args ...any) {
 	str := fmt.Sprintf(message, args...)
 	fd.PushMessage("ERROR", str)
 	kg.Err(str)
@@ -487,7 +487,7 @@ func (fd *Feeder) Warn(message string) {
 }
 
 // Warnf Function
-func (fd *Feeder) Warnf(message string, args ...interface{}) {
+func (fd *Feeder) Warnf(message string, args ...any) {
 	str := fmt.Sprintf(message, args...)
 	fd.PushMessage("WARN", str)
 	kg.Warnf(str)

--- a/KubeArmor/feeder/policyMatcher.go
+++ b/KubeArmor/feeder/policyMatcher.go
@@ -192,7 +192,7 @@ func getDeviceResource(class string, subClass, protocol *int32, level *int32) st
 }
 
 // newMatchPolicy Function
-func (fd *Feeder) newMatchPolicy(policyEnabled int, policyName, src string, mp interface{}) tp.MatchPolicy {
+func (fd *Feeder) newMatchPolicy(policyEnabled int, policyName, src string, mp any) tp.MatchPolicy {
 	match := tp.MatchPolicy{
 		PolicyName: policyName,
 		Source:     src,
@@ -391,9 +391,7 @@ func (fd *Feeder) UpdateSecurityPolicies(action string, endPoint tp.EndPoint) {
 	name := endPoint.NamespaceName + "_" + endPoint.EndPointName
 
 	if action == "DELETED" {
-		if _, ok := fd.SecurityPolicies[name]; ok {
-			delete(fd.SecurityPolicies, name)
-		}
+		delete(fd.SecurityPolicies, name)
 	}
 
 	// ADDED | MODIFIED
@@ -1807,7 +1805,7 @@ func (fd *Feeder) UpdateMatchedPolicy(log tp.Log) tp.Log {
 				if (!secPolicy.IsFromSource) || (secPolicy.IsFromSource && (strings.HasPrefix(log.Source, secPolicy.Source+" ") || secPolicy.Source == log.ProcessName)) {
 					skip := false
 
-					for _, matchCapability := range strings.Split(secPolicy.Resource, ",") {
+					for matchCapability := range strings.SplitSeq(secPolicy.Resource, ",") {
 						if skip {
 							break
 						}

--- a/KubeArmor/kvmAgent/kvmAgent.go
+++ b/KubeArmor/kvmAgent/kvmAgent.go
@@ -12,13 +12,13 @@ import (
 	"net"
 	"os"
 	"strings"
-	"time"
 
 	kg "github.com/kubearmor/KubeArmor/KubeArmor/log"
 	tp "github.com/kubearmor/KubeArmor/KubeArmor/types"
 
 	pb "github.com/kubearmor/KubeArmor/protobuf"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/metadata"
 )
 
@@ -59,8 +59,7 @@ func NewKVMAgent(eventCb tp.KubeArmorHostPolicyEventCallback) *KVMAgent {
 	kvm.gRPCServer = gRPCServer
 
 	// Connect to gRPC server
-	ctx, _ := context.WithTimeout(context.Background(), time.Second*5)
-	gRPCConnection, err := grpc.DialContext(ctx, kvm.gRPCServer, grpc.WithInsecure(), grpc.WithBlock())
+	gRPCConnection, err := grpc.NewClient(kvm.gRPCServer, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		kg.Errf("Not accessible to gRPC server (%s)", err.Error())
 		return nil
@@ -106,8 +105,7 @@ func (kvm *KVMAgent) ConnectToKVMService() {
 			}
 
 			// connect to gRPC server again
-			ctx, _ := context.WithTimeout(context.Background(), time.Second*5)
-			gRPCConnection, err := grpc.DialContext(ctx, kvm.gRPCServer, grpc.WithInsecure(), grpc.WithBlock())
+			gRPCConnection, err := grpc.NewClient(kvm.gRPCServer, grpc.WithTransportCredentials(insecure.NewCredentials()))
 			if err != nil {
 				kg.Errf("Not accessible to gRPC server (%s)", err.Error())
 				return
@@ -144,8 +142,7 @@ func (kvm *KVMAgent) ConnectToKVMService() {
 				}
 
 				// connect to gRPC server again
-				ctx, _ := context.WithTimeout(context.Background(), time.Second*5)
-				gRPCConnection, err := grpc.DialContext(ctx, kvm.gRPCServer, grpc.WithInsecure(), grpc.WithBlock())
+				gRPCConnection, err := grpc.NewClient(kvm.gRPCServer, grpc.WithTransportCredentials(insecure.NewCredentials()))
 				if err != nil {
 					kg.Errf("Not accessible to gRPC server (%s)", err.Error())
 					return

--- a/KubeArmor/log/logger.go
+++ b/KubeArmor/log/logger.go
@@ -84,7 +84,7 @@ func Print(message string) {
 }
 
 // Printf Function
-func Printf(message string, args ...interface{}) {
+func Printf(message string, args ...any) {
 	zapLogger.Infof(message, args...)
 }
 
@@ -94,7 +94,7 @@ func Debug(message string) {
 }
 
 // Debugf Function
-func Debugf(message string, args ...interface{}) {
+func Debugf(message string, args ...any) {
 	zapLogger.Debugf(message, args...)
 }
 
@@ -104,7 +104,7 @@ func Err(message string) {
 }
 
 // Errf Function
-func Errf(message string, args ...interface{}) {
+func Errf(message string, args ...any) {
 	zapLogger.Errorf(message, args...)
 }
 
@@ -114,6 +114,6 @@ func Warn(message string) {
 }
 
 // Warnf Function
-func Warnf(message string, args ...interface{}) {
+func Warnf(message string, args ...any) {
 	zapLogger.Warnf(message, args...)
 }

--- a/KubeArmor/monitor/syscallParser.go
+++ b/KubeArmor/monitor/syscallParser.go
@@ -1026,9 +1026,9 @@ func readArgTypeFromBuff(buff io.Reader) (uint8, error) {
 }
 
 // readArgFromBuff Function
-func readArgFromBuff(dataBuff io.Reader) (interface{}, error) {
+func readArgFromBuff(dataBuff io.Reader) (any, error) {
 	var err error
-	var res interface{}
+	var res any
 
 	at, err := readArgTypeFromBuff(dataBuff)
 	if err != nil {
@@ -1184,8 +1184,8 @@ func GetHashes(dataBuff *bytes.Buffer) (HashContext, error) {
 }
 
 // GetArgs Function
-func GetArgs(dataBuff *bytes.Buffer, Argnum int32) ([]interface{}, error) {
-	args := []interface{}{}
+func GetArgs(dataBuff *bytes.Buffer, Argnum int32) ([]any, error) {
+	args := []any{}
 
 	for i := 0; i < int(Argnum); i++ {
 		arg, err := readArgFromBuff(dataBuff)

--- a/KubeArmor/monitor/systemMonitor.go
+++ b/KubeArmor/monitor/systemMonitor.go
@@ -107,7 +107,7 @@ type ContextCombined struct {
 	ContainerID string
 	ContextSys  SyscallContext
 	HashData    HashContext
-	ContextArgs []interface{}
+	ContextArgs []any
 }
 
 // ======================= //
@@ -578,17 +578,20 @@ func (mon *SystemMonitor) InitBPF() error {
 		mon.Probes["kprobe__udp_sendmsg"], err = link.Kprobe("udp_sendmsg", mon.BpfModule.Programs["kprobe__udp_sendmsg"], nil)
 		if err != nil {
 			mon.Logger.Warnf("error loading kprobe udp_sendmsg %v", err)
+			delete(mon.Probes, "kprobe__udp_sendmsg")
 		}
 
 		for _, syscallName := range systemCalls {
 			mon.Probes["kprobe__"+syscallName], err = link.Kprobe("sys_"+syscallName, mon.BpfModule.Programs["kprobe__"+syscallName], nil)
 			if err != nil {
 				mon.Logger.Warnf("error loading kprobe %s: %v", syscallName, err)
+				delete(mon.Probes, "kprobe__"+syscallName)
 			}
 
 			mon.Probes["kretprobe__"+syscallName], err = link.Kretprobe("sys_"+syscallName, mon.BpfModule.Programs["kretprobe__"+syscallName], nil)
 			if err != nil {
 				mon.Logger.Warnf("error loading kretprobe %s: %v", syscallName, err)
+				delete(mon.Probes, "kretprobe__"+syscallName)
 			}
 
 		}
@@ -597,6 +600,7 @@ func (mon *SystemMonitor) InitBPF() error {
 			mon.Probes[sysTracepoint[1]], err = link.Tracepoint(sysTracepoint[0], sysTracepoint[1], mon.BpfModule.Programs[sysTracepoint[1]], nil)
 			if err != nil {
 				mon.Logger.Warnf("error:%s: %v", sysTracepoint, err)
+				delete(mon.Probes, sysTracepoint[1])
 			}
 		}
 
@@ -604,6 +608,7 @@ func (mon *SystemMonitor) InitBPF() error {
 			mon.Probes["kprobe__"+sysKprobe], err = link.Kprobe(sysKprobe, mon.BpfModule.Programs["kprobe__"+sysKprobe], nil)
 			if err != nil {
 				mon.Logger.Warnf("error loading kprobe %s: %v", sysKprobe, err)
+				delete(mon.Probes, "kprobe__"+sysKprobe)
 			}
 		}
 
@@ -611,6 +616,7 @@ func (mon *SystemMonitor) InitBPF() error {
 			mon.Probes["kprobe__"+netSyscall], err = link.Kprobe(netSyscall, mon.BpfModule.Programs["kprobe__"+netSyscall], nil)
 			if err != nil {
 				mon.Logger.Warnf("error loading kprobe %s: %v", netSyscall, err)
+				delete(mon.Probes, "kprobe__"+netSyscall)
 			}
 		}
 
@@ -618,6 +624,7 @@ func (mon *SystemMonitor) InitBPF() error {
 			mon.Probes["kretprobe__"+netRetSyscall], err = link.Kretprobe(netRetSyscall, mon.BpfModule.Programs["kretprobe__"+netRetSyscall], nil)
 			if err != nil {
 				mon.Logger.Warnf("error loading kretprobe %s: %v", netRetSyscall, err)
+				delete(mon.Probes, "kretprobe__"+netRetSyscall)
 			}
 		}
 
@@ -788,7 +795,7 @@ func (mon *SystemMonitor) TraceSyscall() {
 
 			// Best effort replay
 			go func() {
-				for i := 0; i < 10; i++ {
+				for range 10 {
 					containerID := ""
 
 					if ctx.PidID != 0 && ctx.MntID != 0 {

--- a/deployments/main.go
+++ b/deployments/main.go
@@ -28,7 +28,7 @@ func main() {
 	var namespace = *nsPtr
 
 	for _, env := range envs {
-		v := []interface{}{
+		v := []any{
 			// ServiceAccounts
 			dp.GetServiceAccount(namespace),
 			dp.GetRelayServiceAccount(namespace),
@@ -88,7 +88,7 @@ func main() {
 
 }
 
-func writeToYAML(f *os.File, o interface{}) error {
+func writeToYAML(f *os.File, o any) error {
 	// Use "clarketm/json" to marshal so as to support zero values of structs with omitempty
 	j, err := json.Marshal(o)
 	if err != nil {

--- a/pkg/KubeArmorOperator/hook/crio.go
+++ b/pkg/KubeArmorOperator/hook/crio.go
@@ -28,7 +28,7 @@ type crioHandler struct {
 }
 
 func newCRIOHandler(socket string) (handler, error) {
-	conn, err := grpc.Dial(
+	conn, err := grpc.NewClient(
 		socket,
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
 	)

--- a/pkg/KubeArmorOperator/internal/controller/cluster.go
+++ b/pkg/KubeArmorOperator/internal/controller/cluster.go
@@ -244,7 +244,7 @@ func (clusterWatcher *ClusterWatcher) WatchNodes() {
 	log := clusterWatcher.Log
 	nodeInformer := informer.Core().V1().Nodes().Informer()
 	nodeInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}) {
+		AddFunc: func(obj any) {
 			if node, ok := obj.(*corev1.Node); ok {
 				runtime := node.Status.NodeInfo.ContainerRuntimeVersion
 				runtime = strings.Split(runtime, ":")[0]
@@ -260,7 +260,7 @@ func (clusterWatcher *ClusterWatcher) WatchNodes() {
 				}
 			}
 		},
-		UpdateFunc: func(oldObj, newObj interface{}) {
+		UpdateFunc: func(oldObj, newObj any) {
 
 			if node, ok := newObj.(*corev1.Node); ok {
 				oldRand := ""
@@ -350,7 +350,7 @@ func (clusterWatcher *ClusterWatcher) WatchNodes() {
 				log.Error(newObj)
 			}
 		},
-		DeleteFunc: func(obj interface{}) {
+		DeleteFunc: func(obj any) {
 			if node, ok := obj.(*corev1.Node); ok {
 				deletedNode := Node{}
 				clusterWatcher.NodesLock.Lock()
@@ -432,7 +432,7 @@ func (clusterWatcher *ClusterWatcher) WatchConfigCrd() {
 
 	informer.AddEventHandler(
 		cache.ResourceEventHandlerFuncs{
-			AddFunc: func(obj interface{}) {
+			AddFunc: func(obj any) {
 				configCrdList, err := clusterWatcher.Opv1Client.OperatorV1().KubeArmorConfigs(common.Namespace).List(context.Background(), metav1.ListOptions{})
 				if err != nil {
 					clusterWatcher.Log.Warn("Failed to list Operator Config CRs")
@@ -476,7 +476,7 @@ func (clusterWatcher *ClusterWatcher) WatchConfigCrd() {
 
 				}
 			},
-			UpdateFunc: func(oldObj, newObj interface{}) {
+			UpdateFunc: func(oldObj, newObj any) {
 				if cfg, ok := newObj.(*opv1.KubeArmorConfig); ok {
 					// update configmap only if it's operating crd
 					if common.OperatorConfigCrd != nil && cfg.Name == common.OperatorConfigCrd.Name {
@@ -520,7 +520,7 @@ func (clusterWatcher *ClusterWatcher) WatchConfigCrd() {
 					}
 				}
 			},
-			DeleteFunc: func(obj interface{}) {
+			DeleteFunc: func(obj any) {
 				if cfg, ok := obj.(*opv1.KubeArmorConfig); ok {
 					if common.OperatorConfigCrd != nil && cfg.Name == common.OperatorConfigCrd.Name {
 						common.OperatorConfigCrd = nil

--- a/pkg/KubeArmorOperator/internal/controller/resources.go
+++ b/pkg/KubeArmorOperator/internal/controller/resources.go
@@ -206,7 +206,7 @@ func genEnforcerVolumes(enforcer string) (vol []corev1.Volume, volMnt []corev1.V
 	if enforcer == "none" {
 		return nil, nil
 	}
-	for _, e := range strings.Split(enforcer, ".") {
+	for e := range strings.SplitSeq(enforcer, ".") {
 		vol = append(vol, common.EnforcerVolumes[e]...)
 		volMnt = append(volMnt, common.EnforcerVolumesMounts[e]...)
 	}

--- a/tests/util/kartutil.go
+++ b/tests/util/kartutil.go
@@ -230,7 +230,7 @@ func K8sDeploymentCheck(depname string, ns string, timeout time.Duration) error 
 }
 
 func AnnotationsMatch(pod corev1.Pod, ants []string) bool {
-	if ants == nil || len(ants) <= 0 {
+	if len(ants) <= 0 {
 		return true
 	}
 	for _, ant := range ants {
@@ -397,8 +397,7 @@ func KspDeleteAll() {
 	if err != nil {
 		return
 	}
-	lines := strings.Split(sout, "\n")
-	for _, line := range lines {
+	for line := range strings.SplitSeq(sout, "\n") {
 		if line == "" {
 			continue
 		}
@@ -493,9 +492,8 @@ func K8sApplyFile(fileName string) error {
 
 	// multiple yaml files seperate by ---
 	fileAsString := string(f[:])
-	sepYamlfiles := strings.Split(fileAsString, "---")
 
-	for _, f := range sepYamlfiles {
+	for f := range strings.SplitSeq(fileAsString, "---") {
 		if f == "\n" || f == "" {
 			// ignore empty cases
 			continue

--- a/wiki/runtime_enforcer.md
+++ b/wiki/runtime_enforcer.md
@@ -193,7 +193,7 @@ func (se *SELinuxEnforcer) UpdateSELinuxLabels(profilePath string) bool {
 
 	res := true
 	// Iterate through rules from the profile file
-	for _, line := range strings.Split(string(profile), "\n") {
+	for line := range strings.SplitSeq(string(profile), "\n") {
 		words := strings.Fields(line)
 		if len(words) != 7 { continue }
 


### PR DESCRIPTION
changes:
- replace `strings.Split` with `strings.SplitSeq` when iterating over the sequence.
- use `grpc.WithTransportCredentials(insecure.NewCredentials())` instead of the deprecated `grpc.WithInsecure()`.
- prefer the use of `any` over `interface{}`.
- prefer the use of switch-case over if-else-if.
- use `slices.Sort` instead of `sort.Slice`.
- use `maps.Copy` instead of `m[k] = v` over all k.
- use `for range int` instead of C-style loop.

specific changes in `KubeArmor/core/kubeUpdate.go`:
- convert posture to lowercase instead of checking multiple cases in `validateDefaultPosture`.
- change unused variable `action` to `_` in `updateVisibilityWithCM`.

**Purpose of PR?**:

Fixes golang warnings.

**Does this PR introduce a breaking change?**

No.

**If the changes in this PR are manually verified, list down the scenarios covered:**:

**Additional information for reviewer?** :
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [ ] Bug fix. Fixes #<issue number>
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [X] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Commit has unit tests
- [ ] Commit has integration tests

<!--

The PR title message must follow convention:
`<type>(<scope>): <subject>`.

Where: <br />
- `type` is to define what type of PR is this.
  Most common types are:
    - `feat`      - for new features, not a new feature for build script
    - `fix`       - for bug fixes or improvements, not a fix for build script
    - `chore`     - changes not related to production code
    - `docs`      - changes related to documentation
    - `style`     - formatting, missing semi colons, linting fix etc; no significant production code changes
    - `test`      - adding missing tests, refactoring tests; no production code change
    - `refactor`  - refactoring production code, eg. renaming a variable or function name, there should not be any significant production code changes

- `scope` is a single word that best describes where the changes fit.
    - feature(`monitor`,`enforcer`)
    - test(`tests`, `bdd`)
    - chore(`build`)
- `subject` is a single line brief description of the changes made in the pull request.

-->