### PR TITLE
chore(makefile): define RHEL9_BUILD_GTE_400 macro correctly

### DIFF
--- a/KubeArmor/BPF/Makefile.vars
+++ b/KubeArmor/BPF/Makefile.vars
@@ -83,11 +83,11 @@ $(info RHEL9 compatible kernel, build: $(RHEL9_BUILD))
     RHEL9_BUILD_GTE_400 := $(shell [ $(RHEL9_BUILD) -ge 400 ] && echo 1 || echo 0)
     ifeq ($(RHEL9_BUILD_GTE_400),1)
         $(info RHEL9 build is greater or equal to 400)
+    	INC_F += -DRHEL9_BUILD_GTE_400
     else
         $(info RHEL9 build is less than 400)
     endif
 
-    INC_F += -DRHEL9_BUILD_GTE_400
 else
     $(info Non-RHEL9 kernel, skipping RHEL9-specific logic)
 endif


### PR DESCRIPTION
**Purpose of PR?**:
<img width="605" height="139" alt="image (11)" src="https://github.com/user-attachments/assets/337c0c2e-e5de-4356-9534-83295ef0c25a" />



`-DRHEL9_BUILD_GTE_400` defines the macro equivalent to `#define RHEL9_BUILD_GTE_400 1` currently the macro was defined for all the case irrespective of the build version check it's leading system monitor build fail on rhel9 based distro with build version < 400. this PR fixes this issue by defining RHEL9_BUILD_GTE_400 only when build is atleast 400.

**Does this PR introduce a breaking change?**
No
**If the changes in this PR are manually verified, list down the scenarios covered:**:

**Additional information for reviewer?** :
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [x] Bug fix. Fixes
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Commit has unit tests
- [ ] Commit has integration tests

<!--

The PR title message must follow convention:
`<type>(<scope>): <subject>`.

Where: <br />
- `type` is to define what type of PR is this.
  Most common types are:
    - `feat`      - for new features, not a new feature for build script
    - `fix`       - for bug fixes or improvements, not a fix for build script
    - `chore`     - changes not related to production code
    - `docs`      - changes related to documentation
    - `style`     - formatting, missing semi colons, linting fix etc; no significant production code changes
    - `test`      - adding missing tests, refactoring tests; no production code change
    - `refactor`  - refactoring production code, eg. renaming a variable or function name, there should not be any significant production code changes

- `scope` is a single word that best describes where the changes fit.
    - feature(`monitor`,`enforcer`)
    - test(`tests`, `bdd`)
    - chore(`build`)
- `subject` is a single line brief description of the changes made in the pull request.

-->