### PR TITLE
Fix config watcher untracked ns

### DIFF
--- a/KubeArmor/config/config.go
+++ b/KubeArmor/config/config.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"sync/atomic"
 
 	kg "github.com/kubearmor/KubeArmor/KubeArmor/log"
 	"github.com/spf13/viper"
@@ -51,13 +52,13 @@ type KubearmorConfig struct {
 	HostDefaultCapabilitiesPosture string // Default Enforcement Action in Global Capabilities Context
 	HostDefaultDevicePosture       string // Default Enforcement Action in Global USB Device Conntext
 
-	CoverageTest       bool     // Enable/Disable Coverage Test
-	ConfigUntrackedNs  []string // untracked namespaces
-	LsmOrder           []string // LSM order
-	BPFFsPath          string   // path to the BPF filesystem
-	EnforcerAlerts     bool     // policy enforcer
-	DefaultPostureLogs bool     // Enable/Disable Default Posture logs for AppArmor LSM
-	InitTimeout        string   // Timeout for main thread init stages
+	CoverageTest       bool         // Enable/Disable Coverage Test
+	ConfigUntrackedNs  atomic.Value // untracked namespaces
+	LsmOrder           []string     // LSM order
+	BPFFsPath          string       // path to the BPF filesystem
+	EnforcerAlerts     bool         // policy enforcer
+	DefaultPostureLogs bool         // Enable/Disable Default Posture logs for AppArmor LSM
+	InitTimeout        string       // Timeout for main thread init stages
 
 	StateAgent  bool // enable KubeArmor state agent
 	UseOCIHooks bool
@@ -347,7 +348,7 @@ func LoadConfig() error {
 
 	GlobalCfg.CoverageTest = viper.GetBool(ConfigCoverageTest)
 
-	GlobalCfg.ConfigUntrackedNs = strings.Split(viper.GetString(ConfigUntrackedNs), ",")
+	GlobalCfg.ConfigUntrackedNs.Store(strings.Split(viper.GetString(ConfigUntrackedNs), ","))
 
 	GlobalCfg.LsmOrder = strings.Split(viper.GetString(LsmOrder), ",")
 

--- a/KubeArmor/core/kubeUpdate.go
+++ b/KubeArmor/core/kubeUpdate.go
@@ -362,7 +362,8 @@ func (dm *KubeArmorDaemon) UpdateEndPointWithPod(action string, pod tp.K8sPod) {
 				dm.Logger.UpdateSecurityPolicies(action, endpoint)
 				if newPoint.PolicyEnabled == tp.KubeArmorPolicyEnabled {
 					// enforce security policies
-					if !kl.ContainsElement(dm.SystemMonitor.UntrackedNamespaces, endpoint.NamespaceName) {
+					if !kl.ContainsElement(cfg.GlobalCfg.ConfigUntrackedNs.Load().([]string), endpoint.NamespaceName) || action == deleteEvent {
+						// we want to avoid new policies in untracked namespaces but deletion of the existing policies should be allowed
 						if dm.RuntimeEnforcer != nil {
 							dm.RuntimeEnforcer.UpdateSecurityPolicies(endpoint)
 						}
@@ -547,7 +548,8 @@ func (dm *KubeArmorDaemon) UpdateEndPointWithPod(action string, pod tp.K8sPod) {
 
 					if endpoint.PolicyEnabled == tp.KubeArmorPolicyEnabled {
 						// enforce security policies
-						if !kl.ContainsElement(dm.SystemMonitor.UntrackedNamespaces, endpoint.NamespaceName) {
+						if !kl.ContainsElement(cfg.GlobalCfg.ConfigUntrackedNs.Load().([]string), endpoint.NamespaceName) || action == deleteEvent {
+							// we want to avoid new policies in untracked namespaces but deletion of the existing policies should be allowed
 							if dm.RuntimeEnforcer != nil {
 								dm.RuntimeEnforcer.UpdateSecurityPolicies(endpoint)
 							}
@@ -1165,7 +1167,8 @@ func (dm *KubeArmorDaemon) UpdateSecurityPolicy(action string, secPolicyType str
 
 					if dm.EndPoints[idx].PolicyEnabled == tp.KubeArmorPolicyEnabled {
 						// enforce security policies
-						if !kl.ContainsElement(dm.SystemMonitor.UntrackedNamespaces, dm.EndPoints[idx].NamespaceName) {
+						if !kl.ContainsElement(cfg.GlobalCfg.ConfigUntrackedNs.Load().([]string), dm.EndPoints[idx].NamespaceName) || action == deleteEvent {
+							// we want to avoid new policies in untracked namespaces but deletion of the existing policies should be allowed
 							if dm.RuntimeEnforcer != nil {
 								dm.RuntimeEnforcer.UpdateSecurityPolicies(dm.EndPoints[idx])
 							}
@@ -1238,7 +1241,8 @@ func (dm *KubeArmorDaemon) UpdateSecurityPolicy(action string, secPolicyType str
 
 					if dm.EndPoints[idx].PolicyEnabled == tp.KubeArmorPolicyEnabled {
 						// enforce security policies
-						if !kl.ContainsElement(dm.SystemMonitor.UntrackedNamespaces, dm.EndPoints[idx].NamespaceName) {
+						if !kl.ContainsElement(cfg.GlobalCfg.ConfigUntrackedNs.Load().([]string), dm.EndPoints[idx].NamespaceName) || action == deleteEvent {
+							// we want to avoid new policies in untracked namespaces but deletion of the existing policies should be allowed
 							if dm.RuntimeEnforcer != nil {
 								dm.RuntimeEnforcer.UpdateSecurityPolicies(dm.EndPoints[idx])
 							}
@@ -2609,7 +2613,7 @@ func (dm *KubeArmorDaemon) UpdateDefaultPostureWithCM(endPoint *tp.EndPoint, act
 		if dm.RuntimeEnforcer != nil {
 			if endPoint.PolicyEnabled == tp.KubeArmorPolicyEnabled {
 				// enforce security policies
-				if !kl.ContainsElement(dm.SystemMonitor.UntrackedNamespaces, endPoint.NamespaceName) {
+				if !kl.ContainsElement(cfg.GlobalCfg.ConfigUntrackedNs.Load().([]string), endPoint.NamespaceName) {
 					dm.RuntimeEnforcer.UpdateSecurityPolicies(*endPoint)
 				} else {
 					dm.Logger.Warnf("Policy cannot be enforced in untracked namespace %s", endPoint.NamespaceName)
@@ -2684,7 +2688,7 @@ func (dm *KubeArmorDaemon) UpdateDefaultPosture(action string, namespace string,
 				if dm.RuntimeEnforcer != nil {
 					if endPoint.PolicyEnabled == tp.KubeArmorPolicyEnabled {
 						// enforce security policies
-						if !kl.ContainsElement(dm.SystemMonitor.UntrackedNamespaces, endPoint.NamespaceName) {
+						if !kl.ContainsElement(cfg.GlobalCfg.ConfigUntrackedNs.Load().([]string), endPoint.NamespaceName) {
 							dm.RuntimeEnforcer.UpdateSecurityPolicies(endPoint)
 						} else {
 							dm.Logger.Warnf("Policy cannot be enforced in untracked namespace %s", endPoint.NamespaceName)
@@ -2770,10 +2774,10 @@ func (dm *KubeArmorDaemon) updateVisibilityWithCM(cm *corev1.ConfigMap, _ string
 	}
 
 	for _, ns := range nsList.Items {
-
 		// 1. If namespace is untracked → explicitly remove visibility
-		if kl.ContainsElement(dm.SystemMonitor.UntrackedNamespaces, ns.Name) {
-			dm.UpdateVisibility(deleteEvent, ns.Name, tp.Visibility{})
+		if kl.ContainsElement(cfg.GlobalCfg.ConfigUntrackedNs.Load().([]string), ns.Name) {
+			//update visibility to empty for untracked namespaces
+			dm.UpdateVisibility(updateEvent, ns.Name, tp.Visibility{})
 			continue
 		}
 
@@ -2936,9 +2940,7 @@ func (dm *KubeArmorDaemon) WatchConfigMap() cache.InformerSynced {
 				dm.Node.ClusterName = cm.Data[cfg.ConfigCluster]
 				dm.NodeLock.Unlock()
 				if v, ok := cm.Data[cfg.ConfigUntrackedNs]; ok {
-					dm.SystemMonitor.UpdateUntrackedNamespaces(v)
-					dm.Logger.Printf("initial untracked namespaces set: %s", v)
-
+					UpdateUntrackedNamespaces(v)
 				}
 				if _, ok := cm.Data[cfg.ConfigDefaultPostureLogs]; ok {
 					cfg.GlobalCfg.DefaultPostureLogs = (cm.Data[cfg.ConfigDefaultPostureLogs] == "true")
@@ -3021,9 +3023,9 @@ func (dm *KubeArmorDaemon) WatchConfigMap() cache.InformerSynced {
 				dm.updatEndpointsWithCM(cm, updateEvent)
 
 				// forward untracked namespaces to SystemMonitor
-				dm.SystemMonitor.UpdateUntrackedNamespaces(
-					cm.Data[cfg.ConfigUntrackedNs],
-				)
+				if v, ok := cm.Data[cfg.ConfigUntrackedNs]; ok {
+					UpdateUntrackedNamespaces(v)
+				}
 
 				// visibility updates are already handled here
 				dm.updateVisibilityWithCM(cm, updateEvent)
@@ -3121,4 +3123,17 @@ func (dm *KubeArmorDaemon) GetConfigMapNS() string {
 		return "kubearmor"
 	}
 	return envNamespace
+}
+
+// UpdateUntrackedNamespaces updates the runtime untracked namespaces list.
+func UpdateUntrackedNamespaces(v string) {
+	parts := strings.Split(v, ",")
+
+	namespaces := make([]string, 0, len(parts))
+	for _, ns := range parts {
+		if ns = strings.TrimSpace(ns); ns != "" {
+			namespaces = append(namespaces, ns)
+		}
+	}
+	cfg.GlobalCfg.ConfigUntrackedNs.Store(namespaces)
 }

--- a/KubeArmor/feeder/feeder_test.go
+++ b/KubeArmor/feeder/feeder_test.go
@@ -22,9 +22,8 @@ var baseCfg cfg.KubearmorConfig
 func cloneConfig() cfg.KubearmorConfig {
 	c := baseCfg
 
-	if baseCfg.ConfigUntrackedNs != nil {
-		c.ConfigUntrackedNs = make([]string, len(baseCfg.ConfigUntrackedNs))
-		copy(c.ConfigUntrackedNs, baseCfg.ConfigUntrackedNs)
+	if v := cfg.GlobalCfg.ConfigUntrackedNs.Load(); v != nil {
+		c.ConfigUntrackedNs.Store(v)
 	}
 
 	if baseCfg.LsmOrder != nil {

--- a/KubeArmor/monitor/systemMonitor.go
+++ b/KubeArmor/monitor/systemMonitor.go
@@ -329,6 +329,21 @@ func (mon *SystemMonitor) UpdateThrottlingConfig() {
 		cfg.GlobalCfg.ThrottleSec)
 }
 
+// UpdateUntrackedNamespaces updates the runtime untracked namespace list.
+
+func (sm *SystemMonitor) UpdateUntrackedNamespaces(v string) {
+	namespaces := []string{}
+
+	for _, ns := range strings.Split(v, ",") {
+		ns = strings.TrimSpace(ns)
+		if ns != "" {
+			namespaces = append(namespaces, ns)
+		}
+	}
+
+	sm.UntrackedNamespaces = namespaces
+}
+
 // UpdateNsKeyMap Function
 func (mon *SystemMonitor) UpdateNsKeyMap(action string, nsKey NsKey, visibility tp.Visibility) {
 	var err error

--- a/KubeArmor/monitor/systemMonitor.go
+++ b/KubeArmor/monitor/systemMonitor.go
@@ -11,6 +11,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -332,13 +334,22 @@ func (mon *SystemMonitor) UpdateThrottlingConfig() {
 // UpdateUntrackedNamespaces updates the runtime untracked namespace list.
 
 func (sm *SystemMonitor) UpdateUntrackedNamespaces(v string) {
-	namespaces := []string{}
+	parts := strings.Split(v, ",")
 
-	for _, ns := range strings.Split(v, ",") {
+	namespaces := make([]string, 0, len(parts))
+	for _, ns := range parts {
 		ns = strings.TrimSpace(ns)
 		if ns != "" {
 			namespaces = append(namespaces, ns)
 		}
+	}
+
+	// Normalize order to avoid false updates
+	sort.Strings(namespaces)
+
+	// No-op if nothing changed
+	if slices.Equal(sm.UntrackedNamespaces, namespaces) {
+		return
 	}
 
 	sm.UntrackedNamespaces = namespaces

--- a/KubeArmor/monitor/systemMonitor.go
+++ b/KubeArmor/monitor/systemMonitor.go
@@ -167,9 +167,6 @@ type SystemMonitor struct {
 	SyscallChannel chan []byte
 	SyscallPerfMap *perf.Reader
 
-	// lists to skip
-	UntrackedNamespaces []string
-
 	// podLabelsMap
 	PodLabelsMap     map[string]string
 	PodLabelsMapLock *sync.RWMutex
@@ -222,10 +219,6 @@ func NewSystemMonitor(node *tp.Node, nodeLock **sync.RWMutex, logger *fd.Feeder,
 		ValueSize:  4,
 		MaxEntries: 6,
 	}
-
-	// assign the value of untracked ns from GlobalCfg
-	mon.UntrackedNamespaces = make([]string, len(cfg.GlobalCfg.ConfigUntrackedNs))
-	copy(mon.UntrackedNamespaces, cfg.GlobalCfg.ConfigUntrackedNs)
 
 	mon.PodLabelsMap = make(map[string]string)
 	mon.PodLabelsMapLock = new(sync.RWMutex)
@@ -327,21 +320,6 @@ func (mon *SystemMonitor) UpdateThrottlingConfig() {
 		cfg.GlobalCfg.AlertThrottling,
 		cfg.GlobalCfg.MaxAlertPerSec,
 		cfg.GlobalCfg.ThrottleSec)
-}
-
-// UpdateUntrackedNamespaces updates the runtime untracked namespace list.
-
-func (sm *SystemMonitor) UpdateUntrackedNamespaces(v string) {
-	parts := strings.Split(v, ",")
-
-	namespaces := make([]string, 0, len(parts))
-	for _, ns := range parts {
-		if ns = strings.TrimSpace(ns); ns != "" {
-			namespaces = append(namespaces, ns)
-		}
-	}
-
-	sm.UntrackedNamespaces = namespaces
 }
 
 // UpdateNsKeyMap Function
@@ -880,7 +858,7 @@ func (mon *SystemMonitor) TraceSyscall() {
 				if containerID != "" {
 					ContainersLock.RLock()
 					namespace := Containers[containerID].NamespaceName
-					if kl.ContainsElement(mon.UntrackedNamespaces, namespace) {
+					if kl.ContainsElement(cfg.GlobalCfg.ConfigUntrackedNs.Load().([]string), namespace) {
 						ContainersLock.RUnlock()
 						continue
 					}

--- a/KubeArmor/monitor/systemMonitor.go
+++ b/KubeArmor/monitor/systemMonitor.go
@@ -11,8 +11,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"slices"
-	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -338,18 +336,9 @@ func (sm *SystemMonitor) UpdateUntrackedNamespaces(v string) {
 
 	namespaces := make([]string, 0, len(parts))
 	for _, ns := range parts {
-		ns = strings.TrimSpace(ns)
-		if ns != "" {
+		if ns = strings.TrimSpace(ns); ns != "" {
 			namespaces = append(namespaces, ns)
 		}
-	}
-
-	// Normalize order to avoid false updates
-	sort.Strings(namespaces)
-
-	// No-op if nothing changed
-	if slices.Equal(sm.UntrackedNamespaces, namespaces) {
-		return
 	}
 
 	sm.UntrackedNamespaces = namespaces


### PR DESCRIPTION
**Purpose of PR?**:

This PR fixes an issue where updates to the `untrackedNs` field in the
KubeArmor ConfigMap were not reflected at runtime.

Previously, `untrackedNs` was only read during startup. This change updates
the ConfigMap watcher to detect runtime changes to `untrackedNs` and refresh
`SystemMonitor.UntrackedNamespaces` dynamically, ensuring visibility and
monitoring behavior is updated without requiring a KubeArmor restart.

Fixes #2315 


**Does this PR introduce a breaking change?**

No. This change is backward-compatible and only affects runtime behavior
when the ConfigMap value is updated.


**If the changes in this PR are manually verified, list down the scenarios covered:**:

- Updated `untrackedNs` in `kubearmor-config` while KubeArmor was running
- Verified that changes are picked up at runtime without restarting the pod
- Confirmed that visibility logic respects the updated untracked namespace list


**Additional information for reviewer?** :
_This PR is a focused bug fix and is not part of a larger design change._


**Checklist:**
- [x] Bug fix. Fixes #<issue number>
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] PR Title follows the convention of `<type>(<scope>): <subject>`
- [ ] Commit has unit tests
- [ ] Commit has integration tests
