### PR TITLE
fix: refresh in-cluster token rotation (TokenCache + TokenProvider)

### DIFF
--- a/KubeArmor/core/token_inject.go
+++ b/KubeArmor/core/token_inject.go
@@ -1,0 +1,25 @@
+package core
+
+import (
+	"log"
+	"net/http"
+)
+
+// ReplaceAuthHeader injects the latest ServiceAccount token into the request.
+// This ensures all manual API calls use the rotated token instead of a old / expired token.
+func ReplaceAuthHeader(req *http.Request, provider TokenProvider) {
+	if provider == nil || req == nil {
+		return
+	}
+
+	// fetch token from the cache (auto-refreshes on rotation)
+	tok, err := provider.Get()
+	if err != nil {
+		log.Printf("failed to get token: %v", err)
+	}
+
+	// only set header when a valid token is available
+	if tok != "" {
+		req.Header.Set("Authorization", "Bearer "+tok)
+	}
+}

--- a/KubeArmor/core/tokencache.go
+++ b/KubeArmor/core/tokencache.go
@@ -1,0 +1,116 @@
+package core
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"os"
+	"sync/atomic"
+
+	"golang.org/x/sync/singleflight"
+)
+
+var DefaultTokenPath = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+
+// TokenProvider is used by callers to fetch the latest SA token.
+type TokenProvider interface {
+	Get() (string, error)
+}
+
+// TokenCache tracks the ServiceAccount token and refreshes it
+// when Kubernetes rotates the projected token file.
+type TokenCache struct {
+	token atomic.Value       // cached token
+	mtime atomic.Value       // last file mtime
+	group singleflight.Group // prevents duplicate refreshes
+}
+
+func NewTokenCache() *TokenCache {
+	tc := &TokenCache{}
+	tc.token.Store([]byte{})
+	tc.mtime.Store(int64(0))
+	return tc
+}
+
+var ErrNoToken = errors.New("No Token Available")
+
+// readTokenFile reads the projected token file and returns (contents, mtime).
+func readTokenFile(path string) ([]byte, int64, error) {
+	st, err := os.Stat(path)
+	if err != nil {
+		return nil, 0, err
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer f.Close()
+
+	b, err := io.ReadAll(f)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	return b, st.ModTime().UnixNano(), nil
+}
+
+// Get returns the latest token.
+// - If the token file changed → reload
+// - If the file is temporarily unreadable → return last known good token
+// - Only one goroutine performs file reads --(singleflight)
+func (c *TokenCache) Get() (string, error) {
+	cached := c.token.Load().([]byte)
+
+	v, err, _ := c.group.Do("load-token", func() (interface{}, error) {
+		b, m, e := readTokenFile(DefaultTokenPath)
+		if e != nil {
+			// fallback: use previously cached token
+			if len(cached) > 0 {
+				out := make([]byte, len(cached))
+				copy(out, cached)
+				return out, nil
+			}
+			return nil, e
+		}
+
+		b = bytes.TrimSpace(b)
+
+		// no change → return cached token
+		prev := c.mtime.Load().(int64)
+		if prev == m && len(cached) > 0 {
+			out := make([]byte, len(cached))
+			copy(out, cached)
+			return out, nil
+		}
+
+		// file changed → update cache
+		cpy := make([]byte, len(b))
+		copy(cpy, b)
+		c.token.Store(cpy)
+		c.mtime.Store(m)
+		return cpy, nil
+	})
+	if err != nil {
+		return "", err
+	}
+
+	out := bytes.TrimSpace(v.([]byte))
+	if len(out) == 0 {
+		return "", ErrNoToken
+	}
+
+	return string(out), nil
+}
+
+// tokenProviderImpl adapts TokenCache to the TokenProvider interface.
+type tokenProviderImpl struct {
+	cache *TokenCache
+}
+
+func (p *tokenProviderImpl) Get() (string, error) {
+	return p.cache.Get()
+}
+
+// Global default provider used by in-cluster HTTP callers.
+var globalTokenCache = NewTokenCache()
+var GlobalTokenProvider TokenProvider = &tokenProviderImpl{cache: globalTokenCache}

--- a/KubeArmor/core/tokencache_test.go
+++ b/KubeArmor/core/tokencache_test.go
@@ -1,0 +1,53 @@
+package core
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// TestTokenCacheRefresh verifies that TokenCache correctly detects changes
+// to the ServiceAccount token file and returns the updated value.
+func TestTokenCacheRefresh(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, "token")
+
+	// write initial token
+	if err := os.WriteFile(path, []byte("first"), 0o600); err != nil {
+		t.Fatalf("write first: %v", err)
+	}
+
+	// temporarily point DefaultTokenPath to our test file
+	old := DefaultTokenPath
+	DefaultTokenPath = path
+	defer func() { DefaultTokenPath = old }()
+
+	tc := NewTokenCache()
+
+	// first read should return the initial token
+	v, err := tc.Get()
+	if err != nil {
+		t.Fatalf("first get failed: %v", err)
+	}
+	if v != "first" {
+		t.Fatalf("expected 'first', got %q", v)
+	}
+
+	// wait a little so file mtime changes reliably on all filesystems
+	time.Sleep(20 * time.Millisecond)
+
+	// write updated token (simulating rotation)
+	if err := os.WriteFile(path, []byte("second"), 0o600); err != nil {
+		t.Fatalf("write second: %v", err)
+	}
+
+	// Get() should detect the mtime change and return the new token
+	v2, err := tc.Get()
+	if err != nil {
+		t.Fatalf("second get failed: %v", err)
+	}
+	if v2 != "second" {
+		t.Fatalf("expected 'second', got %q", v2)
+	}
+}


