### PR TITLE
Fix broken link in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ _As contributors and maintainers of this project, and in the interest of fosteri
 Since, KubeArmor is part of the Kubernetes Community, we request you to also go through the following:
 
 - [Kubernetes Contributor Guide](https://www.kubernetes.dev/docs/guide/): Main contributor documentation.
-- [Contributor Cheat Sheet](https://github.com/kubernetes/community/blob/master/contributors/guide/contributor-cheatsheet.md): Common resources for existing developers.
+- [Contributor Cheat Sheet](https://github.com/kubernetes/community/blob/master/contributors/guide/contributor-cheatsheet/README.md): Common resources for existing developers.
 
 ## Getting Started
 


### PR DESCRIPTION
Purpose of PR:
Fix broken link in [CONTRIBUTING.md]

Details:
The link to the contributor cheat sheet was incorrect:
Old link: [https://github.com/kubernetes/community/blob/master/contributors/guide/contributor-cheatsheet.md]

Updated to: [https://github.com/kubernetes/community/blob/master/contributors/guide/contributor-cheatsheet/README.md

This PR updates the link to point to the correct contributor cheat sheet.