### PR TITLE
Make untrackedNs configurable via Helm values

### DIFF
--- a/deployments/helm/KubeArmor/templates/daemonset.yaml
+++ b/deployments/helm/KubeArmor/templates/daemonset.yaml
@@ -30,6 +30,11 @@ spec:
         {{printf "- -tlsEnabled=%t" .Values.tls.enabled}}
         {{printf "- -tlsCertPath=%s" .Values.kubearmor.tls.tlsCertPath}}
         {{printf "- -tlsCertProvider=%s" .Values.kubearmor.tls.tlsCertProvider}}
+        {{- if .Values.kubearmor.args }}
+        {{- range .Values.kubearmor.args }}
+        - {{ . | quote }}
+        {{- end }}
+        {{- end }}
         image: {{printf "%s:%s" .Values.kubearmor.image.repository .Values.kubearmor.image.tag}}
         imagePullPolicy: {{ .Values.kubearmor.imagePullPolicy }}
         env:

--- a/deployments/helm/KubeArmor/values.yaml
+++ b/deployments/helm/KubeArmor/values.yaml
@@ -124,7 +124,8 @@ kubearmor:
   imagePullPolicy: Always
 
   # kubearmor daemonset arguments. See `kubearmor --help`
-  args: []
+  args:
+      - "--untrackedNs=kube-system,kubearmor"
 
   tls:
     tlsCertPath: /var/lib/kubearmor/tls


### PR DESCRIPTION
**Purpose of PR?**:

Expose `kubearmor.args` in the Helm DaemonSet template so that users can configure runtime flags such as `--untrackedNs` through `values.yaml`.

Fixes #2315

**Does this PR introduce a breaking change?**

No.  
This change is backward-compatible. If `kubearmor.args` is not set, the chart behaves exactly as before.

**If the changes in this PR are manually verified, list down the scenarios covered:**

- Added the following in `values.yaml`:
  ```yaml
  kubearmor:
    args:
      - "--untrackedNs=kube-system,kubearmor"
  ```
- Installed/updated the Helm chart using:
  ```bash
  helm upgrade --install kubearmor . -n kubearmor --create-namespace
  ```
- Verified the DaemonSet template now includes the passed arguments:
  ```bash
  kubectl get daemonset -n kubearmor -o jsonpath='{.items[0].spec.template.spec.containers[0].args}'
  ```
  Output shows:
  ```
  ["-gRPC=32767","-tlsEnabled=false","...","--untrackedNs=kube-system,kubearmor"]
  ```
- Confirmed KubeArmor runtime logs reflect untracked namespaces:
  ```
  untrackedNs: kube-system,kubearmor
  Policy cannot be enforced in untracked namespace kubearmor
  ```
- Verified that if no custom args are provided, default behavior continues unchanged.

**Additional information for reviewer?** :

This PR addresses an issue where updating `untrackedNs` in configuration had no effect because the Helm chart did not forward user-provided args to the DaemonSet.  
The fix introduces templating logic to append `kubearmor.args` into the DaemonSet container arguments.  
This makes the chart more flexible and allows configuring any future CLI flags through `values.yaml`.

_Mention if this PR is part of any design or a continuation of previous PRs_:  
This PR is standalone and not part of a larger design change.

---


### Steps to Reproduce

1. Added the following in `values.yaml`:
   ```yaml
   kubearmor:
     args:
       - "--untrackedNs=kube-system,kubearmor"
   ```
2. Deployed the chart:
   ```bash
   helm upgrade --install kubearmor . -n kubearmor --create-namespace
   ```
3. Checked DaemonSet arguments:
   ```bash
   kubectl get daemonset -n kubearmor \
     -o jsonpath='{.items[0].spec.template.spec.containers[0].args}'
   ```
4. Observed that the output **did not** contain the `--untrackedNs` argument.



<img width="1107" height="147" alt="Screenshot 2025-12-12 230057" src="https://github.com/user-attachments/assets/e9902c96-4cb1-4cba-9a57-7ea3b640da9f" />


### **After applying the patch** 

<img width="1090" height="868" alt="Screenshot 2025-12-12 211423" src="https://github.com/user-attachments/assets/30fbe14e-a5f6-4e8d-b516-aedcbb695d17" />


**Checklist:**
- [x] Bug fix. Fixes #2315
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] PR Title follows the convention of `<type>(<scope>): <subject>`
- [ ] Commit has unit tests
- [ ] Commit has integration tests
