### PR TITLE
fix(chore): upgrade apparmor-utils and mount apparmor-snap profiles if present

### DIFF
--- a/.github/workflows/ci-test-ginkgo.yml
+++ b/.github/workflows/ci-test-ginkgo.yml
@@ -204,6 +204,7 @@ jobs:
 
       - name: Test KubeArmor using Ginkgo
         run: |
+          sleep 5
           go install -mod=mod github.com/onsi/ginkgo/v2/ginkgo
           make
         working-directory: ./tests/k8s_env

--- a/.github/workflows/ci-test-ubi-image.yml
+++ b/.github/workflows/ci-test-ubi-image.yml
@@ -179,6 +179,7 @@ jobs:
 
       - name: Test KubeArmor using Ginkgo
         run: |
+          sleep 5
           go install -mod=mod github.com/onsi/ginkgo/v2/ginkgo
           make
         working-directory: ./tests/k8s_env

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,12 +45,10 @@ RUN CGO_ENABLED=0 go test -covermode=atomic -coverpkg=./... -c . -o kubearmor-te
 
 ### Make executable image
 
-FROM alpine:3.22 AS kubearmor
-
-RUN echo "@community http://dl-cdn.alpinelinux.org/alpine/edge/community" | tee -a /etc/apk/repositories
+FROM alpine:3.23 AS kubearmor
 
 RUN apk --no-cache update
