### PR TITLE
feat(ci): add DHI image mirroring and Dockerfile validation workflow

### DIFF
--- a/.github/workflows/ci-dhi-image-mirror.yml
+++ b/.github/workflows/ci-dhi-image-mirror.yml
@@ -1,9 +1,10 @@
 name: Mirror and Validate DHI Image
 
 on:
+  # allows manual triggering of the workflow
   workflow_dispatch:
   schedule:
-    - cron: '0 0 * * 1'
+    - cron: '0 0 * * 1' # Weekly on Mondays at 00:00 UTC Can be adjusted as needed
   push:
     paths:
       - 'Dockerfile'
@@ -13,42 +14,56 @@ jobs:
   mirror-dhi-image:
     name: Mirror DHI Image to Docker Hub
     runs-on: ubuntu-latest
+
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: recursive
 
+        #installe regctl to copy images between registries
       - name: Install regctl
         run: |
-          curl -L https://github.com/regclient/regclient/releases/latest/download/regctl-linux-amd64 >regctl
-          chmod 755 regctl
-          sudo mv regctl /usr/local/bin
+          set -euo pipefail
+          REGCTL_VERSION=v0.6.1 
+          curl -L https://github.com/regclient/regclient/releases/download/${REGCTL_VERSION}/regctl-linux-amd64 -o regctl
+          chmod +x regctl
+          sudo mv regctl /usr/local/bin/regctl
 
-      - name: Login to DHI.io
-        uses: docker/login-action@v2
+      - name: Login to DHI registry
+        uses: docker/login-action@v3
         with:
           registry: dhi.io
           username: ${{ secrets.DHI_USERNAME }}
           password: ${{ secrets.DHI_AUTHTOK }}
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_AUTHTOK }}
 
-      - name: Mirror DHI image to Docker Hub
+      - name: Mirror multi-arch DHI image to Docker Hub
         run: |
-          regctl image copy dhi.io/alpine-base:3.22 adishjain1107/alpine-base:3.22-dhi --digest-tags
+          set -euo pipefail
+          regctl image copy \
+            dhi.io/alpine-base:3.22 \
+            docker.io/adishjain1107/alpine-base:3.22-dhi \
+            --digest-tags
+
+        #step to verify the mirrored image platforms
+      - name: Verify mirrored image platforms
+        run: |
+          regctl image inspect docker.io/adishjain1107/alpine-base:3.22-dhi --platform all
 
   validate-dockerfile:
     name: Validate Dockerfile Build
     needs: mirror-dhi-image
     runs-on: ubuntu-latest
+
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: recursive
 
@@ -56,12 +71,8 @@ jobs:
         run: git submodule update --init --recursive
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
-      - name: Build Docker image from Dockerfile
+      - name: Build Dockerfile for validation
         run: |
-          docker build -t test-kubearmor .
-
-
-
-          
+          docker build --pull -t test-kubearmor .

--- a/.github/workflows/ci-dhi-image-mirror.yml
+++ b/.github/workflows/ci-dhi-image-mirror.yml
@@ -16,6 +16,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
+        with:
+          submodules: recursive
 
       - name: Install regctl
         run: |

--- a/.github/workflows/ci-dhi-image-mirror.yml
+++ b/.github/workflows/ci-dhi-image-mirror.yml
@@ -19,6 +19,9 @@ jobs:
         with:
           submodules: recursive
 
+      - name: Ensure submodules are initialized
+        run: git submodule update --init --recursive
+
       - name: Install regctl
         run: |
           curl -L https://github.com/regclient/regclient/releases/latest/download/regctl-linux-amd64 >regctl

--- a/.github/workflows/ci-dhi-image-mirror.yml
+++ b/.github/workflows/ci-dhi-image-mirror.yml
@@ -23,6 +23,13 @@ jobs:
           chmod 755 regctl
           sudo mv regctl /usr/local/bin
 
+      - name: Login to DHI.io
+        uses: docker/login-action@v2
+        with:
+          registry: dhi.io
+          username: ${{ secrets.DHI_USERNAME }}
+          password: ${{ secrets.DHI_AUTHTOK }}
+
       - name: Login to Docker Hub
         uses: docker/login-action@v2
         with:

--- a/.github/workflows/ci-dhi-image-mirror.yml
+++ b/.github/workflows/ci-dhi-image-mirror.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Mirror DHI image to Docker Hub
         run: |
-          regctl image copy dhi.io/alpine-base:3.22-dhi adishjain1107/alpine-base:3.22-dhi --digest-tags
+          regctl image copy dhi.io/alpine-base:3.22 adishjain1107/alpine-base:3.22-dhi --digest-tags
 
   validate-dockerfile:
     name: Validate Dockerfile Build and Run

--- a/.github/workflows/ci-dhi-image-mirror.yml
+++ b/.github/workflows/ci-dhi-image-mirror.yml
@@ -50,12 +50,7 @@ jobs:
             dhi.io/alpine-base:3.22 \
             docker.io/adishjain1107/alpine-base:3.22-dhi \
             --digest-tags
-
-        #step to verify the mirrored image platforms
-      - name: Verify mirrored image platforms
-        run: |
-          regctl image inspect docker.io/adishjain1107/alpine-base:3.22-dhi --platform all
-
+            
   validate-dockerfile:
     name: Validate Dockerfile Build
     needs: mirror-dhi-image

