### PR TITLE
test(nonk8s_env): HSP and KSP test suites

### DIFF
--- a/tests/nonk8s_env/host_policy/host_policy_suite_test.go
+++ b/tests/nonk8s_env/host_policy/host_policy_suite_test.go
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 Authors of KubeArmor
+
+package host_policy_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestHostPolicy(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Host Policy Test Suite")
+}

--- a/tests/nonk8s_env/host_policy/host_policy_test.go
+++ b/tests/nonk8s_env/host_policy/host_policy_test.go
@@ -1,0 +1,284 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 Authors of KubeArmor
+
+package host_policy_test
+
+import (
+	"time"
+
+	"github.com/kubearmor/KubeArmor/protobuf"
+	. "github.com/kubearmor/KubeArmor/tests/util"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Host Policy Tests", func() {
+	Describe("Karmor Log", func() {
+		It("should generate a host log when /usr/bin/ls is blocked", func() {
+			policyPath := "res/hsp-block-process-ls.yaml"
+
+			err := KarmorHostLogStart("policy", "Process")
+			Expect(err).To(BeNil())
+
+			err = SendPolicy("ADDED", policyPath)
+			Expect(err).To(BeNil())
+
+			AssertHostCommand([]string{"ls", "-l"}, MatchRegexp(`(?i)permission denied`), false)
+
+			target := &protobuf.Alert{Result: "Permission denied"}
+
+			res, err := KarmorGetTargetAlert(5*time.Second, target)
+			Expect(err).To(BeNil())
+			Expect(res.Found).To(BeTrue())
+
+			err = SendPolicy("DELETED", policyPath)
+			Expect(err).To(BeNil())
+			KarmorLogStop()
+			time.Sleep(3 * time.Second)
+		})
+	})
+
+	Describe("Apply and Update Host Policies", func() {
+		It("should apply, update, and enforce process block policy successfully", func() {
+			beforeUpdate := "res/hsp-block-process-before-update.yaml"
+			afterUpdate := "res/hsp-block-process-after-update.yaml"
+
+			err := SendPolicy("ADDED", beforeUpdate)
+			Expect(err).To(BeNil())
+
+			AssertHostCommand([]string{"curl", "--version"}, MatchRegexp(`(?i)permission denied`), false)
+
+			err = SendPolicy("ADDED", afterUpdate)
+			Expect(err).To(BeNil())
+
+			AssertHostCommand([]string{"curl", "--version"}, Not(MatchRegexp(`(?i)permission denied`)), false)
+			AssertHostCommand([]string{"ls"}, MatchRegexp(`(?i)permission denied`), false)
+
+			err = SendPolicy("DELETED", afterUpdate)
+			Expect(err).To(BeNil())
+
+			AssertHostCommand([]string{"ls"}, Not(MatchRegexp(`(?i)permission denied`)), false)
+		})
+	})
+
+	Describe("Host Policy Enforcement", func() {
+		AfterEach(func() {
+			KarmorLogStop()
+			time.Sleep(time.Second * 2)
+		})
+
+		It("should block access to files under /tmp/*", func() {
+			policyPath := "res/hsp-block-file-pattern.yaml"
+
+			err := KarmorHostLogStart("policy", "File")
+			Expect(err).To(BeNil())
+
+			err = SendPolicy("ADDED", policyPath)
+			Expect(err).To(BeNil())
+
+			_, _ = RunHostCommand([]string{"echo", "hello", ">", "/tmp/something.txt"})
+
+			target := &protobuf.Alert{
+				PolicyName: "hsp-block-file-pattern",
+				Result:     "Permission denied",
+			}
+
+			res, err := KarmorGetTargetAlert(5*time.Second, target)
+			Expect(err).To(BeNil())
+			Expect(res.Found).To(BeTrue())
+
+			err = SendPolicy("DELETED", policyPath)
+			Expect(err).To(BeNil())
+		})
+
+		It("should generate a host log when unlink is called under audit policy", func() {
+			policyPath := "res/hsp-audit-syscall.yaml"
+
+			err := KarmorHostLogStart("policy", "Syscall")
+			Expect(err).To(BeNil())
+
+			err = SendPolicy("ADDED", policyPath)
+			Expect(err).To(BeNil())
+
+			_, _ = RunHostCommand([]string{"touch", "/tmp/dummy"})
+			_, _ = RunHostCommand([]string{"unlink", "/tmp/dummy"})
+
+			target := &protobuf.Alert{
+				PolicyName: "hsp-audit-syscall",
+			}
+
+			res, err := KarmorGetTargetAlert(5*time.Second, target)
+			Expect(err).To(BeNil())
+			Expect(res.Found).To(BeTrue())
+
+			err = SendPolicy("DELETED", policyPath)
+			Expect(err).To(BeNil())
+		})
+
+		It("should audit when process in /home/ tries to read /etc/hosts", func() {
+			policyPath := "res/hsp-audit-hosts-fromsource.yaml"
+
+			err := KarmorHostLogStart("policy", "File")
+			Expect(err).To(BeNil())
+
+			err = SendPolicy("ADDED", policyPath)
+			Expect(err).To(BeNil())
+
+			_, err = RunHostCommand([]string{"cat", "/etc/hosts"})
+			Expect(err).To(BeNil())
+
+			target := &protobuf.Alert{
+				PolicyName: "hsp-audit-hosts-fromsource",
+				Result:     "Passed",
+			}
+
+			res, err := KarmorGetTargetAlert(5*time.Second, target)
+			Expect(err).To(BeNil())
+			Expect(res.Found).To(BeTrue())
+
+			err = SendPolicy("DELETED", policyPath)
+			Expect(err).To(BeNil())
+		})
+
+		It("should audit udp network protocol", func() {
+			policyPath := "res/hsp-audit-network-protocol.yaml"
+
+			err := KarmorHostLogStart("policy", "Network")
+			Expect(err).To(BeNil())
+
+			err = SendPolicy("ADDED", policyPath)
+			Expect(err).To(BeNil())
+
+			_, _ = RunHostCommand([]string{"echo", "test", "|", "nc", "-u", "127.0.0.1", "9999"})
+
+			target := &protobuf.Alert{
+				PolicyName: "hsp-audit-network-protocol",
+				Result:     "Passed",
+			}
+
+			res, err := KarmorGetTargetAlert(5*time.Second, target)
+			Expect(err).To(BeNil())
+			Expect(res.Found).To(BeTrue())
+
+			err = SendPolicy("DELETED", policyPath)
+			Expect(err).To(BeNil())
+		})
+
+		It("should block file read (/etc/passwd)", func() {
+			policyPath := "res/hsp-block-file-etc-passwd.yaml"
+
+			err := KarmorHostLogStart("policy", "File")
+			Expect(err).To(BeNil())
+
+			err = SendPolicy("ADDED", policyPath)
+			Expect(err).To(BeNil())
+
+			AssertHostCommand([]string{"cat", "/etc/passwd"}, MatchRegexp(`(?i)permission denied`), false)
+
+			target := &protobuf.Alert{
+				PolicyName: "hsp-kubearmor-dev-file-path-block",
+				Result:     "Permission denied",
+			}
+
+			res, err := KarmorGetTargetAlert(5*time.Second, target)
+			Expect(err).To(BeNil())
+			Expect(res.Found).To(BeTrue())
+
+			err = SendPolicy("DELETED", policyPath)
+			Expect(err).To(BeNil())
+		})
+
+		It("should block /usr/bin/curl execution", func() {
+			policyPath := "res/hsp-block-process-curl.yaml"
+
+			err := KarmorHostLogStart("policy", "Process")
+			Expect(err).To(BeNil())
+
+			err = SendPolicy("ADDED", policyPath)
+			Expect(err).To(BeNil())
+
+			AssertHostCommand([]string{"curl", "--version"}, MatchRegexp(`(?i)permission denied`), false)
+
+			target := &protobuf.Alert{
+				PolicyName: "hsp-block-curl-exec",
+				Result:     "Permission denied",
+			}
+
+			res, err := KarmorGetTargetAlert(5*time.Second, target)
+			Expect(err).To(BeNil())
+			Expect(res.Found).To(BeTrue())
+
+			err = SendPolicy("DELETED", policyPath)
+			Expect(err).To(BeNil())
+		})
+
+		It("should block reading files under /etc recursively", func() {
+			policyPath := "res/hsp-block-file-dir-etc.yaml"
+
+			err := KarmorHostLogStart("policy", "File")
+			Expect(err).To(BeNil())
+
+			err = SendPolicy("ADDED", policyPath)
+			Expect(err).To(BeNil())
+
+			AssertHostCommand([]string{"cat", "/etc/passwd"}, MatchRegexp(`(?i)permission denied`), false)
+			AssertHostCommand([]string{"cat", "/etc/hosts"}, MatchRegexp(`(?i)permission denied`), false)
+
+			target := &protobuf.Alert{
+				PolicyName: "hsp-block-file-dir",
+				Result:     "Permission denied",
+			}
+
+			res, err := KarmorGetTargetAlert(5*time.Second, target)
+			Expect(err).To(BeNil())
+			Expect(res.Found).To(BeTrue())
+
+			err = SendPolicy("DELETED", policyPath)
+			Expect(err).To(BeNil())
+		})
+
+		It("should block process execution (/usr/bin/ls)", func() {
+			policyPath := "res/hsp-block-process-ls.yaml"
+
+			err := SendPolicy("ADDED", policyPath)
+			Expect(err).To(BeNil())
+
+			AssertHostCommand([]string{"ls", "-l"}, MatchRegexp(`(?i)permission denied`), false)
+
+			err = SendPolicy("DELETED", policyPath)
+			Expect(err).To(BeNil())
+		})
+
+		It("should block execution of binaries under /usr/bin directory recursively", func() {
+			policyPath := "res/hsp-block-process-dir-bin.yaml"
+
+			err := SendPolicy("ADDED", policyPath)
+			Expect(err).To(BeNil())
+
+			AssertHostCommand([]string{"ls", "-l"}, MatchRegexp(`(?i)permission denied`), false)
+
+			err = SendPolicy("DELETED", policyPath)
+			Expect(err).To(BeNil())
+		})
+
+		It("should block all apt commands", func() {
+			policyPath := "res/hsp-block-process-apt-pattern.yaml"
+
+			err := SendPolicy("ADDED", policyPath)
+			Expect(err).To(BeNil())
+
+			aptCommands := [][]string{
+				{"apt", "update"},
+				{"apt-get", "upgrade", "-y"},
+				{"apt-cache", "search", "kubernetes"},
+			}
+
+			for _, cmd := range aptCommands {
+				AssertHostCommand(cmd, MatchRegexp(`(?i)permission denied`), false)
+			}
+
+			err = SendPolicy("DELETED", policyPath)
+			Expect(err).To(BeNil())
+		})
+	})
+})