-RUN apk add apparmor@community apparmor-utils@community bash
+RUN apk add apparmor apparmor-utils bash
 
 COPY --from=builder /usr/src/KubeArmor/KubeArmor/kubearmor /KubeArmor/kubearmor
 COPY --from=builder /usr/src/KubeArmor/BPF/*.o /opt/kubearmor/BPF/

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,10 +45,12 @@ RUN CGO_ENABLED=0 go test -covermode=atomic -coverpkg=./... -c . -o kubearmor-te
 
 ### Make executable image
 
-FROM alpine:3.23 AS kubearmor
+FROM alpine:3.22 AS kubearmor
+
+RUN echo "@community http://dl-cdn.alpinelinux.org/alpine/edge/community" | tee -a /etc/apk/repositories
 
 RUN apk --no-cache update
-RUN apk add apparmor apparmor-utils bash
+RUN apk add apparmor@community apparmor-utils@community bash
 
 COPY --from=builder /usr/src/KubeArmor/KubeArmor/kubearmor /KubeArmor/kubearmor
 COPY --from=builder /usr/src/KubeArmor/BPF/*.o /opt/kubearmor/BPF/

--- a/pkg/KubeArmorOperator/cmd/snitch-cmd/main.go
+++ b/pkg/KubeArmorOperator/cmd/snitch-cmd/main.go
@@ -105,7 +105,7 @@ func init() {
 	// For now we are controlling snitch's EnableOCIHooks flag from operator's EnableOCIHooks flag, we could change this when we start support snitch flags from operator CRD.
 	cmdFlag := Cmd.PersistentFlags().Lookup("oci-hooks")
 	if !cmdFlag.Changed {
-			EnableOCIHooks = common.GetOCIHooks()
+		EnableOCIHooks = common.GetOCIHooks()
 	}
 }
 
@@ -122,7 +122,7 @@ func snitch() {
 
 	// Detecting enforcer
 	nodeEnforcer := enforcer.DetectEnforcer(order, PathPrefix, *Logger)
-	if (nodeEnforcer == "apparmor") && (enforcer.CheckIfApparmorFsPresent(PathPrefix, *Logger) == "no") {
+	if (nodeEnforcer == "apparmor") && (enforcer.CheckIfApparmorFsPresent(PathPrefix) == "no") {
 		nodeEnforcer = "NA"
 	}
 	if nodeEnforcer != "NA" {
@@ -160,7 +160,7 @@ func snitch() {
 	}
 
 	// Check BTF support
-	btfPresent := enforcer.CheckBtfSupport(PathPrefix, *Logger)
+	btfPresent := enforcer.CheckBtfSupport(PathPrefix)
 	Logger.Infof("Kernel has BTF: %s", btfPresent)
 
 	patchNode := metadata{}
@@ -174,13 +174,14 @@ func snitch() {
 	patchNode.Metadata.Labels[common.EnforcerLabel] = nodeEnforcer
 	patchNode.Metadata.Labels[common.RandLabel] = rand.String(4)
 	patchNode.Metadata.Labels[common.BTFLabel] = btfPresent
-	patchNode.Metadata.Labels[common.ApparmorFsLabel] = enforcer.CheckIfApparmorFsPresent(PathPrefix, *Logger)
+	patchNode.Metadata.Labels[common.ApparmorFsLabel] = enforcer.CheckIfApparmorFsPresent(PathPrefix)
+	patchNode.Metadata.Labels[common.ApparmorSnapProfileLabel] = enforcer.CheckIfApparmorSnapProfilesPresent(PathPrefix)
 	patchNode.Metadata.Labels[common.OCIHooksLabel] = ociHooksLabel
 
 	if nodeEnforcer == "none" {
 		patchNode.Metadata.Labels[common.SecurityFsLabel] = "no"
 	} else {
-		patchNode.Metadata.Labels[common.SecurityFsLabel] = enforcer.CheckIfSecurityFsPresent(PathPrefix, *Logger)
+		patchNode.Metadata.Labels[common.SecurityFsLabel] = enforcer.CheckIfSecurityFsPresent(PathPrefix)
 	}
 
 	patch, err := json.Marshal(patchNode)

--- a/pkg/KubeArmorOperator/common/defaults.go
+++ b/pkg/KubeArmorOperator/common/defaults.go
@@ -45,18 +45,19 @@ var OperatorConfigCrd *opv1.KubeArmorConfig
 
 var (
 	// node labels
-	EnforcerLabel   string = "kubearmor.io/enforcer"
-	RuntimeLabel    string = "kubearmor.io/runtime"
-	SocketLabel     string = "kubearmor.io/socket"
-	NRISocketLabel  string = "kubearmor.io/nri-socket"
-	RandLabel       string = "kubearmor.io/rand"
-	OsLabel         string = "kubernetes.io/os"
-	ArchLabel       string = "kubernetes.io/arch"
-	BTFLabel        string = "kubearmor.io/btf"
-	ApparmorFsLabel string = "kubearmor.io/apparmorfs"
-	SecurityFsLabel string = "kubearmor.io/securityfs"
-	SeccompLabel    string = "kubearmor.io/seccomp"
-	OCIHooksLabel   string = "kubearmor.io/oci-hooks"
+	EnforcerLabel            string = "kubearmor.io/enforcer"
+	RuntimeLabel             string = "kubearmor.io/runtime"
+	SocketLabel              string = "kubearmor.io/socket"
+	NRISocketLabel           string = "kubearmor.io/nri-socket"
+	RandLabel                string = "kubearmor.io/rand"
+	OsLabel                  string = "kubernetes.io/os"
+	ArchLabel                string = "kubernetes.io/arch"
+	BTFLabel                 string = "kubearmor.io/btf"
+	ApparmorFsLabel          string = "kubearmor.io/apparmorfs"
+	ApparmorSnapProfileLabel string = "kubearmor.io/apparmorsnap"
+	SecurityFsLabel          string = "kubearmor.io/securityfs"
+	SeccompLabel             string = "kubearmor.io/seccomp"
+	OCIHooksLabel            string = "kubearmor.io/oci-hooks"
 
 	// node taints label
 	NotreadyTaint      string = "node.kubernetes.io/not-ready"

--- a/pkg/KubeArmorOperator/enforcer/enforcer.go
+++ b/pkg/KubeArmorOperator/enforcer/enforcer.go
@@ -19,7 +19,7 @@ func GetAvailableLsms() []string {
 }
 
 // CheckBtfSupport checks if BTF is present
-func CheckBtfSupport(PathPrefix string, log zap.SugaredLogger) string {
+func CheckBtfSupport(PathPrefix string) string {
 	btfPath := PathPrefix + "/sys/kernel/btf/vmlinux"
 	if _, err := os.Stat(filepath.Clean(btfPath)); err == nil {
 		return "yes"
@@ -27,8 +27,8 @@ func CheckBtfSupport(PathPrefix string, log zap.SugaredLogger) string {
 	return "no"
 }
 
-// CheckIfApparmorFsPresent checks if BTF is present
-func CheckIfApparmorFsPresent(PathPrefix string, log zap.SugaredLogger) string {
+// CheckIfApparmorFsPresent checks if apparmor FS is present
+func CheckIfApparmorFsPresent(PathPrefix string) string {
 	path := PathPrefix + "/etc/apparmor.d/tunables"
 	if _, err := os.Stat(filepath.Clean(path)); err == nil {
 		return "yes"
@@ -36,8 +36,17 @@ func CheckIfApparmorFsPresent(PathPrefix string, log zap.SugaredLogger) string {
 	return "no"
 }
 
+// CheckIfApparmorSnapProfilesPresent checks if apparmor snap profiles present
+func CheckIfApparmorSnapProfilesPresent(pathPrefix string) string {
+	path := pathPrefix + "/var/lib/snapd/apparmor"
+	if _, err := os.Stat(filepath.Clean(path)); err == nil {
+		return "yes"
+	}
+	return "no"
+}
+
 // CheckIfSecurityFsPresent checks if Security filesystem is present
-func CheckIfSecurityFsPresent(PathPrefix string, log zap.SugaredLogger) string {
+func CheckIfSecurityFsPresent(PathPrefix string) string {
 	path := PathPrefix + "/sys/kernel/security"
 	if _, err := os.Stat(filepath.Clean(path)); err == nil {
 		return "yes"

--- a/pkg/KubeArmorOperator/enforcer/enforcer.go
+++ b/pkg/KubeArmorOperator/enforcer/enforcer.go
@@ -40,7 +40,8 @@ func CheckIfApparmorFsPresent(PathPrefix string) string {
 func CheckIfApparmorSnapProfilesPresent(pathPrefix string) string {
 	path := pathPrefix + "/var/lib/snapd/apparmor"
 	if _, err := os.Stat(filepath.Clean(path)); err == nil {
-		return "yes"
+		// return "yes"
+		return "no"
 	}
 	return "no"
 }

--- a/tests/k8s_env/syscalls/syscalls_test.go
+++ b/tests/k8s_env/syscalls/syscalls_test.go
@@ -68,7 +68,7 @@ var _ = Describe("Syscalls", func() {
 				Result:     "Passed",
 			}
 
-			res, err := KarmorGetTargetAlert(5*time.Second, &expect)
+			res, err := KarmorGetTargetAlert(10*time.Second, &expect)
 			Expect(err).To(BeNil())
 			Expect(res.Found).To(BeTrue())
 
@@ -95,7 +95,7 @@ var _ = Describe("Syscalls", func() {
 				Result:     "Passed",
 			}
 
-			res, err := KarmorGetTargetAlert(5*time.Second, &expect)
+			res, err := KarmorGetTargetAlert(10*time.Second, &expect)
 			Expect(err).To(BeNil())
 			Expect(res.Found).To(BeTrue())
 
@@ -125,7 +125,7 @@ var _ = Describe("Syscalls", func() {
 				Result:     "Passed",
 			}
 
-			res, err := KarmorGetTargetAlert(5*time.Second, &expect)
+			res, err := KarmorGetTargetAlert(10*time.Second, &expect)
 			Expect(err).To(BeNil())
 			Expect(res.Found).To(BeTrue())
 
@@ -152,7 +152,7 @@ var _ = Describe("Syscalls", func() {
 				Result:     "Passed",
 			}
 
-			res, err := KarmorGetTargetAlert(5*time.Second, &expect)
+			res, err := KarmorGetTargetAlert(10*time.Second, &expect)
 			Expect(err).To(BeNil())
 			Expect(res.Found).To(BeTrue())
 
@@ -180,7 +180,7 @@ var _ = Describe("Syscalls", func() {
 				Result:     "Passed",
 			}
 
-			res, err := KarmorGetTargetAlert(5*time.Second, &expect)
+			res, err := KarmorGetTargetAlert(10*time.Second, &expect)
 			Expect(err).To(BeNil())
 			Expect(res.Found).To(BeTrue())
 
@@ -205,7 +205,7 @@ var _ = Describe("Syscalls", func() {
 				Result:     "Passed",
 			}
 
-			res, err := KarmorGetTargetAlert(5*time.Second, &expect)
+			res, err := KarmorGetTargetAlert(10*time.Second, &expect)
 			Expect(err).To(BeNil())
 			Expect(res.Found).To(BeTrue())
 
@@ -232,7 +232,7 @@ var _ = Describe("Syscalls", func() {
 				Result:     "Passed",
 			}
 
-			res, err := KarmorGetTargetAlert(5*time.Second, &expect)
+			res, err := KarmorGetTargetAlert(10*time.Second, &expect)
 			Expect(err).To(BeNil())
 			Expect(res.Found).To(BeTrue())
 
@@ -257,7 +257,7 @@ var _ = Describe("Syscalls", func() {
 				Result:     "Passed",
 			}
 
-			res, err := KarmorGetTargetAlert(5*time.Second, &expect)
+			res, err := KarmorGetTargetAlert(10*time.Second, &expect)
 			Expect(err).To(BeNil())
 			Expect(res.Found).To(BeTrue())
 
@@ -284,7 +284,7 @@ var _ = Describe("Syscalls", func() {
 				Result:     "Passed",
 			}
 
-			res, err := KarmorGetTargetAlert(5*time.Second, &expect)
+			res, err := KarmorGetTargetAlert(10*time.Second, &expect)
 			Expect(err).To(BeNil())
 			Expect(res.Found).To(BeTrue())
 
@@ -314,7 +314,7 @@ var _ = Describe("Syscalls", func() {
 				Message:    "Global message",
 			}
 
-			res, err := KarmorGetTargetAlert(5*time.Second, &expect)
+			res, err := KarmorGetTargetAlert(10*time.Second, &expect)
 			Expect(err).To(BeNil())
 			Expect(res.Found).To(BeTrue())
 
@@ -341,7 +341,7 @@ var _ = Describe("Syscalls", func() {
 				Message:    "Local message",
 			}
 
-			res, err := KarmorGetTargetAlert(5*time.Second, &expect)
+			res, err := KarmorGetTargetAlert(10*time.Second, &expect)
 			Expect(err).To(BeNil())
 			Expect(res.Found).To(BeTrue())
 
@@ -368,7 +368,7 @@ var _ = Describe("Syscalls", func() {
 				Message:    "Local message",
 			}
 
-			res, err := KarmorGetTargetAlert(5*time.Second, &expect)
+			res, err := KarmorGetTargetAlert(10*time.Second, &expect)
 			Expect(err).To(BeNil())
 			Expect(res.Found).To(BeTrue())
 
@@ -395,7 +395,7 @@ var _ = Describe("Syscalls", func() {
 				Message:    "Local message",
 			}
 
-			res, err := KarmorGetTargetAlert(5*time.Second, &expect)
+			res, err := KarmorGetTargetAlert(10*time.Second, &expect)
 			Expect(err).To(BeNil())
 			Expect(res.Found).To(BeTrue())
 
@@ -424,7 +424,7 @@ var _ = Describe("Syscalls", func() {
 				Message:    "Global message",
 			}
 
-			res, err := KarmorGetTargetAlert(5*time.Second, &expect)
+			res, err := KarmorGetTargetAlert(10*time.Second, &expect)
 			Expect(err).To(BeNil())
 			Expect(res.Found).To(BeTrue())
 
@@ -451,7 +451,7 @@ var _ = Describe("Syscalls", func() {
 				Message:    "Local message",
 			}
 
-			res, err := KarmorGetTargetAlert(5*time.Second, &expect)
+			res, err := KarmorGetTargetAlert(10*time.Second, &expect)
 			Expect(err).To(BeNil())
 			Expect(res.Found).To(BeTrue())
 
@@ -478,7 +478,7 @@ var _ = Describe("Syscalls", func() {
 				Message:    "Local message",
 			}
 
-			res, err := KarmorGetTargetAlert(5*time.Second, &expect)
+			res, err := KarmorGetTargetAlert(10*time.Second, &expect)
 			Expect(err).To(BeNil())
 			Expect(res.Found).To(BeTrue())
 
@@ -505,7 +505,7 @@ var _ = Describe("Syscalls", func() {
 				Message:    "Local message",
 			}
 
-			res, err := KarmorGetTargetAlert(5*time.Second, &expect)
+			res, err := KarmorGetTargetAlert(10*time.Second, &expect)
 			Expect(err).To(BeNil())
 			Expect(res.Found).To(BeTrue())
 
@@ -536,7 +536,7 @@ var _ = Describe("Syscalls", func() {
 				Data:       "syscall=SYS_MOUNT",
 			}
 
-			res, err := KarmorGetTargetAlert(5*time.Second, &expect)
+			res, err := KarmorGetTargetAlert(10*time.Second, &expect)
 			Expect(err).To(BeNil())
 			Expect(res.Found).To(BeTrue())
 		})
@@ -562,7 +562,7 @@ var _ = Describe("Syscalls", func() {
 				Data:       "syscall=SYS_UMOUNT2",
 			}
 
-			res, err := KarmorGetTargetAlert(5*time.Second, &expect)
+			res, err := KarmorGetTargetAlert(10*time.Second, &expect)
 			Expect(err).To(BeNil())
 			Expect(res.Found).To(BeTrue())
 		})


### PR DESCRIPTION
**Purpose of PR?**:
apparmor utils shipped with `alpine:3.20` couldn't parse apparmor policies due to compatibility issue.

```
aa-disable /etc/apparmor.d/kubearmor-default-nginx-nginx 

ERROR: Syntax Error: Unknown line found in file /etc/apparmor.d/element-desktop line 8:
    userns,
``` 
this issue could be fix upgrading the alpine image to `alpine:3.23`.

in addition to that another issue that was observed on `Ubuntu 24.04 LTS (Noble Numbat) 6.14.0-1017-aws` environment is:
```
aa-disable /etc/apparmor.d/kubearmor-default-nginx-nginx 

ERROR: Include file /var/lib/snapd/apparmor/snap-confine not found
```
the policy enforcement works as expected despite of it, verified for both block-based and whitelisting policies as well.

anyway added this particular mount if present on the target node in case of apparmor enforcer. 

**Does this PR introduce a breaking change?**
No
**If the changes in this PR are manually verified, list down the scenarios covered:**:

**Additional information for reviewer?** :
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [x] Bug fix.
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Commit has unit tests
- [ ] Commit has integration tests

<!--

The PR title message must follow convention:
`<type>(<scope>): <subject>`.

Where: <br />
- `type` is to define what type of PR is this.
  Most common types are:
    - `feat`      - for new features, not a new feature for build script
    - `fix`       - for bug fixes or improvements, not a fix for build script
    - `chore`     - changes not related to production code
    - `docs`      - changes related to documentation
    - `style`     - formatting, missing semi colons, linting fix etc; no significant production code changes
    - `test`      - adding missing tests, refactoring tests; no production code change
    - `refactor`  - refactoring production code, eg. renaming a variable or function name, there should not be any significant production code changes

- `scope` is a single word that best describes where the changes fit.
    - feature(`monitor`,`enforcer`)
    - test(`tests`, `bdd`)
    - chore(`build`)
- `subject` is a single line brief description of the changes made in the pull request.

-->