### PR DESCRIPTION
Purpose of PR?:

Fixes #2262

This PR adds an in-memory TokenCache and a TokenProvider to refresh the in-cluster ServiceAccount token when Kubernetes rotates it. Previously the client read the token once and reused a static Authorization header, which caused 401 Unauthorized after token rotation. This change ensures the client always uses the current token on disk.

Does this PR introduce a breaking change?

No — this is backwards compatible. If the token file never changes, behavior remains the same. The change centralizes token access via a TokenProvider and replaces manual static header usage; callers using the provider will get the updated token automatically.

If the changes in this PR are manually verified, list down the scenarios covered:

Start the process with an initial token file → requests succeed using the initial token.

Replace the token file contents with a new token (simulate Kubernetes rotation) → subsequent requests use the new token and succeed (no 401).

Unit test (tokencache_test.go) verifies that token refresh is observed when token file mtime/content changes.

Normal behavior when token file is static (no change) — no regressions observed.

(Recommended: maintainers can run go test ./... to validate full test-suite locally.)

Additional information for reviewer? :

This PR contains only the 4 necessary files and minimal integration:

KubeArmor/core/tokencache.go (TokenCache implementation)

KubeArmor/core/token_inject.go (TokenProvider + injection)

KubeArmor/core/tokencache_test.go (unit test)

KubeArmor/core/k8sHandler.go (integration: use TokenProvider for in-cluster client)

Motivation: prevent service disruptions due to SA token rotation in long-running processes.

If maintainers prefer, I can separate a follow-up PR to tidy up .gitignore (one of the repo ignore rules previously caused this PR to require a force-add). I kept this PR focused on the token refresh logic only.

Signed-off-by included in commit message.

Checklist:

 Bug fix. Fixes #2262

 New feature (non-breaking change which adds functionality) — this is a bug-fix / robustness improvement

 Breaking change (fix or feature that would cause existing functionality to not work as expected)

 This change requires a documentation update — (optional; I can add a short note to docs if you want)

 PR Title follows the convention of <type>(<scope>): <subject> (use fix:)

 Commit has unit tests (tokencache_test.go)

 Commit has integration tests — (manual verification described above; can add integration tests in follow-up)
[Fix.docx](https://github.com/user-attachments/files/23841552/Fix.docx)
