### PR TITLE
fix(images): add docker.io prefix to repository for CRI-O 1.34 compatibility

### DIFF
--- a/deployments/helm/KubeArmorOperator/values.yaml
+++ b/deployments/helm/KubeArmorOperator/values.yaml
@@ -33,7 +33,7 @@ kubearmorOperator:
   annotateExisting: false
   name: kubearmor-operator
   image:
-    repository: kubearmor/kubearmor-operator
+    repository: docker.io/kubearmor/kubearmor-operator
     tag: ""
     # Optional, but if there are a lot of image pulls required, Docker might be rate-limited. So, it's good to add pull secrets for production.
     imagePullSecrets: []

--- a/pkg/KubeArmorOperator/common/defaults.go
+++ b/pkg/KubeArmorOperator/common/defaults.go
@@ -72,7 +72,7 @@ var (
 	Privileged              bool   = false
 	HostPID                 bool   = false
 	SnitchName              string = "kubearmor-snitch"
-	SnitchImage             string = "kubearmor/kubearmor-snitch"
+	SnitchImage             string = "docker.io/kubearmor/kubearmor-snitch"
 	SnitchImageTag          string = "latest"
 	KubeArmorSnitchRoleName string = "kubearmor-snitch"
 
@@ -112,7 +112,7 @@ var (
 		"-procfsMount=/host/procfs",
 		"-tlsEnabled=false",
 	}
-	KubeArmorImage            string                        = "kubearmor/kubearmor:stable"
+	KubeArmorImage            string                        = "docker.io/kubearmor/kubearmor:stable"
 	KubeArmorImagePullPolicy  string                        = "Always"
 	KubeArmorImagePullSecrets []corev1.LocalObjectReference = []corev1.LocalObjectReference{}
 	KubeArmorTolerations      []corev1.Toleration           = []corev1.Toleration{}
@@ -121,7 +121,7 @@ var (
 
 	KubeArmorInitName             string                        = "kubearmor-init"
 	KubeArmorInitArgs             []string                      = []string{}
-	KubeArmorInitImage            string                        = "kubearmor/kubearmor-init:stable"
+	KubeArmorInitImage            string                        = "docker.io/kubearmor/kubearmor-init:stable"
 	KubeArmorInitImagePullPolicy  string                        = "Always"
 	KubeArmorInitImagePullSecrets []corev1.LocalObjectReference = []corev1.LocalObjectReference{}
 	KubeArmorInitTolerations      []corev1.Toleration           = []corev1.Toleration{}
@@ -131,7 +131,7 @@ var (
 	KubeArmorRelayArgs []string = []string{
 		"-tlsEnabled=false",
 	}
-	KubeArmorRelayImage            string                        = "kubearmor/kubearmor-relay-server:latest"
+	KubeArmorRelayImage            string                        = "docker.io/kubearmor/kubearmor-relay-server:latest"
 	KubeArmorRelayImagePullPolicy  string                        = "Always"
 	KubeArmorRelayImagePullSecrets []corev1.LocalObjectReference = []corev1.LocalObjectReference{}
 	KubeArmorRelayTolerations      []corev1.Toleration           = []corev1.Toleration{}
@@ -144,7 +144,7 @@ var (
 		"--health-probe-bind-address=:8081",
 		"--annotateExisting=false",
 	}
-	KubeArmorControllerImage              string                        = "kubearmor/kubearmor-controller:latest"
+	KubeArmorControllerImage              string                        = "docker.io/kubearmor/kubearmor-controller:latest"
 	KubeArmorControllerImagePullPolicy    string                        = "Always"
 	KubeArmorControllerImagePullSecrets   []corev1.LocalObjectReference = []corev1.LocalObjectReference{}
 	KubeArmorControllerTolerations        []corev1.Toleration           = []corev1.Toleration{}


### PR DESCRIPTION
🧩 Purpose of PR
Add the docker.io/ prefix to image repository references to ensure compatibility with CRI-O v1.34, which now requires fully qualified image names.

🪲 Fixes
N/A — preventive compatibility fix.

💥 Breaking Change
No — this is a non-breaking update.

✅ Manual Verification
Verified successful deployment on CRI-O v1.34.
Verified backward compatibility with previous CRI-O versions.

ℹ️ Additional Information
This change ensures that CRI-O can correctly resolve image references that previously failed without an explicit registry prefix.

Not part of any previous PR — this is a standalone compatibility improvement.

🧾 Checklist
 Bug fix (non-breaking change which fixes an issue)
 PR title follows convention <type>(<scope>): <subject>