--- a/tests/nonk8s_env/host_policy/res/hsp-audit-hosts-fromsource.yaml
+++ b/tests/nonk8s_env/host_policy/res/hsp-audit-hosts-fromsource.yaml
@@ -1,0 +1,16 @@
+apiVersion: security.kubearmor.com/v1
+kind: KubeArmorHostPolicy
+metadata:
+  name: hsp-audit-hosts-fromsource
+spec:
+  nodeSelector:
+    matchLabels:
+      kubearmor.io/hostname: "*"
+  file:
+    matchPaths:
+      - path: /etc/hosts
+        fromSource:
+          - path: /usr/bin/cat
+  action: Audit
+  severity: 7
+  message: "Process /usr/bin/cat cat attempted to read /etc/hosts"

--- a/tests/nonk8s_env/host_policy/res/hsp-audit-network-protocol.yaml
+++ b/tests/nonk8s_env/host_policy/res/hsp-audit-network-protocol.yaml
@@ -1,0 +1,23 @@
+apiVersion: security.kubearmor.com/v1
+kind: KubeArmorHostPolicy
+metadata:
+  name: hsp-audit-network-protocol
+spec:
+  nodeSelector:
+    matchLabels:
+      kubearmor.io/hostname: "*"
+
+  severity: 5
+  tags:
+    - global-tag
+  message: global-msg
+  action: Audit
+
+  network:
+    severity: 7
+    tags:
+      - network-tag
+    message: UDP is being monitored
+
+    matchProtocols:
+      - protocol: udp

