### PR TITLE
fix(monitor): fix system monitor compilation on rhel kernels

### DIFF
--- a/KubeArmor/BPF/Makefile.vars
+++ b/KubeArmor/BPF/Makefile.vars
@@ -72,6 +72,26 @@ else
 	 	 	-include $(KRNDIR)/include/linux/kconfig.h
 endif
 
+# rhel build version
+RHEL_BUILD := $(shell echo "$(UNAME_R)" | sed -nE 's/.*-([0-9]+)\..*\.el[0-9]+(_[0-9]+)?\..*/\1/p')
+
+# rhel build version -ge 400
+RHEL_BUILD_GTE_400 := 0
+
+ifneq ($(strip $(RHEL_BUILD)),)
+$(info RHEL compatible kernel, build: $(RHEL_BUILD))
+    RHEL_BUILD_GTE_400 := $(shell [ $(RHEL_BUILD) -ge 400 ] && echo 1 || echo 0)
+    ifeq ($(RHEL_BUILD_GTE_400),1)
+        $(info RHEL build is greater or equal to 400)
+    else
+        $(info RHEL build is less than 400)
+    endif
+
+    INC_F += -DRHEL_BUILD_GTE_400
+else
+    $(info Non-RHEL kernel, skipping RHEL-specific logic)
+endif
+
 KF = $(INC_F) -I$(LIBBPF)/src \
 	 -DLINUX_VERSION_MAJOR=$(KRNV_X) \
 	 -DLINUX_VERSION_PATCHLEVEL=$(KRNV_Y) \

--- a/KubeArmor/BPF/system_monitor.c
+++ b/KubeArmor/BPF/system_monitor.c
@@ -2426,7 +2426,7 @@ int kprobe__udp_sendmsg(struct pt_regs *ctx)
     dport = ntohs(dport);
     if (dport != 53)
         return 0;
-    #if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 3, 13)
+    #if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 3, 13) || RHEL_BUILD_GTE_400
         bpf_probe_read(&iov, sizeof(iov), &msg->msg_iter.__iov);
     #else
         bpf_probe_read(&iov, sizeof(iov), &msg->msg_iter.iov);


### PR DESCRIPTION
**Purpose of PR?**:
the following structure that has been restructured in kernel version 6.3.13 and require conditional handling is being backported in rhel (and rhel-based distros) `5.14.0-400.*` build version, so it will fail to load on respective rhel kernel versions.

https://github.com/kubearmor/KubeArmor/blob/46455070d261da02bf8c6fb1d2b17df364b76a17/KubeArmor/BPF/system_monitor.c#L2429-L2433

this PR handles it by adding an additional compilation flag `RHEL_BUILD_GTE_400` that check if the distro is rhel based distro i.e. `5.14.0-570.58.1.el9_6.x86_64` and if the build i.e. `570` in this case is greater than or equal to `400`. and conditionally compile the system monitor accordingly.

**Does this PR introduce a breaking change?**
No
**If the changes in this PR are manually verified, list down the scenarios covered:**:

**Additional information for reviewer?** :
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [x] Bug fix.
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Commit has unit tests
- [ ] Commit has integration tests

<!--

The PR title message must follow convention:
`<type>(<scope>): <subject>`.

Where: <br />
- `type` is to define what type of PR is this.
  Most common types are:
    - `feat`      - for new features, not a new feature for build script
    - `fix`       - for bug fixes or improvements, not a fix for build script
    - `chore`     - changes not related to production code
    - `docs`      - changes related to documentation
    - `style`     - formatting, missing semi colons, linting fix etc; no significant production code changes
    - `test`      - adding missing tests, refactoring tests; no production code change
    - `refactor`  - refactoring production code, eg. renaming a variable or function name, there should not be any significant production code changes

- `scope` is a single word that best describes where the changes fit.
    - feature(`monitor`,`enforcer`)
    - test(`tests`, `bdd`)
    - chore(`build`)
- `subject` is a single line brief description of the changes made in the pull request.

-->