### PR TITLE
fix(snitch): add check to detect runtime based on socket file

### DIFF
--- a/pkg/KubeArmorOperator/runtime/runtime.go
+++ b/pkg/KubeArmorOperator/runtime/runtime.go
@@ -67,6 +67,7 @@ func DetectRuntimeViaMap(pathPrefix string, k8sRuntime string, explicitSocket st
 						log.Warnf("%s", err)
 					}
 				}
+				k8sRuntime := determineRuntimeFromSocket(path)
 				return k8sRuntime, path, ""
 			} else {
 				log.Warnf("%s", err)
@@ -77,6 +78,7 @@ func DetectRuntimeViaMap(pathPrefix string, k8sRuntime string, explicitSocket st
 	for runtime, paths := range common.ContainerRuntimeSocketMap {
 		for _, path := range paths {
 			if _, err := os.Stat(pathPrefix + path); err == nil || os.IsPermission(err) {
+				runtime = determineRuntimeFromSocket(path)
 				return runtime, path, ""
 			} else {
 				log.Warnf("%s", err)


### PR DESCRIPTION
**Purpose of PR?**:

in `Kubernetes → Docker → containerd` scenario where docker is using containerd underneath and configured to use `containerd.sock` snitch will return runtime as docker and consequently kubearmor will create a docker CRI client over `containerd.sock` that would lead to an issue.

```
2026-02-20 06:51:34.119535      ESC[34mINFOESC[0m       Verifying Docker API client version: 1.51
2026-02-20 06:51:34.119974      ESC[31mERRORESC[0m      Failed to create new Docker client: Get "http://%2Fvar%2Frun%2Fdocker.sock/v1.51/version": net/http: HTTP/1.x transport connection broken: malformed HTTP response "\x00\x00\x06\x04\x00\x00\x00\x00\x00\x00\x05\x00\x00@\x00".
* Are you trying to connect to a TLS-enabled daemon without TLS?
github.com/kubearmor/KubeArmor/KubeArmor/log.Err
        /usr/src/KubeArmor/KubeArmor/log/logger.go:103
github.com/kubearmor/KubeArmor/KubeArmor/feeder.(*Feeder).Errf
        /usr/src/KubeArmor/KubeArmor/feeder/feeder.go:480
github.com/kubearmor/KubeArmor/KubeArmor/core.(*KubeArmorDaemon).GetAlreadyDeployedDockerContainers
        /usr/src/KubeArmor/KubeArmor/core/dockerHandler.go:288
github.com/kubearmor/KubeArmor/KubeArmor/core.KubeArmor
        /usr/src/KubeArmor/KubeArmor/core/kubeArmor.go:781
main.main
        /usr/src/KubeArmor/KubeArmor/main.go:74
runtime.main
        /usr/local/go/src/runtime/proc.go:283
```

this PR adds another check to detect runtime based on the socket file that is being detected to resolve the issue.

**Does this PR introduce a breaking change?**
No
**If the changes in this PR are manually verified, list down the scenarios covered:**:

**Additional information for reviewer?** :
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [x] Bug fix.
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Commit has unit tests
- [ ] Commit has integration tests

<!--

The PR title message must follow convention:
`<type>(<scope>): <subject>`.

Where: <br />
- `type` is to define what type of PR is this.
  Most common types are:
    - `feat`      - for new features, not a new feature for build script
    - `fix`       - for bug fixes or improvements, not a fix for build script
    - `chore`     - changes not related to production code
    - `docs`      - changes related to documentation
    - `style`     - formatting, missing semi colons, linting fix etc; no significant production code changes
    - `test`      - adding missing tests, refactoring tests; no production code change
    - `refactor`  - refactoring production code, eg. renaming a variable or function name, there should not be any significant production code changes

- `scope` is a single word that best describes where the changes fit.
    - feature(`monitor`,`enforcer`)
    - test(`tests`, `bdd`)
    - chore(`build`)
- `subject` is a single line brief description of the changes made in the pull request.

-->