### PR TITLE
Add missing fields in PRESET alerts 

### DIFF
--- a/KubeArmor/presets/base/basePreset.go
+++ b/KubeArmor/presets/base/basePreset.go
@@ -15,6 +15,18 @@ const (
 	PRESET_ENFORCER string = "PRESET-"
 )
 
+// NSkey struct
+type NsKey struct {
+	PidNS uint32
+	MntNS uint32
+}
+
+// ContainerVal struct
+type ContainerVal struct {
+	NsKey  NsKey
+	Policy tp.MatchPolicy
+}
+
 // PresetType represents type of a preset
 type PresetType uint8
 

--- a/KubeArmor/presets/base/common.go
+++ b/KubeArmor/presets/base/common.go
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 Authors of KubeArmor
+
+package base
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/kubearmor/KubeArmor/KubeArmor/buildinfo"
+	tp "github.com/kubearmor/KubeArmor/KubeArmor/types"
+)
+
+func AddPolicyLogInfo(log *tp.Log, ckv *ContainerVal) {
+	log.PolicyName = ckv.Policy.PolicyName
+	if len(ckv.Policy.Tags) > 0 {
+		log.Tags = strings.Join(ckv.Policy.Tags[:], ",")
+		log.ATags = ckv.Policy.Tags
+	}
+	log.Severity = ckv.Policy.Severity
+	log.Message = ckv.Policy.Message
+	log.Type = "MatchedPolicy"
+	log.KubeArmorVersion = buildinfo.GitSummary
+}
+func UpdateMatchPolicy(ckv *ContainerVal, secPolicy *tp.SecurityPolicy) {
+	ckv.Policy.PolicyName = secPolicy.Metadata["policyName"]
+	ckv.Policy.Severity = strconv.Itoa(secPolicy.Spec.Severity)
+	ckv.Policy.Message = secPolicy.Spec.Message
+	ckv.Policy.Tags = secPolicy.Spec.Tags
+}

--- a/KubeArmor/presets/exec/preset.go
+++ b/KubeArmor/presets/exec/preset.go
@@ -37,18 +37,6 @@ const (
 	NAME string = "ExecPreset"
 )
 
