### PR TITLE
fix(monitor): only rhel9 require special compilation handling

### DIFF
--- a/KubeArmor/BPF/Makefile.vars
+++ b/KubeArmor/BPF/Makefile.vars
@@ -72,24 +72,24 @@ else
 	 	 	-include $(KRNDIR)/include/linux/kconfig.h
 endif
 
-# rhel build version
-RHEL_BUILD := $(shell echo "$(UNAME_R)" | sed -nE 's/.*-([0-9]+)\..*\.el[0-9]+(_[0-9]+)?\..*/\1/p')
+# rhel9 build version
+RHEL9_BUILD := $(shell echo "$(UNAME_R)" | sed -nE 's/.*-([0-9]+)\..*\.el9(_[0-9]+)?\..*/\1/p')
 
-# rhel build version -ge 400
-RHEL_BUILD_GTE_400 := 0
+# rhel9 build version -ge 400
+RHEL9_BUILD_GTE_400 := 0
 
-ifneq ($(strip $(RHEL_BUILD)),)
-$(info RHEL compatible kernel, build: $(RHEL_BUILD))
-    RHEL_BUILD_GTE_400 := $(shell [ $(RHEL_BUILD) -ge 400 ] && echo 1 || echo 0)
-    ifeq ($(RHEL_BUILD_GTE_400),1)
-        $(info RHEL build is greater or equal to 400)
+ifneq ($(strip $(RHEL9_BUILD)),)
+$(info RHEL9 compatible kernel, build: $(RHEL9_BUILD))
+    RHEL9_BUILD_GTE_400 := $(shell [ $(RHEL9_BUILD) -ge 400 ] && echo 1 || echo 0)
+    ifeq ($(RHEL9_BUILD_GTE_400),1)
+        $(info RHEL9 build is greater or equal to 400)
     else
-        $(info RHEL build is less than 400)
+        $(info RHEL9 build is less than 400)
     endif
 
-    INC_F += -DRHEL_BUILD_GTE_400
+    INC_F += -DRHEL9_BUILD_GTE_400
 else
-    $(info Non-RHEL kernel, skipping RHEL-specific logic)
+    $(info Non-RHEL9 kernel, skipping RHEL9-specific logic)
 endif
 
 KF = $(INC_F) -I$(LIBBPF)/src \

--- a/KubeArmor/BPF/system_monitor.c
+++ b/KubeArmor/BPF/system_monitor.c
@@ -2422,7 +2422,7 @@ int kprobe__udp_sendmsg(struct pt_regs *ctx)
     dport = ntohs(dport);
     if (dport != 53)
         return 0;
-    #if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 3, 13) || RHEL_BUILD_GTE_400
+    #if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 3, 13) || RHEL9_BUILD_GTE_400
         bpf_probe_read(&iov, sizeof(iov), &msg->msg_iter.__iov);
     #else
         bpf_probe_read(&iov, sizeof(iov), &msg->msg_iter.iov);


### PR DESCRIPTION
**Purpose of PR?**:
rhel9 based distros requires special handling for the following kernel data being accessed in system monitor. 
```
#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 3, 13) || RHEL9_BUILD_GTE_400
        bpf_probe_read(&iov, sizeof(iov), &msg->msg_iter.__iov);
    #else
        bpf_probe_read(&iov, sizeof(iov), &msg->msg_iter.iov);
    #endif
```

currently the regex matches all rhel based distros and it leads to the issue i.e. rhel8/10 doesn't require this handling. 
```
RHEL compatible kernel, build: 553
RHEL build is greater or equal to 400
RHEL compatible kernel, build: 553
RHEL build is greater or equal to 400
\033[0;32mKernel BTF information found\033[0m
Generating vmlinux.h for kernel 4.18.0
Compiling eBPF bytecode: \033[0;32msystem_monitor.bpf.o\033[0m ...
/KubeArmor/BPF/system_monitor.c:2426:58: error: no member named '__iov' in 'struct iov_iter'
 2426 |         bpf_probe_read(&iov, sizeof(iov), &msg->msg_iter.__iov);
      |                                            ~~~~~~~~~~~~~ ^
1 error generated.
[dell@redhat ~]$ uname -r
4.18.0-553.58.1.el8_10.x86_64
```

This PR updates the regex to match rhel9 based distros only.


**Does this PR introduce a breaking change?**

**If the changes in this PR are manually verified, list down the scenarios covered:**:

**Additional information for reviewer?** :
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [x] Bug fix.
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Commit has unit tests
- [ ] Commit has integration tests

<!--

The PR title message must follow convention:
`<type>(<scope>): <subject>`.

Where: <br />
- `type` is to define what type of PR is this.
  Most common types are:
    - `feat`      - for new features, not a new feature for build script
    - `fix`       - for bug fixes or improvements, not a fix for build script
    - `chore`     - changes not related to production code
    - `docs`      - changes related to documentation
    - `style`     - formatting, missing semi colons, linting fix etc; no significant production code changes
    - `test`      - adding missing tests, refactoring tests; no production code change
    - `refactor`  - refactoring production code, eg. renaming a variable or function name, there should not be any significant production code changes

- `scope` is a single word that best describes where the changes fit.
    - feature(`monitor`,`enforcer`)
    - test(`tests`, `bdd`)
    - chore(`build`)
- `subject` is a single line brief description of the changes made in the pull request.

-->