### PR TITLE
test(ci): improve systemd test workflow to support code coverage

### DIFF
--- a/.github/workflows/ci-test-systemd.yml
+++ b/.github/workflows/ci-test-systemd.yml
@@ -38,33 +38,88 @@ jobs:
       - name: Compile libbpf
         run: ./.github/workflows/install-libbpf.sh
 
-      - name: Install GoReleaser
-        uses: goreleaser/goreleaser-action@v2
-        with:
-          install-only: true
-          version: v1.25.0
-
       - name: Install protoc
         run: |
+          sudo apt-get update
+          sudo apt-get install -y protobuf-compiler
           go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
           go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
-    
-      - name: Build Systemd Release
-        run: make local-release
-        working-directory: KubeArmor
 
-      - name: Install KubeArmor
-        run: sudo apt install -y ./dist/kubearmor*amd64.deb
+      - name: Build Coverage Test Binary
         working-directory: KubeArmor
+        run: make build-coverage
 
-      - name: Check journalctl
-        run: sudo journalctl -u kubearmor --no-pager
-      
-      - name: Test kubearmor using ginkgo 
+      - name: Run KubeArmor
+        working-directory: KubeArmor
+        run: |
+          REPO_ROOT="$(pwd)"
+          CONFIG_PATH="$REPO_ROOT/packaging/kubearmor.yaml"
+
+          echo "Using config: $CONFIG_PATH"
+          test -f "$CONFIG_PATH" && echo "Config file found" || (echo "Config file NOT found!" && exit 1)
+
+          sudo env KUBEARMOR_CFG="$CONFIG_PATH" \
+              ./kubearmor \
+              -logPath=/tmp/kubearmor.log \
+              -test.coverprofile=systemd_coverage.out \
+              > /tmp/kubearmor.out 2>&1 &
+
+          echo $! > kubearmor.pid
+          echo "KubeArmor PID: $(cat kubearmor.pid)"
+
+          sleep 15
+
+      - name: Test KubeArmor using Ginkgo
+        working-directory: ./tests/nonk8s_env
         run: |
           go install -mod=mod github.com/onsi/ginkgo/v2/ginkgo
           make
-        working-directory: ./tests/nonk8s_env
         timeout-minutes: 30
-        
-      
+
+      - name: Stop KubeArmor
+        working-directory: KubeArmor
+        if: always()
+        run: |
+          echo "KubeArmor Process:"
+          ps aux | grep kubearmor
+
+          sudo pkill kubearmor
+
+          for i in {1..30}; do
+            if [ ! -f kubearmor.pid ]; then break; fi
+            if ! ps -p $(cat kubearmor.pid) > /dev/null; then break; fi
+            sleep 1
+          done
+          rm -f kubearmor.pid || true
+
+      - name: Measure code coverage
+        working-directory: KubeArmor
+        if: always()
+        run: |
+          ls -l .
+          for i in {1..5}; do
+            if [ -f systemd_coverage.out ]; then
+              go tool cover -func systemd_coverage.out
+              break
+            fi
+            echo "systemd_coverage.out not found yet, retrying ($i/5)..."
+            sleep 5
+          done
+
+      - name: Archive log artifacts
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: runtime_logs
+          path: |
+            /tmp/kubearmor.*
+          if-no-files-found: ignore
+
+      - name: Upload Coverage
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage_reports
+          path: |
+            KubeArmor/systemd_coverage.out
+          if-no-files-found: ignore

--- a/KubeArmor/Makefile
+++ b/KubeArmor/Makefile
@@ -35,6 +35,23 @@ endif
 endif
 	cd $(CURDIR); CGO_ENABLED=0 go build -ldflags "$(GIT_INFO)" -o kubearmor main.go
 
+.PHONY: build-coverage
+build-coverage: protobuf
+	cd $(CURDIR); go mod tidy
+ifneq (, $(shell which bpftool))
+ifneq (, $(wildcard /sys/kernel/btf/vmlinux))
+	cd $(CURDIR); bpftool btf dump file /sys/kernel/btf/vmlinux format c > BPF/vmlinux.h || true
+endif
+ifneq (, $(shell which llvm-strip))
+	if grep -q bpf '/sys/kernel/security/lsm'; then \
+		cd $(CURDIR); go generate ./... || true; \
+	fi
+endif
+endif
+	cd $(CURDIR); CGO_ENABLED=0 go test -covermode=atomic -coverpkg=./... -c . -ldflags "$(GIT_INFO)" -o kubearmor
+	cd $(CURDIR)/BPF; make clean
+	cd $(CURDIR)/BPF; make
+
 .PHONY: protobuf
 protobuf:
 	cd $(CURDIR); make -C ../protobuf


### PR DESCRIPTION
**Purpose of PR?**:
Enable complete code coverage metrics collection for KubeArmor systemd mode in CI
The workflow now generates a coverage profile from the running binary and uploads the coverage file
Fixed flaky behavior of Systemd CI 
 
**Does this PR introduce a breaking change?**
No

**If the changes in this PR are manually verified, list down the scenarios covered:**
- [Before](https://github.com/kubearmor/KubeArmor/actions/runs/19324207028/job/55271498123)
The previous workflow built a Debian package using GoReleaser, installed it through apt, and executed the tests against the installed systemd service. It did not build a coverage-enabled binary, did not run KubeArmor directly as a test binary, did not collect runtime coverage metrics, and did not archive coverage or runtime logs as artifacts.

- [After](https://github.com/GAURAV-DEEP01/KubeArmor/actions/runs/19422958207/job/55563873097)
The CI workflow now builds a coverage enabled binary through a new build-coverage Makefile target, it now runs KubeArmor as a test binary instead of building and installing the Debian package. The workflow starts the binary directly with a custom configuration, runs the non_K8s tests against it, collects coverage metrics, and uploads logs and coverage artifacts

<img width="700" height="300" alt="image" src="https://github.com/user-attachments/assets/b4092d18-6706-4e37-8556-a2cb62efab24" />

**Tested the CI 4 Times to observer any flaky behaviour**
- [Attempt 1](https://github.com/GAURAV-DEEP01/KubeArmor/actions/runs/19632558564/job/56215536790)
- [Attempt 2](https://github.com/GAURAV-DEEP01/KubeArmor/actions/runs/19632598790/job/56215666332)
- [Attempt 3](https://github.com/GAURAV-DEEP01/KubeArmor/actions/runs/19632719404/job/56216056100)
- [Attempt 4](https://github.com/GAURAV-DEEP01/KubeArmor/actions/runs/19632806165/job/56216334541)
All CI passed and no flaky behavior was observed

**Checklist:**
- [ ] Bug fix. Fixes #<issue number>
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Commit has unit tests
- [ ] Commit has integration tests