-// NsKey struct
-type NsKey struct {
-	PidNS uint32
-	MntNS uint32
-}
-
-// ContainerVal struct
-type ContainerVal struct {
-	NsKey  NsKey
-	Policy string
-}
-
 // Preset struct
 type Preset struct {
 	base.Preset
@@ -60,7 +48,7 @@ type Preset struct {
 	EventsChannel chan []byte
 
 	// ContainerID -> NsKey
-	ContainerMap     map[string]ContainerVal
+	ContainerMap     map[string]base.ContainerVal
 	ContainerMapLock *sync.RWMutex
 
 	Link link.Link
@@ -71,7 +59,7 @@ type Preset struct {
 // NewExecPreset creates an instance of Exec Preset
 func NewExecPreset() *Preset {
 	p := &Preset{}
-	p.ContainerMap = make(map[string]ContainerVal)
+	p.ContainerMap = make(map[string]base.ContainerVal)
 	p.ContainerMapLock = new(sync.RWMutex)
 	return p
 }
@@ -201,8 +189,7 @@ func (p *Preset) TraceEvents() {
 		}, readLink)
 
 		if ckv, ok := p.ContainerMap[containerID]; ok {
-			log.PolicyName = ckv.Policy
-			log.Type = "MatchedPolicy"
+			base.AddPolicyLogInfo(&log, &ckv)
 		}
 
 		log.Operation = "Process"
@@ -235,12 +222,12 @@ func (p *Preset) TraceEvents() {
 
 // RegisterContainer registers a container to exec preset
 func (p *Preset) RegisterContainer(containerID string, pidns, mntns uint32) {
-	ckv := NsKey{PidNS: pidns, MntNS: mntns}
+	ckv := base.NsKey{PidNS: pidns, MntNS: mntns}
 
 	p.ContainerMapLock.Lock()
 	defer p.ContainerMapLock.Unlock()
 	p.Logger.Debugf("[Exec] Registered container with id: %s\n", containerID)
-	p.ContainerMap[containerID] = ContainerVal{NsKey: ckv}
+	p.ContainerMap[containerID] = base.ContainerVal{NsKey: ckv}
 }
 
 // UnregisterContainer func unregisters a container from exec preset
@@ -259,7 +246,7 @@ func (p *Preset) UnregisterContainer(containerID string) {
 }
 
 // AddContainerIDToMap adds a container id to ebpf map
-func (p *Preset) AddContainerIDToMap(id string, ckv NsKey, action string) error {
+func (p *Preset) AddContainerIDToMap(id string, ckv base.NsKey, action string) error {
 	p.Logger.Debugf("[Exec] adding container with id to exec_map exec map: %s\n", id)
 	a := base.Block
 	if action == "Audit" {
@@ -273,7 +260,7 @@ func (p *Preset) AddContainerIDToMap(id string, ckv NsKey, action string) error 
 }
 
 // DeleteContainerIDFromMap deletes a container id from ebpf map
-func (p *Preset) DeleteContainerIDFromMap(id string, ckv NsKey) error {
+func (p *Preset) DeleteContainerIDFromMap(id string, ckv base.NsKey) error {
 	p.Logger.Debugf("[Exec] deleting container with id to exec_map exec map: %s\n", id)
 	if err := p.BPFContainerMap.Delete(ckv); err != nil {
 		if !errors.Is(err, os.ErrNotExist) {
@@ -305,7 +292,7 @@ func (p *Preset) UpdateSecurityPolicies(endPoint tp.EndPoint) {
 
 						return
 					}
-					ckv.Policy = secPolicy.Metadata["policyName"]
+					base.UpdateMatchPolicy(&ckv, &secPolicy)
 					p.ContainerMapLock.Lock()
 					p.ContainerMap[cid] = ckv
 					err := p.AddContainerIDToMap(cid, ckv.NsKey, preset.Action)

--- a/KubeArmor/presets/filelessexec/preset.go
+++ b/KubeArmor/presets/filelessexec/preset.go
@@ -39,18 +39,6 @@ const (
 	NAME string = "FilelessExecutionPreset"
 )
 
-// NsKey struct
-type NsKey struct {
-	PidNS uint32
-	MntNS uint32
-}
-
-// ContainerVal struct
-type ContainerVal struct {
-	NsKey  NsKey
-	Policy string
-}
-
 // Preset struct
 type Preset struct {
 	base.Preset
@@ -62,7 +50,7 @@ type Preset struct {
 	EventsChannel chan []byte
 
 	// ContainerID -> NsKey
-	ContainerMap     map[string]ContainerVal
+	ContainerMap     map[string]base.ContainerVal
 	ContainerMapLock *sync.RWMutex
 
 	Link link.Link
@@ -73,7 +61,7 @@ type Preset struct {
 // NewFilelessExecPreset creates an instance of FilelessExec Preset
 func NewFilelessExecPreset() *Preset {
 	p := &Preset{}
-	p.ContainerMap = make(map[string]ContainerVal)
+	p.ContainerMap = make(map[string]base.ContainerVal)
 	p.ContainerMapLock = new(sync.RWMutex)
 	return p
 }
@@ -200,8 +188,7 @@ func (p *Preset) TraceEvents() {
 		}, readLink)
 
 		if ckv, ok := p.ContainerMap[containerID]; ok {
-			log.PolicyName = ckv.Policy
-			log.Type = "MatchedPolicy"
+			base.AddPolicyLogInfo(&log, &ckv)
 		}
 
 		log.Operation = "Process"
@@ -237,12 +224,11 @@ func (p *Preset) TraceEvents() {
 
 // RegisterContainer registers a container to filelessexec preset
 func (p *Preset) RegisterContainer(containerID string, pidns, mntns uint32) {
-	ckv := NsKey{PidNS: pidns, MntNS: mntns}
-
+	ckv := base.NsKey{PidNS: pidns, MntNS: mntns}
 	p.ContainerMapLock.Lock()
 	defer p.ContainerMapLock.Unlock()
 	p.Logger.Debugf("[FilelessExec] Registered container with id: %s\n", containerID)
-	p.ContainerMap[containerID] = ContainerVal{NsKey: ckv}
+	p.ContainerMap[containerID] = base.ContainerVal{NsKey: ckv}
 }
 
 // UnregisterContainer func unregisters a container from filelessexec preset
@@ -261,7 +247,7 @@ func (p *Preset) UnregisterContainer(containerID string) {
 }
 
 // AddContainerIDToMap adds a container id to ebpf map
-func (p *Preset) AddContainerIDToMap(id string, ckv NsKey, action string) error {
+func (p *Preset) AddContainerIDToMap(id string, ckv base.NsKey, action string) error {
 	p.Logger.Debugf("[FilelessExec] adding container with id to fileless_map exec map: %s\n", id)
 	a := base.Block
 	if action == "Audit" {
@@ -275,7 +261,7 @@ func (p *Preset) AddContainerIDToMap(id string, ckv NsKey, action string) error 
 }
 
 // DeleteContainerIDFromMap deletes a container id from ebpf map
-func (p *Preset) DeleteContainerIDFromMap(id string, ckv NsKey) error {
+func (p *Preset) DeleteContainerIDFromMap(id string, ckv base.NsKey) error {
 	p.Logger.Debugf("[FilelessExec] deleting container with id to fileless_map exec map: %s\n", id)
 	if err := p.BPFContainerMap.Delete(ckv); err != nil {
 		if !errors.Is(err, os.ErrNotExist) {
@@ -307,7 +293,7 @@ func (p *Preset) UpdateSecurityPolicies(endPoint tp.EndPoint) {
 
 						return
 					}
-					ckv.Policy = secPolicy.Metadata["policyName"]
+					base.UpdateMatchPolicy(&ckv, &secPolicy)
 					p.ContainerMapLock.Lock()
 					p.ContainerMap[cid] = ckv
 					err := p.AddContainerIDToMap(cid, ckv.NsKey, preset.Action)


### PR DESCRIPTION
**Purpose of PR?**:

Fixes #2302

```json
{
  "Timestamp": 1765272001,
  "UpdatedTime": "2025-12-09T09:20:01.450811Z",
  "ClusterName": "default",
  "HostName": "aryan",
  "NamespaceName": "presets",
  "Owner": {
    "Ref": "Deployment",
    "Name": "fileless",
    "Namespace": "presets"
  },
  "PodName": "fileless-867bc8c769-g7mr5",
  "Labels": "app=fileless",
  "ContainerID": "af796c9c6d48dba28a5190336fcbea6c16b05904ec86af2175c463662b97a72a",
  "ContainerName": "fileless",
  "ContainerImage": "docker.io/kubearmor/ubuntu-w-utils:0.2@sha256:3e51e92a839b5e8f0dba01e08ec21fa2c1afe85111544a45aba29708c52de44f",
  "HostPPID": 3494068,
  "HostPID": 3625937,
  "PPID": 3494068,
  "PID": 110,
  "UID": 0,
  "ParentProcessName": "/usr/bin/dash",
  "ProcessName": "/proc/self/fd/3",
  "PolicyName": "ksp-preset-block-fileless",
  "Severity": "8",
  "Tags": "MITRE,VDSFKR",
  "ATags": [
    "MITRE",
    "VDSFKR"
  ],
  "Message": "Fileless execution is blocked",
  "Type": "MatchedPolicy",
  "Source": "/proc/self/fd/3",
  "Operation": "Process",
  "Resource": "memfd:",
  "Enforcer": "PRESET-FilelessExecutionPreset",
  "Action": "Block",
  "Result": "Permission denied",
  "Cwd": "/",
  "TTY": "pts0",
  "ExecEvent": {
    "ExecID": "15573283688141239",
    "ExecutableName": "python3"
  },
  "KubeArmorVersion": "v1.6.5-6-g01320956-dirty",
  "NodeID": "efc78266a44e507e428f499e4b92f75d2762926c45050a2ff15b16d834dd415f"
}

```

**Does this PR introduce a breaking change?**

**If the changes in this PR are manually verified, list down the scenarios covered:**:

**Additional information for reviewer?** :
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [ ] Bug fix. Fixes #<issue number>
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Commit has unit tests
- [ ] Commit has integration tests

<!--

The PR title message must follow convention:
`<type>(<scope>): <subject>`.

Where: <br />
- `type` is to define what type of PR is this.
  Most common types are:
    - `feat`      - for new features, not a new feature for build script
    - `fix`       - for bug fixes or improvements, not a fix for build script
    - `chore`     - changes not related to production code
    - `docs`      - changes related to documentation
    - `style`     - formatting, missing semi colons, linting fix etc; no significant production code changes
    - `test`      - adding missing tests, refactoring tests; no production code change
    - `refactor`  - refactoring production code, eg. renaming a variable or function name, there should not be any significant production code changes

- `scope` is a single word that best describes where the changes fit.
    - feature(`monitor`,`enforcer`)
    - test(`tests`, `bdd`)
    - chore(`build`)
- `subject` is a single line brief description of the changes made in the pull request.

-->