### PR TITLE
docs(vagrant): update README with BPF-LSM and CentOS 9 details

### DIFF
--- a/contribution/vagrant/README.md
+++ b/contribution/vagrant/README.md
@@ -2,42 +2,83 @@
 
 We provide multiple Vagrant VMs for development and testing.
 
+> **Prerequisites & Security Modules:**
+> * **AppArmor:** Enabled by default on all **Ubuntu** environments.
+> * **SELinux:** Enabled by default on all **CentOS** environments.
+> * **BPF-LSM:** To test BPF-LSM enforcement, you **must** use `NETNEXT=1` (Ubuntu 22.04 or CentOS 9) to ensure Kernel version >5.7 is used.
+
 ## Vagrant Values
 
 - OS = { centos | ubuntu } (ubuntu by default)
-    - If OS == centos
-        - NETNEXT = { 0 | 1 } (0 by default)
-            - 0: CentOS 8, 1: CentOS 9
-    - If OS == ubuntu
-        - NETNEXT = { -1 | 0 | 1 } (0 by default)
-            - -1: Ubuntu 18.04, 0: Ubuntu 20.04, 1: Ubuntu 22.04
+  - If OS == centos
+    - NETNEXT = { 0 | 1 } (0 by default)
+      - 0: CentOS 8 (Kernel 4.18)
+      - 1: CentOS 9 (Kernel 5.14+, Supports BPF-LSM)
+  - If OS == ubuntu
+    - NETNEXT = { -1 | 0 | 1 } (0 by default)
+      - -1: Ubuntu 18.04 (Kernel 4.15)
+      - 0: Ubuntu 20.04 (Kernel 5.4)
+      - 1: Ubuntu 22.04 (Kernel 5.15+, Supports BPF-LSM)
 
 - K8S = { k3s | kubeadm } (k3s by default)
 
 - RUNTIME = { docker | containerd | crio } (docker by default)
 
 - NODEV = { 0 | 1 } (0 by default)
-    - 0: Kubernetes + Development Setup, 1: Kubernetes only
+  - 0: Kubernetes + Development Setup
+  - 1: Kubernetes only
 
 ## Vagrant VM Management
 
-- Use 'vagrant' command directly
+### 1. Use `vagrant` command directly
+
+You must navigate to the vagrant directory first.
 
 ```
 $ cd KubeArmor/contribution/vagrant
 $ [Vagrant Values] vagrant { up | status | ssh | destroy }
 ```
 
-```
-$ vagrant up -> Ubuntu 20.04 + K3s + Docker + Development Setup
-$ OS=ubuntu NETNEXT=1 vagrant up -> Ubuntu 22.04 + K3s + Docker + Development Setup
-$ NETNEXT=-1 vagrant up -> Ubuntu 18.04 + K3s + Docker + Development Setup
-$ OS=centos vagrant up -> CentOS 8 + K3s + Docker + Development Setup
-$ K8S=kubeadm RUNTIME=containerd vagrant up -> Ubuntu 20.04 + Kubeadm + Containerd + Development Setup
-$ NODEV=1 vagrant up -> Ubuntu.20.04 + K3s + Docker / no Development Setup
-```
+**Examples:**
 
-- Use 'make' command
+```
+$ vagrant up
+```
+Ubuntu 20.04 + K3s + Docker + Development Setup
+
+```
+$ OS=ubuntu NETNEXT=1 vagrant up
+```
+Ubuntu 22.04 (BPF-LSM) + K3s + Docker + Development Setup
+
+```
+$ NETNEXT=-1 vagrant up
+```
+Ubuntu 18.04 + K3s + Docker + Development Setup
+
+```
+$ OS=centos vagrant up
+```
+CentOS 8 + K3s + Docker + Development Setup
+
+```
+$ OS=centos NETNEXT=1 vagrant up
+```
+CentOS 9 (BPF-LSM) + K3s + Docker + Development Setup
+
+```
+$ K8S=kubeadm RUNTIME=containerd vagrant up
+```
+Ubuntu 20.04 + Kubeadm + Containerd + Development Setup
+
+```
+$ NODEV=1 vagrant up
+```
+Ubuntu 20.04 + K3s + Docker / no Development Setup
+
+### 2. Use `make` command
+
+The `make` command acts as a wrapper, allowing you to run vagrant commands from the KubeArmor directory without manually changing directories.
 
 ```
 $ cd KubeArmor/KubeArmor
@@ -46,9 +87,28 @@ $ make { vagrant-up | vagrant-status | vagrant-ssh | vagrant-destroy } [Vagrant 
 
 ```
 $ make vagrant-up
+```
+
+```
 $ make vagrant-up OS=ubuntu NETNEXT=1
+```
+
+```
 $ make vagrant-up NETNEXT=-1
+```
+
+```
 $ make vagrant-up OS=centos
+```
+
+```
+$ make vagrant-up OS=centos NETNEXT=1
+```
+
+```
 $ make vagrant-up K8S=kubeadm RUNTIME=containerd
+```
+
+```
 $ make vagrant-up NODEV=1
 ```

--- a/contribution/vagrant/Vagrantfile
+++ b/contribution/vagrant/Vagrantfile
@@ -9,7 +9,7 @@ NODEV     = ENV['NODEV'] || "0"
 
 if OS == "centos" then
   if NETNEXT == "1" then
-    VM_IMG = "generic/centos9s"
+    VM_IMG = "generic/centos9s" # 5.14
     VM_NAME = "kubearmor-dev-next"
   else # default
     VM_IMG = "generic/centos8s" # 4.18


### PR DESCRIPTION
**Purpose of PR?**:

The current Vagrant documentation lacks clear instructions for enabling BPF-LSM (which requires `NETNEXT=1`) and does not explicitly list CentOS 9 support. This PR updates the README to include these modern environment details, explicitly lists AppArmor/SELinux defaults, and refactors the command examples for better readability.

Fixes #

**Does this PR introduce a breaking change?**
No.

**If the changes in this PR are manually verified, list down the scenarios covered:**:
- Verified the Markdown rendering locally to ensure command blocks and tables display correctly.
- Confirmed accuracy of Kernel versions for Ubuntu and CentOS variants.

**Additional information for reviewer?** :
This updates the Vagrant `README.md` to help new contributors easily set up a BPF-LSM enabled environment without guessing the correct `NETNEXT` values.


**Checklist:**
- [ ] Bug fix. Fixes #<issue number>
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Commit has unit tests
- [ ] Commit has integration tests