### PR TITLE
Alpine base 3.22 update

### DIFF
--- a/.github/workflows/ci-test-ginkgo.yml
+++ b/.github/workflows/ci-test-ginkgo.yml
@@ -21,6 +21,7 @@ on:
       - "examples/multiubuntu/build/**"
       - "pkg/KubeArmorOperator/**"
       - "deployments/helm/**"
+      - "Dockerfile*"
 
 # Declare default permissions as read only.
 permissions: read-all

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,7 @@ RUN CGO_ENABLED=0 go test -covermode=atomic -coverpkg=./... -c . -o kubearmor-te
 
 ### Make executable image
 
-FROM alpine:3.20 AS kubearmor
+FROM dhi.io/alpine-base:3.22 AS kubearmor
 
 RUN echo "@community http://dl-cdn.alpinelinux.org/alpine/edge/community" | tee -a /etc/apk/repositories
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 
 ### Builder
 
-FROM golang:1.24-alpine3.21 AS builder
+FROM golang:1.24-alpine3.22 AS builder
 
 RUN apk --no-cache update
 RUN apk add --no-cache git clang llvm make gcc protobuf protobuf-dev curl elfutils-dev


### PR DESCRIPTION
**Purpose of PR?**:
Update the alpine base image used for building KubeArmor from 3.20 to 3.22.

Fixes #2324 

**Does this PR introduce a breaking change?**
No.

**Manual verification:**
- Local build successful
- Existing k3s deployment continues to run
- CI tests

**Additional information for reviewer?** :
Minimal, scoped change limited to a single Dockerfile line.

**Checklist:**
- [ ] Bug fix. Fixes #<issue number>
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change
- [ ] Documentation update required
- [x] PR title follows convention
- [ ] Unit tests
- [ ] Integration tests
