### PR TITLE
fix: correct spelling and grammar in main.go log message

### DIFF
--- a/KubeArmor/main.go
+++ b/KubeArmor/main.go
@@ -39,7 +39,7 @@ func main() {
 			if err != nil {
 				kg.Err(err.Error())
 			}
-			kg.Warnf("Deleteing existing map %s. This means previous cleanup was failed", path)
+			kg.Warnf("Deleting existing map %s. This means previous cleanup failed", path)
 
 		}
 	}


### PR DESCRIPTION
This pull request includes a minor correction to a log message in the `main.go` file. The change fixes a spelling error in the warning message to improve clarity and professionalism.