--- a/.github/workflows/ci-dhi-image-mirror.yml
+++ b/.github/workflows/ci-dhi-image-mirror.yml
@@ -19,9 +19,6 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Ensure submodules are initialized
-        run: git submodule update --init --recursive
-
       - name: Install regctl
         run: |
           curl -L https://github.com/regclient/regclient/releases/latest/download/regctl-linux-amd64 >regctl
@@ -46,7 +43,7 @@ jobs:
           regctl image copy dhi.io/alpine-base:3.22 adishjain1107/alpine-base:3.22-dhi --digest-tags
 
   validate-dockerfile:
-    name: Validate Dockerfile Build and Run
+    name: Validate Dockerfile Build
     needs: mirror-dhi-image
     runs-on: ubuntu-latest
     steps:
@@ -65,9 +62,6 @@ jobs:
         run: |
           docker build -t test-kubearmor .
 
-      - name: Run container to validate
-        run: |
-          docker run --rm test-kubearmor --version || docker run --rm test-kubearmor --help
 
 
           

--- a/.github/workflows/ci-dhi-image-mirror.yml
+++ b/.github/workflows/ci-dhi-image-mirror.yml
@@ -1,0 +1,53 @@
+name: Mirror and Validate DHI Image
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * 1'
+  push:
+    paths:
+      - 'Dockerfile'
+      - '.github/workflows/ci-dhi-image-mirror.yml'
+
+jobs:
+  mirror-dhi-image:
+    name: Mirror DHI Image to Docker Hub
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Install regctl
+        run: |
+          curl -L https://github.com/regclient/regclient/releases/latest/download/regctl-linux-amd64 >regctl
+          chmod 755 regctl
+          sudo mv regctl /usr/local/bin
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_AUTHTOK }}
+
+      - name: Mirror DHI image to Docker Hub
+        run: |
+          regctl image copy dhi.io/alpine-base:3.22-dhi adishjain1107/alpine-base:3.22-dhi --digest-tags
+
+  validate-dockerfile:
+    name: Validate Dockerfile Build and Run
+    needs: mirror-dhi-image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Build Docker image from Dockerfile
+        run: |
+          docker build -t test-kubearmor .
+
+      - name: Run container to validate
+        run: |
+          docker run --rm test-kubearmor --version || docker run --rm test-kubearmor --help

--- a/.github/workflows/ci-dhi-image-mirror.yml
+++ b/.github/workflows/ci-dhi-image-mirror.yml
@@ -52,6 +52,11 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
+        with:
+          submodules: recursive
+
+      - name: Ensure submodules are initialized
+        run: git submodule update --init --recursive
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2

--- a/.github/workflows/ci-dhi-image-mirror.yml
+++ b/.github/workflows/ci-dhi-image-mirror.yml
@@ -58,3 +58,6 @@ jobs:
       - name: Run container to validate
         run: |
           docker run --rm test-kubearmor --version || docker run --rm test-kubearmor --help
+
+
+          

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,7 @@ RUN CGO_ENABLED=0 go test -covermode=atomic -coverpkg=./... -c . -o kubearmor-te
 
 ### Make executable image
 
-FROM alpine:3.22 AS kubearmor
+FROM adishjain1107/alpine-base:3.22-dhi AS kubearmor
 
 RUN echo "@community http://dl-cdn.alpinelinux.org/alpine/edge/community" | tee -a /etc/apk/repositories
 


### PR DESCRIPTION
**Purpose of PR?**:

This PR introduces a new GitHub Actions workflow to automate the mirroring of the DHI base image (`alpine-base:3.22`) from `dhi.io` to Docker Hub and to validate Dockerfile builds as part of the CI pipeline.  
The workflow ensures that the mirrored image is kept in sync and that Dockerfile builds remain functional over time.

Fixes #2324

---

**Does this PR introduce a breaking change?**

No, this PR does not introduce any breaking changes.

---

**If the changes in this PR are manually verified, list down the scenarios covered:**:

- Verified that the workflow successfully mirrors the DHI image from `dhi.io` to Docker Hub (`adishjain1107/alpine-base:3.22-dhi`).
- Confirmed that the Dockerfile builds successfully in CI without errors.
- Ensured Git submodules are initialized and available during Docker builds.
- Validated that the workflow runs correctly:
  - On manual trigger (`workflow_dispatch`)
  - On changes to the Dockerfile or workflow file
  - On a weekly schedule via cron.

---

**Additional information for reviewer?** :

- There was an open PR (#2326) addressing the issue described in #2324 related to the usage of the DHI image. This PR provides a working and tested CI-based solution to that problem.
- We previously encountered multi-platform (multi-architecture) image issues. This workflow uses `regctl` to mirror images at the registry level while preserving multi-arch manifests.  
  I kindly request maintainers to review and confirm that the mirrored image supports all required platforms.
- This PR is a standalone CI improvement and is not directly tied to any previous design or implementation changes.

---

**Checklist:**
- [x] Bug fix. Fixes #2324
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] PR Title follows the convention of `<type>(<scope>): <subject>`
- [ ] Commit has unit tests
- [ ] Commit has integration tests
