### PR TITLE
fix(monitor, feeder): validate sysexecve events against empty process check

### DIFF
--- a/KubeArmor/monitor/systemMonitor.go
+++ b/KubeArmor/monitor/systemMonitor.go
@@ -1005,6 +1005,10 @@ func (mon *SystemMonitor) TraceSyscall() {
 						log.ExecEvent.ExecutableName = comm
 					}
 
+					if mon.isProcessInformationMissing(&log) {
+						continue
+					}
+
 					// push the generated log
 					if mon.Logger != nil {
 						go mon.Logger.PushLog(log)
@@ -1100,6 +1104,10 @@ func (mon *SystemMonitor) TraceSyscall() {
 					log.ExecEvent.ExecID = strconv.FormatUint(ctx.ExecID, 10)
 					if comm := strings.TrimRight(string(ctx.Comm[:]), "\x00"); len(comm) > 0 {
 						log.ExecEvent.ExecutableName = comm
+					}
+
+					if mon.isProcessInformationMissing(&log) {
+						continue
 					}
 
 					// push the generated log


### PR DESCRIPTION
**Purpose of PR?**:

An event with incomplete information should be dropped, we have check to ensure an event should not have missing process information.

https://github.com/kubearmor/KubeArmor/blob/feb6ca46679963c82a1c966a090a33c800343d89/KubeArmor/monitor/logUpdate.go#L562-L583

but execve(at) events would not go through this check and will be published by the feeder. This PR extends that check for execve events as well.

https://github.com/kubearmor/KubeArmor/blob/feb6ca46679963c82a1c966a090a33c800343d89/KubeArmor/monitor/systemMonitor.go#L937

https://github.com/kubearmor/KubeArmor/blob/feb6ca46679963c82a1c966a090a33c800343d89/KubeArmor/monitor/systemMonitor.go#L1015

For any reasons if a process event has missing process information for example the following event

```
Action:            "",
ClusterName:       "",
Cwd:               "/",
Data:              "syscall=SYS_EXECVE",
Enforcer:          "",
HostName:          "",
HostPID:           7352,
HostPPID:          3676,
Operation:         "Process",
Owner:             &tp.PodOwner{Name: "", Ref: ""},
PID:               7352,
PPID:              0,
ParentProcessName: "/bin/bash",
PolicyName:        "",
Resource:          "/bin/ps -aef",
Result:            "Passed",
Source:            "/bin/bash",
Timestamp:         1769660966,
Type:              "",
UID:               1000,
```
will result in false positive alert if an allow based policy has been applied.
```yaml
process:
  matchDirectories:
  - dir: /
    recursive: true
    action: Allow
```

```yaml
ClusterName: default
HostName: archlinux
Type: MatchedHostPolicy
PolicyName: DefaultPosture
Source: /bin/bash
Resource: /bin/ps -aef
Operation: Process
Action: Audit
Data: syscall=SYS_EXECVE
EventData: map[Syscall:SYS_EXECVE]
Enforcer: eBPF Monitor
Result: Passed
Cwd: /
ExecEvent: map[]
HostPID: 7352
HostPPID: 3676
NodeID: cbbe24ef5c334bb0dfedf2fabd78ccaf217b2fefd69e16e2a72622e09e716634
PID: 7352
PPID: 0
ParentProcessName: /bin/bash
UID: 1000
```

**Does this PR introduce a breaking change?**

**If the changes in this PR are manually verified, list down the scenarios covered:**:

**Additional information for reviewer?** :
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [x] Bug fix.
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Commit has unit tests
- [ ] Commit has integration tests

<!--

The PR title message must follow convention:
`<type>(<scope>): <subject>`.

Where: <br />
- `type` is to define what type of PR is this.
  Most common types are:
    - `feat`      - for new features, not a new feature for build script
    - `fix`       - for bug fixes or improvements, not a fix for build script
    - `chore`     - changes not related to production code
    - `docs`      - changes related to documentation
    - `style`     - formatting, missing semi colons, linting fix etc; no significant production code changes
    - `test`      - adding missing tests, refactoring tests; no production code change
    - `refactor`  - refactoring production code, eg. renaming a variable or function name, there should not be any significant production code changes

- `scope` is a single word that best describes where the changes fit.
    - feature(`monitor`,`enforcer`)
    - test(`tests`, `bdd`)
    - chore(`build`)
- `subject` is a single line brief description of the changes made in the pull request.

-->