### PR TITLE
fix(controller): AppArmor enforcement not working when KubeArmor is deployed in namespaces other than kubearmor

### DIFF
--- a/pkg/KubeArmorController/common/common.go
+++ b/pkg/KubeArmorController/common/common.go
@@ -134,7 +134,7 @@ func RemoveApparmorAnnotation(pod *corev1.Pod) {
 }
 
 func CheckKubearmorStatus(nodeName string, c *kubernetes.Clientset) (bool, error) {
-	pods, err := c.CoreV1().Pods("kubearmor").List(context.TODO(), metav1.ListOptions{
+	pods, err := c.CoreV1().Pods("").List(context.TODO(), metav1.ListOptions{
 		LabelSelector: "kubearmor-app=kubearmor",
 	})
 	if err != nil {


### PR DESCRIPTION
**Purpose of PR?**:

AppArmor policy enforcement was not working when KubeArmor was deployed (by the operator) in any namespace other than `kubearmor`.
The root cause was in the KubeArmor controller logic used to detect which nodes are running KubeArmor. This detection relied on listing pods with the label `kubearmor-app=kubearmor`, but the controller was hardcoded to look only in the `kubearmor` namespace. 
https://github.com/kubearmor/KubeArmor/blob/0f5c973f840bc8c1171cabb4a403b0cb0f7e35a9/pkg/KubeArmorController/common/common.go#L137
As a result, the controller failed to identify running KubeArmor pods in alternative namespaces, preventing policy enforcement.

This PR updates the controller to scan **all namespaces** for pods labeled `kubearmor-app=kubearmor`.

**Does this PR introduce a breaking change?**
No

**If the changes in this PR are manually verified, list down the scenarios covered:**:

**Additional information for reviewer?** :
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [x] Bug fix. Fixes #2259
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Commit has unit tests
- [ ] Commit has integration tests

<!--

The PR title message must follow convention:
`<type>(<scope>): <subject>`.

Where: <br />
- `type` is to define what type of PR is this.
  Most common types are:
    - `feat`      - for new features, not a new feature for build script
    - `fix`       - for bug fixes or improvements, not a fix for build script
    - `chore`     - changes not related to production code
    - `docs`      - changes related to documentation
    - `style`     - formatting, missing semi colons, linting fix etc; no significant production code changes
    - `test`      - adding missing tests, refactoring tests; no production code change
    - `refactor`  - refactoring production code, eg. renaming a variable or function name, there should not be any significant production code changes

- `scope` is a single word that best describes where the changes fit.
    - feature(`monitor`,`enforcer`)
    - test(`tests`, `bdd`)
    - chore(`build`)
- `subject` is a single line brief description of the changes made in the pull request.

-->