### PR TITLE
fix(monitor): garbage protocol value tcp accept

### DIFF
--- a/KubeArmor/BPF/system_monitor.c
+++ b/KubeArmor/BPF/system_monitor.c
@@ -2248,6 +2248,14 @@ int kprobe__accept(struct pt_regs *ctx)
     return save_args(_SYS_ACCEPT, ctx);
 }
 
+// This is disabled currently and will not be loaded by system monitor
+// the decision to disable this probe was taken for two main reasons
+// 1. we're interested in (established) tcp_accpt event only that we're already monitor using __x64_sys_inet_csk_accept
+// 2. if we're interested in socket information as well this is not a good place to get that information
+//    if the request is placed in accept queue then socket might not be initialized and further will change
+//    when the tcp connection is established. A better alternative would be to get the socket information with
+//    kprobe attached to security_socket_accept lsm hook, there we'll get the valid sock address and can read
+//    from there in kretprobe/__x64_sys_accept.
 SEC("kretprobe/__x64_sys_accept")
 int kretprobe__accept(struct pt_regs *ctx)
 {

--- a/KubeArmor/go.mod
+++ b/KubeArmor/go.mod
@@ -1,6 +1,6 @@
 module github.com/kubearmor/KubeArmor/KubeArmor
 
-go 1.24.11
+go 1.24.12
 
 replace (
 	github.com/kubearmor/KubeArmor => ../../

--- a/KubeArmor/monitor/systemMonitor.go
+++ b/KubeArmor/monitor/systemMonitor.go
@@ -571,7 +571,7 @@ func (mon *SystemMonitor) InitBPF() error {
 
 	mon.Logger.Print("Initialized the eBPF system monitor")
 
-	systemCalls := []string{"open", "openat", "execve", "execveat", "socket", "connect", "accept", "bind", "listen", "unlink", "unlinkat", "rmdir", "ptrace", "chown", "setuid", "setgid", "fchownat", "mount", "umount"}
+	systemCalls := []string{"open", "openat", "execve", "execveat", "socket", "connect", "bind", "listen", "unlink", "unlinkat", "rmdir", "ptrace", "chown", "setuid", "setgid", "fchownat", "mount", "umount"}
 	// {category, event}
 	sysTracepoints := [][2]string{{"syscalls", "sys_exit_openat"}, {"syscalls", "sys_enter_setns"}, {"syscalls", "sys_exit_setns"}, {"sched", "sched_process_fork"}}
 	sysKprobes := []string{"do_exit", "security_bprm_check", "security_file_open", "security_path_mknod", "security_path_unlink", "security_path_rmdir", "security_ptrace_access_check"}

--- a/deployments/go.mod
+++ b/deployments/go.mod
@@ -1,6 +1,6 @@
 module github.com/kubearmor/KubeArmor/deployments
 
-go 1.24.11
+go 1.24.12
 
 replace (
 	github.com/kubearmor/KubeArmor => ../

--- a/deployments/podman/go.mod
+++ b/deployments/podman/go.mod
@@ -1,6 +1,6 @@
 module github.com/kubearmor/KubeArmor/deployments/podman
 
-go 1.24.11
+go 1.24.12
 
 require (
 	github.com/containers/podman/v5 v5.6.0

--- a/pkg/KubeArmorController/go.mod
+++ b/pkg/KubeArmorController/go.mod
@@ -1,6 +1,6 @@
 module github.com/kubearmor/KubeArmor/pkg/KubeArmorController
 
-go 1.24.11
+go 1.24.12
 
 require (
 	github.com/go-logr/logr v1.4.3

--- a/pkg/KubeArmorOperator/go.mod
+++ b/pkg/KubeArmorOperator/go.mod
@@ -1,6 +1,6 @@
 module github.com/kubearmor/KubeArmor/pkg/KubeArmorOperator
 
-go 1.24.11
+go 1.24.12
 
 replace (
 	github.com/go-jose/go-jose/v4 => github.com/go-jose/go-jose/v4 v4.0.5

--- a/protobuf/go.mod
+++ b/protobuf/go.mod
@@ -1,6 +1,6 @@
 module github.com/kubearmor/KubeArmor/protobuf
 
-go 1.24.11
+go 1.24.12
 
 replace (
 	github.com/go-jose/go-jose/v4 => github.com/go-jose/go-jose/v4 v4.0.5

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -1,6 +1,6 @@
 module github.com/kubearmor/KubeArmor/tests
 
-go 1.24.11
+go 1.24.12
 
 replace (
 	github.com/kubearmor/KubeArmor/pkg/KubeArmorController => ../pkg/KubeArmorController


### PR DESCRIPTION
**Purpose of PR?**:

Related: #2353 

A similar issue as #2353 was observed with tcp_accpet event as well. this PR fixes the same issue using READ_KERN to access the field instead of direct access.
```
2026-01-29 09:32:19.524789      WARN    Failed to send a log=[Timestamp:1769689939
  UpdatedTime:"2026-01-29T12:32:19.524174Z"  ClusterName:"default"  HostName:"lnx**********"  
ParentProcessName:"/usr/lib/systemd/systemd"  ProcessName:"/opt/kubearmor/kubearmor"  HostPPID:1  HostPID:17353  
PID:17353  Type:"HostLog"  Source:"/opt/kubearmor/kubearmor"  Operation:"Network"  Resource:"remoteip=127.0.0.1 
port=32767 protocol=؞MXPӫ"  Data:"kprobe=tcp_accept domain=AF_INET6"  EventData:{key:"Domain"  value:"AF_INET6"} 
 EventData:{key:"Kprobe"  value:"tcp_accept"}  EventData:{key:"Port"  value:"32767"}  EventData:{key:"Protocol"  value:"
؞M\xaa\xff\xff\xff\xff\xb8\xfcX\xaa\xff\xff\xff\xffPӫ\xa8\xff\xff\xff\xff"}  EventData:{key:"Remoteip"  value:"127.0.0.1"}  
Result:"Passed"  Cwd:"/opt/kubearmor/"  ExecEvent:{ExecID:"0"  ExecutableName:"kubearmor"}  
NodeID:"*******************"] err=[rpc error: code = Internal desc = 
grpc: error while marshaling: string field contains invalid UTF-8]
```

also with this PR **MONITORING OF SYS_ACCEPT SYSTEM CALL HAS BEEN DISABLED** as we're not interested in (non-tcp) accept event currently residing in the accept queue. we're already getting the tcp_accept event for established tcp connections that we're interested in using `kretprobe/__x64_sys_accept`.

**Does this PR introduce a breaking change?**
No
**If the changes in this PR are manually verified, list down the scenarios covered:**:

**Additional information for reviewer?** :
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [x] Bug fix.
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Commit has unit tests
- [ ] Commit has integration tests

<!--

The PR title message must follow convention:
`<type>(<scope>): <subject>`.

Where: <br />
- `type` is to define what type of PR is this.
  Most common types are:
    - `feat`      - for new features, not a new feature for build script
    - `fix`       - for bug fixes or improvements, not a fix for build script
    - `chore`     - changes not related to production code
    - `docs`      - changes related to documentation
    - `style`     - formatting, missing semi colons, linting fix etc; no significant production code changes
    - `test`      - adding missing tests, refactoring tests; no production code change
    - `refactor`  - refactoring production code, eg. renaming a variable or function name, there should not be any significant production code changes

- `scope` is a single word that best describes where the changes fit.
    - feature(`monitor`,`enforcer`)
    - test(`tests`, `bdd`)
    - chore(`build`)
- `subject` is a single line brief description of the changes made in the pull request.

-->