### PR TITLE
fix(config,enforcer): empty selinux profile dir default config

### DIFF
--- a/KubeArmor/common/common.go
+++ b/KubeArmor/common/common.go
@@ -6,6 +6,7 @@ package common
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -683,4 +684,42 @@ func NormalizeIP(ipStr string) string {
 	} else {
 		return "[" + ipStr + "]" // IPv6
 	}
+}
+
+// errUnsafePathToRemove error
+var errUnsafePathToRemove = errors.New("unsafe path to remove")
+
+// isUnsafePathToRemove checks if path is empty or absolute root "/"
+// return true to mark the path unsafe to remove
+func isUnsafePathToRemove(path string) bool {
+	if path == "" {
+		return true
+	}
+
+	clean := filepath.Clean(path)
+
+	// root /
+	if clean == string(filepath.Separator) {
+		return true
+	}
+
+	return false
+}
+
+// RemoveSafe func remove the given path if it is safe(not empty or /)
+// to remove using os.Remove
+func RemoveSafe(path string) error {
+	if isUnsafePathToRemove(path) {
+		return errUnsafePathToRemove
+	}
+	return os.Remove(path)
+}
+
+// RemoveAllSafe func remove the given path if it is safe(not empty or /)
+// to remove using os.RemoveAll
+func RemoveAllSafe(path string) error {
+	if isUnsafePathToRemove(path) {
+		return errUnsafePathToRemove
+	}
+	return os.RemoveAll(path)
 }

