### PR TITLE
Fix goroutine leak in BPF LSM TraceEvents on daemon shutdown

### DIFF
--- a/KubeArmor/enforcer/bpflsm/enforcer.go
+++ b/KubeArmor/enforcer/bpflsm/enforcer.go
@@ -336,8 +336,11 @@ func (be *BPFEnforcer) TraceEvents() {
 	}()
 
 	for {
-
-		dataRaw := <-be.EventsChannel
+		dataRaw, ok := <-be.EventsChannel
+		if !ok {
+			be.Logger.Print("EventsChannel closed, exiting TraceEvents")
+			return
+		}
 
 		var event eventBPF
 
@@ -546,6 +549,10 @@ func (be *BPFEnforcer) DestroyBPFEnforcer() error {
 			be.Logger.Err(err.Error())
 			errBPFCleanUp = errors.Join(errBPFCleanUp, err)
 		}
+	}
+
+	if be.EventsChannel != nil {
+		close(be.EventsChannel)
 	}
 
 	be = nil

--- a/KubeArmor/presets/anonmapexec/preset.go
+++ b/KubeArmor/presets/anonmapexec/preset.go
@@ -171,8 +171,11 @@ func (p *Preset) TraceEvents() {
 	}()
 
 	for {
-
-		dataRaw := <-p.EventsChannel
+		dataRaw, ok := <-p.EventsChannel
+		if !ok {
+			p.Logger.Print("EventsChannel closed, exiting TraceEvents")
+			return
+		}
 
 		var event MmapEvent
 
@@ -346,6 +349,10 @@ func (p *Preset) Destroy() error {
 			p.Logger.Err(err.Error())
 			errBPFCleanUp = errors.Join(errBPFCleanUp, err)
 		}
+	}
+
+	if p.EventsChannel != nil {
+		close(p.EventsChannel)
 	}
 
 	p = nil

--- a/KubeArmor/presets/exec/preset.go
+++ b/KubeArmor/presets/exec/preset.go
@@ -154,8 +154,11 @@ func (p *Preset) TraceEvents() {
 	}()
 
 	for {
-
-		dataRaw := <-p.EventsChannel
+		dataRaw, ok := <-p.EventsChannel
+		if !ok {
+			p.Logger.Print("EventsChannel closed, exiting TraceEvents")
+			return
+		}
 
 		var event base.EventPreset
 
@@ -349,6 +352,10 @@ func (p *Preset) Destroy() error {
 			p.Logger.Err(err.Error())
 			errBPFCleanUp = errors.Join(errBPFCleanUp, err)
 		}
+	}
+
+	if p.EventsChannel != nil {
+		close(p.EventsChannel)
 	}
 
 	p = nil

--- a/KubeArmor/presets/filelessexec/preset.go
+++ b/KubeArmor/presets/filelessexec/preset.go
@@ -156,8 +156,11 @@ func (p *Preset) TraceEvents() {
 	}()
 
 	for {
-
-		dataRaw := <-p.EventsChannel
+		dataRaw, ok := <-p.EventsChannel
+		if !ok {
+			p.Logger.Print("EventsChannel closed, exiting TraceEvents")
+			return
+		}
 
 		var event base.EventPreset
 
@@ -350,6 +353,10 @@ func (p *Preset) Destroy() error {
 			p.Logger.Err(err.Error())
 			errBPFCleanUp = errors.Join(errBPFCleanUp, err)
 		}
+	}
+
+	if p.EventsChannel != nil {
+		close(p.EventsChannel)
 	}
 
 	p = nil

--- a/KubeArmor/presets/protectenv/preset.go
+++ b/KubeArmor/presets/protectenv/preset.go
@@ -155,8 +155,11 @@ func (p *Preset) TraceEvents() {
 	}()
 
 	for {
-
-		dataRaw := <-p.EventsChannel
+		dataRaw, ok := <-p.EventsChannel
+		if !ok {
+			p.Logger.Print("EventsChannel closed, exiting TraceEvents")
+			return
+		}
 
 		var event base.EventPreset
 
@@ -352,6 +355,10 @@ func (p *Preset) Destroy() error {
 			p.Logger.Err(err.Error())
 			errBPFCleanUp = errors.Join(errBPFCleanUp, err)
 		}
+	}
+
+	if p.EventsChannel != nil {
+		close(p.EventsChannel)
 	}
 
 	p = nil

--- a/KubeArmor/presets/protectproc/preset.go
+++ b/KubeArmor/presets/protectproc/preset.go
@@ -153,8 +153,11 @@ func (p *Preset) TraceEvents() {
 	}()
 
 	for {
-
-		dataRaw := <-p.EventsChannel
+		dataRaw, ok := <-p.EventsChannel
+		if !ok {
+			p.Logger.Print("EventsChannel closed, exiting TraceEvents")
+			return
+		}
 
 		var event base.EventPreset
 
@@ -346,6 +349,10 @@ func (p *Preset) Destroy() error {
 			p.Logger.Err(err.Error())
 			errBPFCleanUp = errors.Join(errBPFCleanUp, err)
 		}
+	}
+
+	if p.EventsChannel != nil {
+		close(p.EventsChannel)
 	}
 
 	p = nil


### PR DESCRIPTION
### Summary
This PR fixes a **deterministic goroutine leak** in the BPF LSM enforcer and related preset enforcers.  
On daemon shutdown or restart, the `TraceEvents` consumer goroutine could block forever due to an unclosed channel, leading to **unbounded goroutine and memory growth** in long-running clusters.

The fix ensures proper shutdown signaling by **closing `EventsChannel` and handling channel closure in the consumer loop**.

---

### Problem
`TraceEvents()` uses a producer–consumer pattern backed by `EventsChannel`.

- The producer goroutine exits when the eBPF ring buffer is closed.
- The consumer goroutine blocks on `<-EventsChannel`.
- `EventsChannel` was **never closed** during enforcer destruction.
- Result: the consumer goroutine blocks forever and leaks.

This happens reliably during:
- DaemonSet restarts
- Rolling upgrades
- Node reboots
- Operator-driven reconfigurations

---

### Root Cause
The shutdown logic assumes that closing the eBPF ring buffer (`be.Events.Close()`) is sufficient to stop all goroutines.  
In reality, it only terminates the producer. The consumer goroutine has no shutdown signal and blocks indefinitely.

---

### Fix
- Close `EventsChannel` during `Destroy` / `DestroyBPFEnforcer`
- Update the `TraceEvents` consumer loop to exit cleanly when the channel is closed
- Apply the same fix to all preset enforcers using the same pattern

This is a **minimal, safe fix** with no behavioral changes during normal operation.

---

### Files Changed
- `KubeArmor/enforcer/bpflsm/enforcer.go`
- `KubeArmor/presets/protectenv/preset.go`
- `KubeArmor/presets/filelessexec/preset.go`
- `KubeArmor/presets/protectproc/preset.go`
- `KubeArmor/presets/anonmapexec/preset.go`
- `KubeArmor/presets/exec/preset.go`

---

### How to Reproduce
1. Deploy KubeArmor in a cluster
2. Apply any policy that enables the BPF LSM enforcer
3. Observe goroutine count via pprof:
   ```sh
   curl localhost:32767/debug/pprof/goroutine?debug=1