--- a/tests/nonk8s_env/host_policy/res/hsp-audit-syscall.yaml
+++ b/tests/nonk8s_env/host_policy/res/hsp-audit-syscall.yaml
@@ -1,0 +1,22 @@
+apiVersion: security.kubearmor.com/v1
+kind: KubeArmorHostPolicy
+metadata:
+  name: hsp-audit-syscall
+spec:
+  nodeSelector:
+    matchLabels:
+      kubearmor.io/hostname: "*"
+
+  severity: 5
+  tags: [global-tag]
+
+  syscalls:
+    matchPaths:
+    - syscall:
+      - unlink
+      path: /home/
+      recursive: true
+    severity: 7
+    message: "Unlink used"
+
+  action: Audit

--- a/tests/nonk8s_env/host_policy/res/hsp-block-file-dir-etc.yaml
+++ b/tests/nonk8s_env/host_policy/res/hsp-block-file-dir-etc.yaml
@@ -1,0 +1,14 @@
+apiVersion: security.kubearmor.com/v1
+kind: KubeArmorHostPolicy
+metadata:
+  name: hsp-block-file-dir
+spec:
+  nodeSelector:
+    matchLabels:
+      kubearmor.io/hostname: "*"
+  file:
+    matchDirectories:
+    - dir: /etc/
+      recursive: true
+  action:
+    Block

