### PR TITLE
fix(monitor): check host pidMap for missing parent process name

### DIFF
--- a/KubeArmor/monitor/processTree.go
+++ b/KubeArmor/monitor/processTree.go
@@ -235,6 +235,23 @@ func (mon *SystemMonitor) GetParentExecPath(containerID string, ctx SyscallConte
 		}
 	}
 
+	// check pidMap of host
+	if hostPidMap, ok := ActiveHostPidMap[""]; ok {
+		if node, ok := hostPidMap[ctx.HostPID]; ok {
+			path = node.ParentExecPath
+			if path != "/" && strings.HasPrefix(path, "/") {
+				return path
+			}
+		}
+		// check if parent pid node exists
+		if node, ok := hostPidMap[ctx.HostPPID]; ok {
+			path = node.ExecPath
+			if path != "/" && strings.HasPrefix(path, "/") {
+				return path
+			}
+		}
+	}
+
 	if readlink {
 		// just in case that it couldn't still get the full path
 		if data, err := os.Readlink(filepath.Join(cfg.GlobalCfg.ProcFsMount, strconv.FormatUint(uint64(ctx.HostPPID), 10), "/exe")); err == nil && data != "" && data != "/" {


### PR DESCRIPTION
**Purpose of PR?**:
This PR fixes missing `ParentProcessName` / `Source` fields in process observability logs for container processes whose parents are short‑lived.
KubeArmor builds process context from a per‑container PID map (`ActiveHostPidMap[containerID]`) plus a host‑level map (`ActiveHostPidMap[""]`). For each event, `GetParentExecPath` tries to resolve the parent executable path using:​

1. The container’s pidMap[containerID]
2. A `/proc/<HostPPID>/exe` readlink (when readlink == true)

Parents like `runc` generally live only in the host map (containerID == ""). In some cases the following sequence occurred:

1. A host process executes, which goes on to become the parent process of the container process in event of which we could not resolve its parent.
2. The context of this parent is saved in pidMap[""].
3. The container process spawns (child of the host process). When checking the parent process for this, we call `BuildLogBase` (readlink = false) which only checks in the container's pidMap. Result -> Since this is the first process event for this container, we do not have the node for the container process' PID in the pidMap.
4. We call `BuildPIDNode` for the container process, create a pidMap for this container and add this pid node for the container process' HostPID. We still call this function with readlink = false and due to the previous point, we can't resolve parent process.
5. We save the log to update when `sys_execve` returns.
6. Before the `UpdateLogBase` function is called for the saved log of this container process, the parent process has already exited. Now we may have a pid node for the container process' HostPID in its pidMap but we don't have its parent process name, and because the host process was very short‑lived, by the time the container context tried readlink, `/proc/<HostPPID>/exe` no longer existed and the call failed.
7. Result is a container process log with missing parent process name and source.

### Solution
Since the parent process was already cached in the pidMap[""], check in that without checking `procfs`.  

Fixes #2299 

**Does this PR introduce a breaking change?**
No

**If the changes in this PR are manually verified, list down the scenarios covered:**:

**Additional information for reviewer?** :
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [x] Bug fix. Fixes #2299 
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Commit has unit tests
- [ ] Commit has integration tests

<!--

The PR title message must follow convention:
`<type>(<scope>): <subject>`.

Where: <br />
- `type` is to define what type of PR is this.
  Most common types are:
    - `feat`      - for new features, not a new feature for build script
    - `fix`       - for bug fixes or improvements, not a fix for build script
    - `chore`     - changes not related to production code
    - `docs`      - changes related to documentation
    - `style`     - formatting, missing semi colons, linting fix etc; no significant production code changes
    - `test`      - adding missing tests, refactoring tests; no production code change
    - `refactor`  - refactoring production code, eg. renaming a variable or function name, there should not be any significant production code changes

- `scope` is a single word that best describes where the changes fit.
    - feature(`monitor`,`enforcer`)
    - test(`tests`, `bdd`)
    - chore(`build`)
- `subject` is a single line brief description of the changes made in the pull request.

-->