--- a/KubeArmor/config/config.go
+++ b/KubeArmor/config/config.go
@@ -377,6 +377,8 @@ func LoadConfig() error {
 
 	GlobalCfg.MatchArgs = viper.GetBool(ConfigArgMatching)
 
+	GlobalCfg.SELinuxProfileDir = viper.GetString(ConfigSELinuxProfileDir)
+
 	LoadDynamicConfig()
 
 	kg.Printf("Final Configuration [%+v]", GlobalCfg)

--- a/KubeArmor/core/hook_handler.go
+++ b/KubeArmor/core/hook_handler.go
@@ -30,7 +30,7 @@ func (dm *KubeArmorDaemon) ListenToK8sHook() {
 	}
 
 	listenPath := filepath.Join(kubearmorDir, "ka.sock")
-	err := os.Remove(listenPath) // in case kubearmor crashed and the socket wasn't removed
+	err := kl.RemoveSafe(listenPath) // in case kubearmor crashed and the socket wasn't removed
 	if err != nil && !errors.Is(err, os.ErrNotExist) {
 		dm.Logger.Warnf("Failed to cleanup ka.sock: %v", err)
 	}
@@ -42,7 +42,7 @@ func (dm *KubeArmorDaemon) ListenToK8sHook() {
 	}
 
 	defer socket.Close()
-	defer os.Remove(listenPath)
+	defer kl.RemoveSafe(listenPath)
 	ready := &atomic.Bool{}
 
 	for {

--- a/KubeArmor/core/hook_handlier_non_k8s.go
+++ b/KubeArmor/core/hook_handlier_non_k8s.go
@@ -32,7 +32,7 @@ func (dm *KubeArmorDaemon) ListenToNonK8sHook() {
 	}
 
 	listenPath := filepath.Join(kubearmorDir, "ka.sock")
-	err := os.Remove(listenPath) // in case kubearmor crashed and the socket wasn't removed (cleaning the socket file if got crashed)
+	err := kl.RemoveSafe(listenPath) // in case kubearmor crashed and the socket wasn't removed (cleaning the socket file if got crashed)
 	if err != nil && !errors.Is(err, os.ErrNotExist) {
 		dm.Logger.Warnf("Failed to cleanup ka.sock: %v", err)
 	}
@@ -49,7 +49,7 @@ func (dm *KubeArmorDaemon) ListenToNonK8sHook() {
 	}
 
 	defer socket.Close()
-	defer os.Remove(listenPath)
+	defer kl.RemoveSafe(listenPath)
 	ready := &atomic.Bool{}
 
 	for {

--- a/KubeArmor/core/kubeArmor.go
+++ b/KubeArmor/core/kubeArmor.go
@@ -240,7 +240,7 @@ func (dm *KubeArmorDaemon) DestroyKubeArmorDaemon() {
 	if _, err := os.Stat(cfg.PIDFilePath); err == nil {
 		kg.Print("Deleting PID file")
 
-		err := os.Remove(cfg.PIDFilePath)
+		err := common.RemoveSafe(cfg.PIDFilePath)
 		if err != nil {
 			kg.Errf("Failed to delete PID file")
 		}

--- a/KubeArmor/core/unorchestratedUpdates.go
+++ b/KubeArmor/core/unorchestratedUpdates.go
@@ -874,7 +874,7 @@ func (dm *KubeArmorDaemon) removeBackUpPolicy(name string) {
 		return
 	}
 
-	if err := os.Remove(fname); err != nil {
+	if err := kl.RemoveSafe(fname); err != nil {
 		kg.Errf("unable to delete file:%s err=%s", fname, err.Error())
 	}
 }

--- a/KubeArmor/enforcer/SELinuxEnforcer.go
+++ b/KubeArmor/enforcer/SELinuxEnforcer.go
@@ -81,7 +81,7 @@ func NewSELinuxEnforcer(node tp.Node, logger *fd.Feeder) *SELinuxEnforcer {
 	}
 
 	// remove old profiles if exists
-	if err = os.RemoveAll(filepath.Clean(cfg.GlobalCfg.SELinuxProfileDir)); err != nil {
+	if err = kl.RemoveAllSafe(filepath.Clean(cfg.GlobalCfg.SELinuxProfileDir)); err != nil {
 		se.Logger.Errf("Failed to remove existing SELinux profiles (%s)", err.Error())
 		return nil
 	}

--- a/KubeArmor/enforcer/appArmorEnforcer.go
+++ b/KubeArmor/enforcer/appArmorEnforcer.go
@@ -157,7 +157,7 @@ profile apparmor-default flags=(attach_disconnected,mediate_deleted) {
 				continue // still need to check other profiles
 			}
 
-			if err := os.Remove(filepath.Clean("/etc/apparmor.d/" + fileName)); err != nil {
+			if err := kl.RemoveSafe(filepath.Clean("/etc/apparmor.d/" + fileName)); err != nil {
 				ae.Logger.Warnf("Unable to remove /etc/apparmor.d/%s (%s)", fileName, err.Error())
 				continue // still need to check other profiles
 			}
@@ -465,7 +465,7 @@ func (ae *AppArmorEnforcer) UnregisterAppArmorHostProfile() bool {
 		if err := ae.CreateAppArmorHostProfile(); err != nil {
 			ae.Logger.Warnf("Unable to reset the KubeArmor host profile in %s", cfg.GlobalCfg.Host)
 
-			if err := os.Remove(appArmorHostFile); err != nil {
+			if err := kl.RemoveSafe(appArmorHostFile); err != nil {
 				ae.Logger.Warnf("Unable to remove the KubeArmor host profile from %s (%s)", cfg.GlobalCfg.Host, err.Error())
 			}
 
@@ -475,13 +475,13 @@ func (ae *AppArmorEnforcer) UnregisterAppArmorHostProfile() bool {
 		if err := kl.RunCommandAndWaitWithErr("apparmor_parser", []string{"-r", "-W", "-C", appArmorHostFile}); err != nil {
 			ae.Logger.Warnf("Unable to reset the KubeArmor host profile in %s", cfg.GlobalCfg.Host)
 
-			if err := os.Remove(appArmorHostFile); err != nil {
+			if err := kl.RemoveSafe(appArmorHostFile); err != nil {
 				ae.Logger.Warnf("Unable to remove the KubeArmor host profile from %s (%s)", cfg.GlobalCfg.Host, err.Error())
 			}
 
 		}
 
-		if err := os.Remove(appArmorHostFile); err != nil {
+		if err := kl.RemoveSafe(appArmorHostFile); err != nil {
 			ae.Logger.Warnf("Unable to remove the KubeArmor host profile from %s (%s)", cfg.GlobalCfg.Host, err.Error())
 			return false
 		}

--- a/KubeArmor/enforcer/appArmorProfile.go
+++ b/KubeArmor/enforcer/appArmorProfile.go
@@ -547,7 +547,7 @@ func (ae *AppArmorEnforcer) GenerateAppArmorProfile(appArmorProfile string, secu
 			if err != nil {
 				ae.Logger.Warnf("Unable to create tmp file, err=%s", err.Error())
 			} else {
-				defer os.Remove(file.Name())
+				defer kl.RemoveSafe(file.Name())
 				writer := bufio.NewWriter(file)
 				for _, prof := range profileToDelete {
 					_, err = writer.WriteString(prof + "} \n")

--- a/KubeArmor/main.go
+++ b/KubeArmor/main.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/kubearmor/KubeArmor/KubeArmor/buildinfo"
+	kl "github.com/kubearmor/KubeArmor/KubeArmor/common"
 	cfg "github.com/kubearmor/KubeArmor/KubeArmor/config"
 	"github.com/kubearmor/KubeArmor/KubeArmor/core"
 	kg "github.com/kubearmor/KubeArmor/KubeArmor/log"
@@ -45,7 +46,7 @@ func main() {
 			if this is triggered that means there is incomplete cleanup process
 			from the last installation */
 			path := filepath.Join(bpfMapsDir, entry.Name())
-			err := os.Remove(path)
+			err := kl.RemoveSafe(path)
 			if err != nil {
 				kg.Errf("Failed to delete BPF map %s: %v", path, err)
 			} else {


### PR DESCRIPTION
**Purpose of PR?**:
We have this configuration to set the default directory path for kubearmor managed selinux profiles.
https://github.com/kubearmor/KubeArmor/blob/064011f208b60913a3bbef80890b1ff59471decb/KubeArmor/config/config.go#L28
this configuration is supposed to be updated with the command-line flag value `--seLinuxProfileDir` to global config  in `LoadConfig()`, but it's not.
https://github.com/kubearmor/KubeArmor/blob/064011f208b60913a3bbef80890b1ff59471decb/KubeArmor/config/config.go#L148
It could lead to a critical issue resulting in deleting all root filesystem equivalent to `sudo rm -rf /`
https://github.com/kubearmor/KubeArmor/blob/064011f208b60913a3bbef80890b1ff59471decb/KubeArmor/enforcer/SELinuxEnforcer.go#L78C2-L87C3

It affect the environments with selinux is the enforcer enabled. 

<img width="1796" height="501" alt="image (10)" src="https://github.com/user-attachments/assets/f4b0fbc7-f2b5-4211-b326-1c11653e1285" />

This PR updates the `SELinuxProfileDir` configuration with `--seLinuxProfileDir` flag value. and also
adds a wrapper on top of `os.Remove` and `os.RemoveAll` to remove a path if only if it's not empty and not absolute root (/). 

**Does this PR introduce a breaking change?**
No
**If the changes in this PR are manually verified, list down the scenarios covered:**:

Tested on one of the affected environment

```
Found KubeArmor running in Systemd mode 

Host : 
        OS Image:                       Oracle Linux Server 9.6          
        Kernel Version:                 6.12.0-105.51.5.el9uek.x86_64    
        Kubelet Version:                                                 
        Container Runtime:                                               
        Active LSM:                                                      
        Host Security:                  false                            
        Container Security:             false                            
        Container Default Posture:      audit(File)                             audit(Capabilities)     audit(Network)
        Host Default Posture:           audit(File)                             audit(Capabilities)     audit(Network)
        Host Visibility:                process,file,network,capabilities
```

**Additional information for reviewer?** :
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [x] Bug fix.
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Commit has unit tests
- [ ] Commit has integration tests

<!--

The PR title message must follow convention:
`<type>(<scope>): <subject>`.

Where: <br />
- `type` is to define what type of PR is this.
  Most common types are:
    - `feat`      - for new features, not a new feature for build script
    - `fix`       - for bug fixes or improvements, not a fix for build script
    - `chore`     - changes not related to production code
    - `docs`      - changes related to documentation
    - `style`     - formatting, missing semi colons, linting fix etc; no significant production code changes
    - `test`      - adding missing tests, refactoring tests; no production code change
    - `refactor`  - refactoring production code, eg. renaming a variable or function name, there should not be any significant production code changes

- `scope` is a single word that best describes where the changes fit.
    - feature(`monitor`,`enforcer`)
    - test(`tests`, `bdd`)
    - chore(`build`)
- `subject` is a single line brief description of the changes made in the pull request.

-->