### PR TITLE
 Move KubeArmor Daemon to Context-Based Shutdown--phase-1

### DIFF
--- a/KubeArmor/core/containerdHandler.go
+++ b/KubeArmor/core/containerdHandler.go
@@ -583,7 +583,7 @@ func (dm *KubeArmorDaemon) UpdateContainerdContainer(ctx context.Context, contai
 }
 
 // MonitorContainerdEvents Function
-func (dm *KubeArmorDaemon) MonitorContainerdEvents() {
+func (dm *KubeArmorDaemon) MonitorContainerdEvents(ctx context.Context) {
 	dm.WgDaemon.Add(1)
 	defer dm.WgDaemon.Done()
 
@@ -608,6 +608,10 @@ func (dm *KubeArmorDaemon) MonitorContainerdEvents() {
 	}
 	for {
 		select {
+		case <-ctx.Done():
+			 dm.Logger.Print("Stopping containerd events monitor via context")
+        return
+		
 		case <-StopChan:
 			return
 

--- a/KubeArmor/core/dockerHandler.go
+++ b/KubeArmor/core/dockerHandler.go
@@ -779,7 +779,7 @@ func (dm *KubeArmorDaemon) UpdateDockerContainer(containerID, action string) {
 }
 
 // MonitorDockerEvents Function
-func (dm *KubeArmorDaemon) MonitorDockerEvents() {
+func (dm *KubeArmorDaemon) MonitorDockerEvents(ctx context.Context) {
 	dm.WgDaemon.Add(1)
 	defer dm.WgDaemon.Done()
 
@@ -795,13 +795,14 @@ func (dm *KubeArmorDaemon) MonitorDockerEvents() {
 
 	dm.Logger.Print("Started to monitor Docker events")
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
 	EventChan := Docker.GetEventChannel(ctx, StopChan)
 
 	for {
 		select {
+		case <-ctx.Done():
+			dm.Logger.Print("Stopping Docker event monitor via context")
+            return
+			
 		case <-StopChan:
 			return
 


### PR DESCRIPTION
Fixes #2295

**Purpose of PR?**:

Enhancement: **Phase-1 – Introduce context-based graceful shutdown for Docker event monitor.**

**Does this PR introduce a breaking change?**

No breaking changes — only internal enhancement to support context-driven shutdown.

**If the changes in this PR are manually verified, list down the scenarios covered:**:

- Start KubeArmor in non-K8s mode
- Trigger Docker events (create/stop containers)
- Press CTRL+C to terminate
- Verified logs show:
`  Stopping Docker event monitor via context`
- No goroutines remain stuck
- Shutdown completes cleanly

**Additional information for reviewer?** :
This is **Phase-1** of the context-shutdown migration (Docker monitor only).  
Next phases will cover containerd/CRIO/NRI and removing StopChan.


<img width="1034" height="278" alt="Screenshot 2025-12-10 130408" src="https://github.com/user-attachments/assets/c0021d07-a3ae-49b1-a882-69b5949b77c0" />

**Checklist:**
- [ ] Bug fix. Fixes #<issue number>
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Commit has unit tests
- [ ] Commit has integration tests