--- a/tests/nonk8s_env/host_policy/res/hsp-block-file-etc-passwd.yaml
+++ b/tests/nonk8s_env/host_policy/res/hsp-block-file-etc-passwd.yaml
@@ -1,0 +1,13 @@
+apiVersion: security.kubearmor.com/v1
+kind: KubeArmorHostPolicy
+metadata:
+  name: hsp-kubearmor-dev-file-path-block
+spec:
+  nodeSelector:
+    matchLabels:
+      kubearmor.io/hostname: "*"
+  file:
+    matchPaths:
+      - path: /etc/passwd
+  action:
+    Block

--- a/tests/nonk8s_env/host_policy/res/hsp-block-file-pattern.yaml
+++ b/tests/nonk8s_env/host_policy/res/hsp-block-file-pattern.yaml
@@ -1,0 +1,22 @@
+apiVersion: security.kubearmor.com/v1
+kind: KubeArmorHostPolicy
+metadata:
+  name: hsp-block-file-pattern
+spec:
+  nodeSelector:
+    matchLabels:
+      kubearmor.io/hostname: "*"
+  severity: 5
+  tags:
+    - host
+    - filesystem
+  message: file access detected
+  action: Block
+
+  file:
+    severity: 4
+    tags:
+      - fs-monitor
+    message: file event
+    matchPatterns:
+      - pattern: /tmp/*

--- a/tests/nonk8s_env/host_policy/res/hsp-block-process-after-update.yaml
+++ b/tests/nonk8s_env/host_policy/res/hsp-block-process-after-update.yaml
@@ -1,0 +1,12 @@
+apiVersion: security.kubearmor.com/v1
+kind: KubeArmorHostPolicy
+metadata:
+  name: hsp-update-test
+spec:
+  nodeSelector:
+    matchLabels:
+      kubearmor.io/hostname: "*"
+  process:
+    matchPaths:
+      - path: /usr/bin/ls
+  action: Block

--- a/tests/nonk8s_env/host_policy/res/hsp-block-process-apt-pattern.yaml
+++ b/tests/nonk8s_env/host_policy/res/hsp-block-process-apt-pattern.yaml
@@ -1,0 +1,15 @@
+apiVersion: security.kubearmor.com/v1
+kind: KubeArmorHostPolicy
+metadata:
+  name: hsp-block-apt-commands
+spec:
+  nodeSelector:
+    matchLabels:
+      kubearmor.io/hostname: "*"
+  process:
+    matchPatterns:
+      - pattern: /usr/bin/apt*
+  action: Block
+  severity: 5
+  tags: [package-manager, test]
+  message: "All apt commands are blocked"

--- a/tests/nonk8s_env/host_policy/res/hsp-block-process-before-update.yaml
+++ b/tests/nonk8s_env/host_policy/res/hsp-block-process-before-update.yaml
@@ -1,0 +1,12 @@
+apiVersion: security.kubearmor.com/v1
+kind: KubeArmorHostPolicy
+metadata:
+  name: hsp-update-test
+spec:
+  nodeSelector:
+    matchLabels:
+      kubearmor.io/hostname: "*"
+  process:
+    matchPaths:
+      - path: /usr/bin/curl
+  action: Block

--- a/tests/nonk8s_env/host_policy/res/hsp-block-process-curl.yaml
+++ b/tests/nonk8s_env/host_policy/res/hsp-block-process-curl.yaml
@@ -1,0 +1,15 @@
+apiVersion: security.kubearmor.com/v1
+kind: KubeArmorHostPolicy
+metadata:
+  name: hsp-block-curl-exec
+spec:
+  nodeSelector:
+    matchLabels:
+      kubearmor.io/hostname: "*"
+  process:
+    matchPaths:
+      - path: /usr/bin/curl
+  action: Block
+  severity: 5
+  tags: [http]
+  message: "curl execution blocked"

--- a/tests/nonk8s_env/host_policy/res/hsp-block-process-dir-bin.yaml
+++ b/tests/nonk8s_env/host_policy/res/hsp-block-process-dir-bin.yaml
@@ -1,0 +1,22 @@
+apiVersion: security.kubearmor.com/v1
+kind: KubeArmorHostPolicy
+metadata:
+  name: hsp-block-process-dir
+spec:
+  nodeSelector:
+    matchLabels:
+      kubearmor.io/hostname: "*"
+  severity: 5
+  tags:
+    - global-tag
+  message: global-msg
+  action: Block
+
+  process:
+    tags:
+      - process-tag
+    message: process-msg
+    matchDirectories:
+      - dir: /usr/bin
+        recursive: true
+        severity: 3

--- a/tests/nonk8s_env/host_policy/res/hsp-block-process-ls.yaml
+++ b/tests/nonk8s_env/host_policy/res/hsp-block-process-ls.yaml
@@ -1,0 +1,13 @@
+apiVersion: security.kubearmor.com/v1
+kind: KubeArmorHostPolicy
+metadata:
+  name: hsp-proc-path-block
+spec:
+  nodeSelector:
+    matchLabels:
+      kubearmor.io/hostname: "*"
+  process:
+    matchPaths:
+    - path: /usr/bin/ls
+  action:
+    Block

--- a/tests/nonk8s_env/ksp/ksp_suite_test.go
+++ b/tests/nonk8s_env/ksp/ksp_suite_test.go
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 Authors of KubeArmor
+package ksp_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestSystemd(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "KSP Suite")
+}

--- a/tests/nonk8s_env/ksp/ksp_test.go
+++ b/tests/nonk8s_env/ksp/ksp_test.go
@@ -1,0 +1,175 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 Authors of KubeArmor
+package ksp_test
+
+import (
+	"time"
+
+	"github.com/kubearmor/KubeArmor/protobuf"
+	. "github.com/kubearmor/KubeArmor/tests/util"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = BeforeSuite(func() {
+	_, err := RunDockerCommand([]string{
+		"compose", "-f", "res/wordpress_docker/compose.yaml", "up", "-d",
+	})
+	Expect(err).To(BeNil())
+
+	time.Sleep(5 * time.Second)
+})
+
+var _ = AfterSuite(func() {
+	_, err := RunDockerCommand([]string{"rm", "-f", "wordpress-mysql"})
+	Expect(err).To(BeNil())
+
+	time.Sleep(5 * time.Second)
+})
+
+var _ = Describe("KSP Test", func() {
+	AfterEach(func() {
+		KarmorLogStop()
+		time.Sleep(time.Second)
+	})
+
+	It("can audit file access", func() {
+		err := KarmorHostLogStart("policy", "File")
+		Expect(err).To(BeNil())
+
+		policyPath := "res/ksp-audit-file-access.yaml"
+
+		err = SendPolicy("ADDED", policyPath)
+		Expect(err).To(BeNil())
+
+		_, err = RunDockerCommand([]string{
+			"exec", "wordpress-mysql", "bash", "-c", "cat /etc/shadow",
+		})
+		Expect(err).To(BeNil())
+
+		target := &protobuf.Alert{
+			PolicyName: "ksp-audit-file-access",
+			Action:     "Audit",
+			Result:     "Passed",
+		}
+
+		res, err := KarmorGetTargetAlert(5*time.Second, target)
+		Expect(err).To(BeNil())
+		Expect(res.Found).To(BeTrue())
+
+		err = SendPolicy("DELETED", policyPath)
+		Expect(err).To(BeNil())
+	})
+
+	It("can audit access to /bin/ dir", func() {
+		err := KarmorHostLogStart("policy", "Process")
+		Expect(err).To(BeNil())
+
+		policyPath := "res/ksp-audit-exec-dir.yaml"
+
+		err = SendPolicy("ADDED", policyPath)
+		Expect(err).To(BeNil())
+
+		_, err = RunDockerCommand([]string{
+			"exec", "wordpress-mysql", "bash", "-c", "ls",
+		})
+		Expect(err).To(BeNil())
+
+		target := &protobuf.Alert{
+			PolicyName: "ksp-block-exec-dir",
+			Action:     "Audit",
+			Result:     "Passed",
+		}
+
+		res, err := KarmorGetTargetAlert(5*time.Second, target)
+		Expect(err).To(BeNil())
+		Expect(res.Found).To(BeTrue())
+
+		err = SendPolicy("DELETED", policyPath)
+		Expect(err).To(BeNil())
+	})
+
+	It("can audit TCP protocol access using curl", func() {
+		err := KarmorHostLogStart("policy", "Network")
+		Expect(err).To(BeNil())
+
+		policyPath := "res/ksp-audit-protocol-tcp.yaml"
+
+		err = SendPolicy("ADDED", policyPath)
+		Expect(err).To(BeNil())
+
+		_, err = RunDockerCommand([]string{
+			"exec", "wordpress-mysql", "bash", "-c", "curl --help",
+		})
+		Expect(err).To(BeNil())
+
+		target := &protobuf.Alert{
+			PolicyName: "ksp-audit-protocol-tcp",
+			Action:     "Audit",
+			Result:     "Passed",
+		}
+
+		res, err := KarmorGetTargetAlert(5*time.Second, target)
+		Expect(err).To(BeNil())
+		Expect(res.Found).To(BeTrue())
+
+		err = SendPolicy("DELETED", policyPath)
+		Expect(err).To(BeNil())
+	})
+
+	It("can audit access to /tmp via pattern", func() {
+		err := KarmorHostLogStart("policy", "File")
+		Expect(err).To(BeNil())
+
+		policyPath := "res/ksp-audit-file-pattern.yaml"
+
+		err = SendPolicy("ADDED", policyPath)
+		Expect(err).To(BeNil())
+
+		_, err = RunDockerCommand([]string{
+			"exec", "wordpress-mysql", "bash", "-c", "echo test > /tmp/karmor_test_file",
+		})
+		Expect(err).To(BeNil())
+
+		target := &protobuf.Alert{
+			PolicyName: "ksp-audit-file-pattern",
+			Action:     "Audit",
+			Result:     "Passed",
+		}
+
+		res, err := KarmorGetTargetAlert(5*time.Second, target)
+		Expect(err).To(BeNil())
+		Expect(res.Found).To(BeTrue())
+
+		err = SendPolicy("DELETED", policyPath)
+		Expect(err).To(BeNil())
+	})
+
+	It("can audit apt process execution via pattern", func() {
+		err := KarmorHostLogStart("policy", "Process")
+		Expect(err).To(BeNil())
+
+		policyPath := "res/ksp-audit-process-apt-pattern.yaml"
+
+		err = SendPolicy("ADDED", policyPath)
+		Expect(err).To(BeNil())
+
+		_, err = RunDockerCommand([]string{
+			"exec", "wordpress-mysql", "bash", "-c", "apt --help",
+		})
+		Expect(err).To(BeNil())
+
+		target := &protobuf.Alert{
+			PolicyName: "ksp-audit-process-apt-pattern",
+			Action:     "Audit",
+			Result:     "Passed",
+		}
+
+		res, err := KarmorGetTargetAlert(10*time.Second, target)
+		Expect(err).To(BeNil())
+		Expect(res.Found).To(BeTrue())
+
+		err = SendPolicy("DELETED", policyPath)
+		Expect(err).To(BeNil())
+	})
+})

--- a/tests/nonk8s_env/ksp/res/ksp-audit-exec-dir.yaml
+++ b/tests/nonk8s_env/ksp/res/ksp-audit-exec-dir.yaml
@@ -1,0 +1,14 @@
+apiVersion: security.kubearmor.com/v1
+kind: KubeArmorPolicy
+metadata:
+  name: ksp-block-exec-dir
+spec:
+  severity: 7
+  selector:
+    matchLabels:
+      kubearmor.io/container.name: wordpress-mysql
+  process:
+    matchDirectories:
+    - dir: /usr/bin/
+      recursive: true
+  action: Audit

--- a/tests/nonk8s_env/ksp/res/ksp-audit-file-access.yaml
+++ b/tests/nonk8s_env/ksp/res/ksp-audit-file-access.yaml
@@ -1,0 +1,15 @@
+apiVersion: security.kubearmor.com/v1
+kind: KubeArmorPolicy
+metadata:
+  name: ksp-audit-file-access
+spec:
+  severity: 7
+  selector:
+    matchLabels:
+      kubearmor.io/container.name: wordpress-mysql
+  file:
+    matchPaths:
+    - path: /etc/passwd
+    - path: /etc/shadow
+  action:
+    Audit

--- a/tests/nonk8s_env/ksp/res/ksp-audit-file-pattern.yaml
+++ b/tests/nonk8s_env/ksp/res/ksp-audit-file-pattern.yaml
@@ -1,0 +1,22 @@
+apiVersion: security.kubearmor.com/v1
+kind: KubeArmorPolicy
+metadata:
+  name: ksp-audit-file-pattern
+spec:
+  severity: 7
+  selector:
+    matchLabels:
+      kubearmor.io/container.name: wordpress-mysql
+  tags:
+    - host
+    - filesystem
+  message: file access detected
+  action: Audit
+
+  file:
+    severity: 4
+    tags:
+      - fs-monitor
+    message: file event
+    matchPatterns:
+      - pattern: /tmp/*

--- a/tests/nonk8s_env/ksp/res/ksp-audit-process-apt-pattern.yaml
+++ b/tests/nonk8s_env/ksp/res/ksp-audit-process-apt-pattern.yaml
@@ -1,0 +1,14 @@
+apiVersion: security.kubearmor.com/v1
+kind: KubeArmorPolicy
+metadata:
+  name: ksp-audit-process-apt-pattern
+spec:
+  severity: 7
+  selector:
+    matchLabels:
+      kubearmor.io/container.name: wordpress-mysql
+  process:
+    matchPatterns:
+      - pattern: /usr/bin/apt*
+  action: Audit
+  tags: [package-manager, test]

--- a/tests/nonk8s_env/ksp/res/ksp-audit-protocol-tcp.yaml
+++ b/tests/nonk8s_env/ksp/res/ksp-audit-protocol-tcp.yaml
@@ -1,0 +1,16 @@
+apiVersion: security.kubearmor.com/v1
+kind: KubeArmorPolicy
+metadata:
+  name: ksp-audit-protocol-tcp
+spec:
+  severity: 7
+  selector:
+    matchLabels:
+      kubearmor.io/container.name: wordpress-mysql
+  network:
+    matchProtocols:
+    - protocol: tcp
+      fromSource:
+      - path: /usr/bin/curl
+  action:
+    Audit

--- a/tests/nonk8s_env/ksp/res/wordpress_docker/compose.yaml
+++ b/tests/nonk8s_env/ksp/res/wordpress_docker/compose.yaml
@@ -1,0 +1,14 @@
+services:
+  wordpress:
+    container_name: wordpress-mysql
+    image: wordpress:latest
+    ports:
+      - 80:80
+    restart: always
+    environment:
+      - WORDPRESS_DB_HOST=db
+      - WORDPRESS_DB_USER=wordpress
+      - WORDPRESS_DB_PASSWORD=wordpress
+      - WORDPRESS_DB_NAME=wordpress
+volumes:
+  db_data:

--- a/tests/util/karmorlog.go
+++ b/tests/util/karmorlog.go
@@ -7,6 +7,7 @@ package util
 import (
 	"errors"
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
@@ -249,6 +250,38 @@ func KarmorLogStart(logFilter string, ns string, op string, pod string) error {
 	return nil
 }
 
+func KarmorHostLogStart(logFilter string, op string) error {
+	drainEventChan()
+
+	if eventChan == nil {
+		eventChan = make(chan klog.EventInfo, maxEvents)
+	}
+
+	nullFile, err := os.OpenFile("/dev/null", os.O_WRONLY, 0)
+	if err != nil {
+		return err
+	}
+
+	go func() {
+		err := klog.StartObserver(k8sClient, klog.Options{
+			LogFilter:        logFilter,
+			ReadCAFromSecret: false,
+			LogPath:          nullFile.Name(),
+			Operation:        op,
+			MsgPath:          "none",
+			EventChan:        eventChan,
+			GRPC:             ":32767",
+			Secure:           false,
+		})
+		if err != nil {
+			log.Errorf("failed to start observer. Error=%s", err.Error())
+		}
+	}()
+
+	time.Sleep(3 * time.Second)
+	return nil
+}
+
 // KarmorGetLogs waits for logs from kubearmor. KarmorQueueLog() has to be called
 // before this so that the channel is established.
 func KarmorGetLogs(timeout time.Duration, maxEvents int) ([]*pb.Log, []*pb.Alert, error) {
@@ -263,15 +296,16 @@ func KarmorGetLogs(timeout time.Duration, maxEvents int) ([]*pb.Log, []*pb.Alert
 	for eventChan != nil {
 		select {
 		case evtin := <-eventChan:
-			if evtin.Type == "Alert" {
+			switch evtin.Type {
+			case "Alert":
 				alert := pb.Alert{}
 				protojson.Unmarshal(evtin.Data, &alert)
 				alerts = append(alerts, &alert)
-			} else if evtin.Type == "Log" {
+			case "Log":
 				log := pb.Log{}
 				protojson.Unmarshal(evtin.Data, &log)
 				logs = append(logs, &log)
-			} else {
+			default:
 				log.Errorf("UNKNOWN EVT type %s", evtin.Type)
 			}
 			evtCnt++

--- a/tests/util/kartutil.go
+++ b/tests/util/kartutil.go
@@ -686,11 +686,26 @@ func K8sRuntime() string {
 }
 
 // RunDockerCommand() executes docker commmands
-func RunDockerCommand(cmdstr string) (string, error) {
-	cmdf := strings.Fields(cmdstr)
-	cmd := exec.Command("docker", cmdf...)
-	sout, err := cmd.Output()
-	return string(sout), err
+func RunDockerCommand(cmdParts []string) (string, error) {
+	if len(cmdParts) == 0 {
+		return "", errors.New("empty command")
+	}
+	bin := "docker"
+
+	cmd := exec.Command(bin, cmdParts...)
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	err := cmd.Run()
+	if err != nil {
+		return "", errors.New(stderr.String())
+	}
+
+	return strings.TrimSpace(stdout.String()), nil
 }
 
 func AssertCommand(wp string, namespace string, cmd []string, match gomegaTypes.GomegaMatcher, eventual bool) {
@@ -707,6 +722,48 @@ func AssertCommand(wp string, namespace string, cmd []string, match gomegaTypes.
 		fmt.Printf("---START---\n%s---END---\n", sout)
 		Expect(sout).To(match)
 	}
+}
+
+func AssertHostCommand(cmd []string, match gomegaTypes.GomegaMatcher, eventual bool) {
+	if eventual {
+		Eventually(func() string {
+			output, err := RunHostCommand(cmd)
+			fmt.Printf("---START---\nOUTPUT: %s\nERROR: %v\n---END---\n", output, err)
+			if err != nil {
+				return strings.Join([]string{output, err.Error()}, "\n")
+			}
+			return output
+		}, 10*time.Second, 2*time.Second).Should(match)
+	} else {
+		output, err := RunHostCommand(cmd)
+		fmt.Printf("---START---\nOUTPUT: %s\nERROR: %v\n---END---\n", output, err)
+		var combined string
+		if err != nil {
+			combined = strings.Join([]string{output, err.Error()}, "\n")
+		} else {
+			combined = output
+		}
+		Expect(combined).To(match)
+	}
+}
+
+func RunHostCommand(cmd []string) (string, error) {
+	if len(cmd) == 0 {
+		return "", fmt.Errorf("empty command")
+	}
+
+	args := append([]string{"-c"}, strings.Join(cmd, " "))
+	command := exec.Command("bash", args...)
+	command.Env = []string{}
+
+	output, err := command.CombinedOutput()
+	outStr := strings.TrimSpace(string(output))
+
+	if err != nil {
+		return outStr, fmt.Errorf("cmd %v failed: %w, output: %s", cmd, err, outStr)
+	}
+
+	return outStr, nil
 }
 
 // SendPolicy sends kubearmor policy using grpc client


### PR DESCRIPTION
**Purpose of PR?**:
Adds new test suites HSP and KSP for Systemd environment covering file, process, network, and syscall policies. This increases test coverage and ensures consistent policy enforcement across Systemd mode

**Does this PR introduce a breaking change?**
No

**If the changes in this PR are manually verified, list down the scenarios covered:**
Host policies: file, process, network, and syscall audit/block scenarios
KSP policies: file access, process audit, protocol, and pattern validations
Smoke tests: refactored with similar behaviors
Utility changes in karmorlog.go and kartutil.go for Systemd tests

**Tested the tests in CI 4 Times to observer any flaky behaviour**
[Attempt 1](https://github.com/GAURAV-DEEP01/KubeArmor/actions/runs/19632558564/job/56215536790)
[Attempt 2](https://github.com/GAURAV-DEEP01/KubeArmor/actions/runs/19632598790/job/56215666332)
[Attempt 3](https://github.com/GAURAV-DEEP01/KubeArmor/actions/runs/19632719404/job/56216056100)
[Attempt 4](https://github.com/GAURAV-DEEP01/KubeArmor/actions/runs/19632806165/job/56216334541)
All tests passed and no flaky behavior was observed

**Coverage Report**
[Systemd_test_coverage_report metrics](https://github.com/user-attachments/files/23711975/Systemd_test_coverage_report.txt)
[Systemd_test_coverage_report.html](https://github.com/user-attachments/files/23711979/Systemd_test_coverage_report.html)

**Systemd test CI with metrics, tested on fork**
Tested these new HSP and KSP test on fork [Systemd Test with coverage](https://github.com/GAURAV-DEEP01/KubeArmor/actions/runs/19631499336/job/56212155281)

**Additional information for reviewer?** :
Total Coverage for Systemd tests 30.3%
Most of the coverage are complementary for k8s and non-k8s 
<img width="460" height="256" alt="image" src="https://github.com/user-attachments/assets/a7ad8db5-e7a5-4c91-a8df-f2d76e91c57a" />
and many more functions/code blocks/files covered that are complementary

**Checklist:**
- [ ] Bug fix. Fixes #<issue number>
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Commit has unit tests
- [x] Commit has integration tests
