### PR TITLE
fix(presets): update action field with preset alerts

### DIFF
--- a/KubeArmor/presets/anonmapexec/preset.go
+++ b/KubeArmor/presets/anonmapexec/preset.go
@@ -228,8 +228,10 @@ func (p *Preset) TraceEvents() {
 		log.Operation = "File"
 		if event.Retval >= 0 {
 			log.Result = "Passed"
+			log.Action = "Audit"
 		} else {
 			log.Result = "Permission denied"
+			log.Action = "Block"
 		}
 		log.Enforcer = base.PRESET_ENFORCER + NAME
 		log.KubeArmorVersion = buildinfo.GitSummary

--- a/KubeArmor/presets/exec/preset.go
+++ b/KubeArmor/presets/exec/preset.go
@@ -213,8 +213,10 @@ func (p *Preset) TraceEvents() {
 
 		if event.Retval >= 0 {
 			log.Result = "Passed"
+			log.Action = "Audit"
 		} else {
 			log.Result = "Permission denied"
+			log.Action = "Block"
 		}
 
 		log.Enforcer = base.PRESET_ENFORCER + NAME

--- a/KubeArmor/presets/filelessexec/preset.go
+++ b/KubeArmor/presets/filelessexec/preset.go
@@ -213,8 +213,10 @@ func (p *Preset) TraceEvents() {
 
 		if event.Retval >= 0 {
 			log.Result = "Passed"
+			log.Action = "Audit"
 		} else {
 			log.Result = "Permission denied"
+			log.Action = "Block"
 		}
 
 		log.Enforcer = base.PRESET_ENFORCER + NAME

--- a/KubeArmor/presets/protectenv/preset.go
+++ b/KubeArmor/presets/protectenv/preset.go
@@ -215,7 +215,9 @@ func (p *Preset) TraceEvents() {
 
 		if event.Retval >= 0 {
 			log.Result = "Passed"
+			log.Action = "Audit"
 		} else {
+			log.Action = "Block"
 			log.Result = "Permission denied"
 		}
 

--- a/KubeArmor/presets/protectproc/preset.go
+++ b/KubeArmor/presets/protectproc/preset.go
@@ -208,7 +208,9 @@ func (p *Preset) TraceEvents() {
 
 		if event.Retval >= 0 {
 			log.Result = "Passed"
+			log.Action = "Audit"
 		} else {
+			log.Action = "Block"
 			log.Result = "Permission denied"
 		}
 


### PR DESCRIPTION
**Purpose of PR?**:
the preset alerts missing action field
```json
{
  "Timestamp": 1761807426,
  "UpdatedTime": "2025-10-30T06:57:06.827732Z",
  "ClusterName": "default",
  "HostName": "kubearmor-dev-next",
  "NamespaceName": "default",
  "Owner": {
    "Ref": "Deployment",
    "Name": "nginx",
    "Namespace": "default"
  },
  "PodName": "nginx-6fdb9f946-j6psz",
  "Labels": "app=nginx",
  "ContainerID": "14508a9259223d2ad5f782966abecefb21408250469bcd3937c3f78c22fd4bbd",
  "ContainerName": "nginx",
  "ContainerImage": "docker.io/library/nginx:latest@sha256:f547e3d0d5d02f7009737b284abc87d808e4252b42dceea361811e9fc606287f",
  "HostPPID": 12659,
  "HostPID": 12729,
  "PPID": 12659,
  "PID": 60,
  "UID": 0,
  "ParentProcessName": "/usr/bin/bash",
  "ProcessName": "/usr/bin/cat",
  "PolicyName": "preset-proc-env",
  "Type": "MatchedPolicy",
  "Source": "/usr/bin/cat /proc/1/environ",
  "Operation": "File",
  "Resource": "/usr/bin/cat",
  "Enforcer": "PRESET-ProtectEnvPreset",
  "Result": "Permission denied",
  "Cwd": "/",
  "TTY": "pts0",
  "ExecEvent": {
    "ExecID": "54671679010686",
    "ExecutableName": "cat"
  },
  "KubeArmorVersion": "v1.6.3-dirty"
}
```
this PR handles it updating all presets to update the action.
```json
{
  "Timestamp": 1761807866,
  "UpdatedTime": "2025-10-30T07:04:26.322831Z",
  "ClusterName": "default",
  "HostName": "kubearmor-dev-next",
  "NamespaceName": "default",
  "Owner": {
    "Ref": "Deployment",
    "Name": "nginx",
    "Namespace": "default"
  },
  "PodName": "nginx-6fdb9f946-j6psz",
  "Labels": "app=nginx",
  "ContainerID": "14508a9259223d2ad5f782966abecefb21408250469bcd3937c3f78c22fd4bbd",
  "ContainerName": "nginx",
  "ContainerImage": "docker.io/library/nginx:latest@sha256:f547e3d0d5d02f7009737b284abc87d808e4252b42dceea361811e9fc606287f",
  "HostPPID": 12659,
  "HostPID": 14374,
  "PPID": 12659,
  "PID": 61,
  "UID": 0,
  "PolicyName": "preset-proc-env",
  "Type": "MatchedPolicy",
  "Source": "/usr/bin/cat",
  "Operation": "File",
  "Resource": "/usr/bin/cat",
  "Enforcer": "PRESET-ProtectEnvPreset",
  "Action": "Block",
  "Result": "Permission denied",
  "Cwd": "/",
  "TTY": "pts0",
  "ExecEvent": {
    "ExecID": "0",
    "ExecutableName": "cat"
  },
  "KubeArmorVersion": "v1.5.7-199-g292bdb94-dirty"
}
``` 

**Does this PR introduce a breaking change?**

**If the changes in this PR are manually verified, list down the scenarios covered:**:

**Additional information for reviewer?** :
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [ ] Bug fix. Fixes #<issue number>
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Commit has unit tests
- [ ] Commit has integration tests

<!--

The PR title message must follow convention:
`<type>(<scope>): <subject>`.

Where: <br />
- `type` is to define what type of PR is this.
  Most common types are:
    - `feat`      - for new features, not a new feature for build script
    - `fix`       - for bug fixes or improvements, not a fix for build script
    - `chore`     - changes not related to production code
    - `docs`      - changes related to documentation
    - `style`     - formatting, missing semi colons, linting fix etc; no significant production code changes
    - `test`      - adding missing tests, refactoring tests; no production code change
    - `refactor`  - refactoring production code, eg. renaming a variable or function name, there should not be any significant production code changes

- `scope` is a single word that best describes where the changes fit.
    - feature(`monitor`,`enforcer`)
    - test(`tests`, `bdd`)
    - chore(`build`)
- `subject` is a single line brief description of the changes made in the pull request.

-->