### PR TITLE
fix:  Compilation failed for oracle linux server 7.9 with kernel 5.4

### DIFF
--- a/KubeArmor/BPF/system_monitor.c
+++ b/KubeArmor/BPF/system_monitor.c
@@ -2434,19 +2434,16 @@ int kretprobe__inet_csk_accept(struct pt_regs *ctx)
 
     // Code from https://github.com/iovisor/bcc/blob/master/tools/tcpaccept.py with adaptations
     u16 protocol = 1;
-#ifndef BTF_SUPPORTED
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 6, 0)
+    protocol = READ_KERN(newsk->sk_protocol);
+#else
     int gso_max_segs_offset = offsetof(struct sock, sk_gso_max_segs);
     int sk_lingertime_offset = offsetof(struct sock, sk_lingertime);
-    // this is no more a valid assumption for kernel > v6.8
-    // since BTF is supported since 5.3 it should not be an issue
     if (sk_lingertime_offset - gso_max_segs_offset == 2)
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 6, 0)
-        protocol = READ_KERN(newsk->sk_protocol);
-#else
         protocol = newsk->sk_protocol;
-#endif
     else if (sk_lingertime_offset - gso_max_segs_offset == 4)
-    // 4.10+ with little endian
+// 4.10+ with little endian
 #if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
         protocol = READ_KERN(*(u8 *)((u64)&newsk->sk_gso_max_segs - 3));
     else
@@ -2460,20 +2457,6 @@ int kretprobe__inet_csk_accept(struct pt_regs *ctx)
         protocol = READ_KERN(*(u8 *)((u64)&newsk->sk_wmem_queued - 1));
 #else
 #error "Fix your compiler's __BYTE_ORDER__?!"
-#endif
-#else // <= BTF_SUPPORTED
-
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 6, 0)
-    protocol = READ_KERN(newsk->sk_protocol);
-#else
-    // Pre-5.6 (e.g., 5.4): Bypass the bitfield restriction using a relocatable anchor
-#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
-    protocol = READ_KERN(*(u8 *)((u64)&newsk->sk_gso_max_segs - 3));
-#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
-    protocol = READ_KERN(*(u8 *)((u64)&newsk->sk_gso_max_segs - 1));
-#else
-#error "Fix your compiler's __BYTE_ORDER__?!"
-#endif
 #endif
 #endif
 

--- a/KubeArmor/common/bpffs.go
+++ b/KubeArmor/common/bpffs.go
@@ -116,9 +116,7 @@ func checkOrMountDefaultLocations() error {
 			"inside container and BPFFS is not mounted on the host. ",
 			mapRoot)
 
-		if lockedDown {
-			setMapRoot(mapRoot)
-		}
+		setMapRoot(fallbackBPFFsPath)
 
 		cMounted, cBpffsInstance, err := mountinfo.IsMountFS(mountinfo.FilesystemTypeBPFFS, mapRoot)
 		if err != nil {
@@ -130,7 +128,8 @@ func checkOrMountDefaultLocations() error {
 				return err
 			}
 		} else if !cBpffsInstance {
-			kg.Printf("%s is mounted but has a different filesystem than BPFFS", fallbackBPFFsPath)
+			kg.Warnf("%s is mounted but has a different filesystem than BPFFS", fallbackBPFFsPath)
+
 		}
 	}
 

--- a/KubeArmor/monitor/systemMonitor.go
+++ b/KubeArmor/monitor/systemMonitor.go
@@ -568,7 +568,7 @@ func (mon *SystemMonitor) InitBPF() error {
 		bpfModuleSpec,
 		cle.CollectionOptions{
 			Maps: cle.MapOptions{
-				PinPath: PinPath,
+				PinPath: mon.PinPath,
 			},
 		},
 	)

--- a/KubeArmor/monitor/systemMonitor.go
+++ b/KubeArmor/monitor/systemMonitor.go
@@ -243,6 +243,11 @@ func (mon *SystemMonitor) initBPFMaps() error {
 		}, cle.MapOptions{
 			PinPath: mon.PinPath,
 		})
+	if errviz != nil {
+		mon.Logger.Errf("Error Creating System Monitor Visibility Map : %s", errviz.Error())
+		// returning to avoid updates on nil visibility map
+		return errviz
+	}
 	mon.BpfNsVisibilityMap = visibilityMap
 	mon.UpdateVisibility()
 
@@ -258,6 +263,12 @@ func (mon *SystemMonitor) initBPFMaps() error {
 		}, cle.MapOptions{
 			PinPath: mon.PinPath,
 		})
+	if errconfig != nil {
+		mon.Logger.Errf("Error Creating System Monitor Config Map : %s", errconfig.Error())
+		// returning to avoid updates on nil config map
+		return errconfig
+
+	}
 	mon.BpfConfigMap = bpfConfigMap
 	if cfg.GlobalCfg.HostPolicy {
 		if err := mon.BpfConfigMap.Update(uint32(0), uint32(1), cle.UpdateAny); err != nil {


### PR DESCRIPTION
**Purpose of PR?**:

Fixes #
This PR fixes the System monitor compilation failure for oracle linux server 7.9 with kernel 5.4

RCA :- 
The failure was caused by attempting to access sk_protocol, which is a bit-field in struct sock on kernel 5.4; eBPF (via READ_KERN / offsetof) cannot safely reference bit-fields, leading to compilation error.

This PR adds the same work around which we use on non BTF kernels for extracting protocol.

```
2026-02-26 11:05:20.280766	WARN	Error creating kubernetes config, invalid configuration: no configuration has been provided, try setting KUBERNETES_MASTER environment variable
2026-02-26 11:05:20.281109	INFO	BUILD-INFO: version: v1.6.8-22-g11289149-dirty, branch: fix_oci_7.9, date: 2026-02-26T09:51:59Z
2026-02-26 11:05:20.281407	WARN	Deleting existing map /sys/fs/bpf/kubearmor_alert_throttle. This indicates previous cleanup failed
2026-02-26 11:05:20.281521	WARN	Deleting existing map /sys/fs/bpf/kubearmor_args_store. This indicates previous cleanup failed
2026-02-26 11:05:20.281596	WARN	Deleting existing map /sys/fs/bpf/kubearmor_config. This indicates previous cleanup failed
2026-02-26 11:05:20.281672	WARN	Deleting existing map /sys/fs/bpf/kubearmor_exec_pids. This indicates previous cleanup failed
2026-02-26 11:05:20.281738	WARN	Deleting existing map /sys/fs/bpf/kubearmor_ima_hash_map. This indicates previous cleanup failed
2026-02-26 11:05:20.281810	WARN	Deleting existing map /sys/fs/bpf/kubearmor_visibility. This indicates previous cleanup failed
2026-02-26 11:05:20.281932	INFO	Arguments [alertThrottling:true annotateResources:false bpfFsPath:/sys/fs/bpf cluster:default coverageTest:false criSocket: debug:false defaultCapabilitiesPosture:audit defaultFilePosture:audit defaultNetworkPosture:audit defaultPostureLogs:true dropResourceFromProcessLogs:false enableIMA:false enableKubeArmorHostPolicy:false enableKubeArmorPolicy:true enableKubeArmorStateAgent:false enableKubeArmorVm:false enableNRI:false enableUSBDeviceHandler:false enforcerAlerts:true gRPC:32767 host:aryansharma-test-vm hostDefaultCapabilitiesPosture:audit hostDefaultDevicePosture:audit hostDefaultFilePosture:audit hostDefaultNetworkPosture:audit hostVisibility:default initTimeout:60s k8s:true kubeconfig: logPath:none lsm:bpf,apparmor,selinux machineIDPath:/etc/machine-id matchArgs:true maxAlertPerSec:10 nriIndex:99 nriSocket: procfsMount:/proc seLinuxProfileDir:/tmp/kubearmor.selinux throttleSec:30 tlsCertPath:/var/lib/kubearmor/tls tlsCertProvider:self tlsEnabled:false untrackedNs:kube-system,kubearmor useOCIHooks:false visibility:process,file,network,capabilities]
2026-02-26 11:05:20.282111	INFO	Configuration [{Cluster: Host: GRPC: TLSEnabled:false TLSCertPath: TLSCertProvider: LogPath: SELinuxProfileDir: CRISocket: NRISocket: NRIIndex: NRIEnabled:false Visibility: HostVisibility: EnableIMA:false Policy:false HostPolicy:false KVMAgent:false K8sEnv:false Debug:false DefaultFilePosture: DefaultNetworkPosture: DefaultCapabilitiesPosture: HostDefaultFilePosture: HostDefaultNetworkPosture: HostDefaultCapabilitiesPosture: HostDefaultDevicePosture: CoverageTest:false ConfigUntrackedNs:{v:<nil>} LsmOrder:[] BPFFsPath: EnforcerAlerts:false DefaultPostureLogs:false InitTimeout: StateAgent:false UseOCIHooks:false AlertThrottling:false MaxAlertPerSec:0 ThrottleSec:0 AnnotateResources:false ProcFsMount: DropResourceFromProcessLogs:false MachineIDPath: USBDeviceHandler:false MatchArgs:false}]
2026-02-26 11:05:20.282261	INFO	Final Configuration [{Cluster:default Host:aryansharma-test-vm GRPC:32767 TLSEnabled:false TLSCertPath:/var/lib/kubearmor/tls TLSCertProvider:self LogPath:none SELinuxProfileDir:/tmp/kubearmor.selinux CRISocket:unix:///var/run/docker.sock NRISocket: NRIIndex:99 NRIEnabled:false Visibility:process,network HostVisibility:process,network EnableIMA:false Policy:true HostPolicy:true KVMAgent:false K8sEnv:false Debug:false DefaultFilePosture:audit DefaultNetworkPosture:audit DefaultCapabilitiesPosture:audit HostDefaultFilePosture:audit HostDefaultNetworkPosture:audit HostDefaultCapabilitiesPosture:audit HostDefaultDevicePosture:audit CoverageTest:false ConfigUntrackedNs:{v:[kube-system kubearmor]} LsmOrder:[bpf apparmor selinux] BPFFsPath:/sys/fs/bpf EnforcerAlerts:true DefaultPostureLogs:true InitTimeout:60s StateAgent:true UseOCIHooks:false AlertThrottling:true MaxAlertPerSec:10 ThrottleSec:30 AnnotateResources:false ProcFsMount:/proc DropResourceFromProcessLogs:false MachineIDPath:/etc/machine-id USBDeviceHandler:false MatchArgs:true}]
2026-02-26 11:05:20.282344	INFO	Final Configuration [{Cluster:default Host:aryansharma-test-vm GRPC:32767 TLSEnabled:false TLSCertPath:/var/lib/kubearmor/tls TLSCertProvider:self LogPath:none SELinuxProfileDir:/tmp/kubearmor.selinux CRISocket:unix:///var/run/docker.sock NRISocket: NRIIndex:99 NRIEnabled:false Visibility:process,network HostVisibility:process,network EnableIMA:false Policy:true HostPolicy:true KVMAgent:false K8sEnv:false Debug:false DefaultFilePosture:audit DefaultNetworkPosture:audit DefaultCapabilitiesPosture:audit HostDefaultFilePosture:audit HostDefaultNetworkPosture:audit HostDefaultCapabilitiesPosture:audit HostDefaultDevicePosture:audit CoverageTest:false ConfigUntrackedNs:{v:[kube-system kubearmor]} LsmOrder:[bpf apparmor selinux] BPFFsPath:/sys/fs/bpf EnforcerAlerts:true DefaultPostureLogs:true InitTimeout:60s StateAgent:true UseOCIHooks:false AlertThrottling:true MaxAlertPerSec:10 ThrottleSec:30 AnnotateResources:false ProcFsMount:/proc DropResourceFromProcessLogs:false MachineIDPath:/etc/machine-id USBDeviceHandler:false MatchArgs:true}]
2026-02-26 11:05:20.285258	INFO	Node Name: aryansharma-test-vm
2026-02-26 11:05:20.285276	INFO	Node IP: 172.20.32.2
2026-02-26 11:05:20.285284	INFO	Node ID: a17e93583a8d15e92f852ccdcc99ba4c3dbf2e4438bc10cffe96fdaa3b5931a3
2026-02-26 11:05:20.285291	INFO	OS Image: 
2026-02-26 11:05:20.285299	INFO	Kernel Version: 5.4.17-2136.348.3.el7uek.x86_64
2026-02-26 11:05:20.285863	INFO	Initialized KubeArmor Logger
2026-02-26 11:05:20.285900	INFO	Initialized State Agent Server
2026-02-26 11:05:20.479622	INFO	Detected mounted BPF filesystem at /sys/fs/bpf
2026-02-26 11:05:20.480305	INFO	Initializing eBPF system monitor
bpf visibility map created
visibility map created successfully
2026-02-26 11:05:20.488526	INFO	Successfully added visibility map with key={PidNS:0 MntNS:0} to the kernel
visibility map created successfully
2026-02-26 11:05:20.493503	INFO	Successfully added visibility map with key={PidNS:12648430 MntNS:12648430} to the kernel
bpf config map created
2026-02-26 11:05:20.493632	INFO	Alert Throttling configured {alertThrottling:true, maxAlertPerSec:10, throttleSec:30}
2026-02-26 11:05:20.493647	INFO	Argument matching configured {matchArgs:true}
2026-02-26 11:05:20.493653	INFO	eBPF system monitor object file path: /opt/kubearmor/BPF/system_monitor.bpf.o
2026-02-26 11:05:42.280153	INFO	Initialized the eBPF system monitor
2026-02-26 11:06:02.079261	WARN	error loading kprobe security_path_mknod: creating perf_kprobe PMU (arch-specific fallback for "security_path_mknod"): token __x64_security_path_mknod: not found: no such file or directory
2026-02-26 11:06:02.479231	WARN	error loading kprobe security_path_unlink: creating perf_kprobe PMU (arch-specific fallback for "security_path_unlink"): token __x64_security_path_unlink: not found: no such file or directory
2026-02-26 11:06:02.979171	WARN	error loading kprobe security_path_rmdir: creating perf_kprobe PMU (arch-specific fallback for "security_path_rmdir"): token __x64_security_path_rmdir: not found: no such file or directory
2026-02-26 11:06:04.285307	INFO	Initialized KubeArmor Monitor
2026-02-26 11:06:04.285355	INFO	Started to monitor system events
2026-02-26 11:06:04.379967	WARN	BPF LSM not supported field TestMemfd: program test_memfd: attach LSM/LSMMac: mmap_file LSM hook not supported
2026-02-26 11:06:04.380014	INFO	Supported LSMs: lockdown,capability,yama,selinux
2026-02-26 11:06:04.380056	ERROR	Failed to find /usr/sbin/semanage (stat /usr/sbin/semanage: no such file or directory)
github.com/kubearmor/KubeArmor/KubeArmor/log.Err
	/usr/src/KubeArmor/KubeArmor/log/logger.go:103
github.com/kubearmor/KubeArmor/KubeArmor/feeder.(*Feeder).Errf
	/usr/src/KubeArmor/KubeArmor/feeder/feeder.go:501
github.com/kubearmor/KubeArmor/KubeArmor/enforcer.NewSELinuxEnforcer
	/usr/src/KubeArmor/KubeArmor/enforcer/SELinuxEnforcer.go:50
github.com/kubearmor/KubeArmor/KubeArmor/enforcer.selectLsm
	/usr/src/KubeArmor/KubeArmor/enforcer/runtimeEnforcer.go:85
github.com/kubearmor/KubeArmor/KubeArmor/enforcer.NewRuntimeEnforcer
	/usr/src/KubeArmor/KubeArmor/enforcer/runtimeEnforcer.go:175
github.com/kubearmor/KubeArmor/KubeArmor/core.(*KubeArmorDaemon).InitRuntimeEnforcer
	/usr/src/KubeArmor/KubeArmor/core/kubeArmor.go:323
github.com/kubearmor/KubeArmor/KubeArmor/core.KubeArmor
	/usr/src/KubeArmor/KubeArmor/core/kubeArmor.go:646
main.main
	/usr/src/KubeArmor/KubeArmor/main.go:74
runtime.main
	/usr/local/go/src/runtime/proc.go:283
2026-02-26 11:06:04.380093	ERROR	Failed to find /usr/sbin/semanage (stat /usr/sbin/semanage: no such file or directory)
github.com/kubearmor/KubeArmor/KubeArmor/log.Err
	/usr/src/KubeArmor/KubeArmor/log/logger.go:103
github.com/kubearmor/KubeArmor/KubeArmor/feeder.(*Feeder).Errf
	/usr/src/KubeArmor/KubeArmor/feeder/feeder.go:501
github.com/kubearmor/KubeArmor/KubeArmor/enforcer.NewSELinuxEnforcer
	/usr/src/KubeArmor/KubeArmor/enforcer/SELinuxEnforcer.go:50
github.com/kubearmor/KubeArmor/KubeArmor/enforcer.selectLsm
	/usr/src/KubeArmor/KubeArmor/enforcer/runtimeEnforcer.go:85
github.com/kubearmor/KubeArmor/KubeArmor/enforcer.NewRuntimeEnforcer
	/usr/src/KubeArmor/KubeArmor/enforcer/runtimeEnforcer.go:175
github.com/kubearmor/KubeArmor/KubeArmor/core.(*KubeArmorDaemon).InitRuntimeEnforcer
	/usr/src/KubeArmor/KubeArmor/core/kubeArmor.go:323
github.com/kubearmor/KubeArmor/KubeArmor/core.KubeArmor
	/usr/src/KubeArmor/KubeArmor/core/kubeArmor.go:646
main.main
	/usr/src/KubeArmor/KubeArmor/main.go:74
runtime.main
	/usr/local/go/src/runtime/proc.go:283
2026-02-26 11:06:04.380111	INFO	Disabled KubeArmor Enforcer: failed to create runtime enforcer
2026-02-26 11:06:04.380121	INFO	Disabled Presets: failed to create presets
2026-02-26 11:06:04.380218	INFO	Namespace container_namespace visibiliy configured {File:false Process:true Network:true Capabilities:false DNS:false IMA:false}
2026-02-26 11:06:04.381036	INFO	Verifying Docker API client version: 1.45
2026-02-26 11:06:04.579059	INFO	Initialized Docker Handler (version: 1.45)
visibility map created successfully
2026-02-26 11:06:04.587513	INFO	Successfully added visibility map with key={PidNS:4026532630 MntNS:4026532627} to the kernel
2026-02-26 11:06:04.587540	INFO	Detected a container (added/adaacf515437)
visibility map created successfully
2026-02-26 11:06:04.593504	INFO	Successfully added visibility map with key={PidNS:4026531836 MntNS:4026532623} to the kernel
2026-02-26 11:06:04.593525	INFO	Detected a container (added/de31c4b8f151)
2026-02-26 11:06:04.593536	INFO	Using unix:///var/run/docker.sock for monitoring containers
2026-02-26 11:06:04.593554	INFO	Started to monitor Docker events
2026-02-26 11:06:05.593867	INFO	Started to monitor container security policies on gRPC
2026-02-26 11:06:05.593905	INFO	Started to monitor host security policies on gRPC
2026-02-26 11:06:05.593939	INFO	Started to serve gRPC-based log feeds
2026-02-26 11:06:05.593944	INFO	Initialized KubeArmor
2026-02-26 11:06:05.593968	WARN	Policies dir not found for restoration
2026-02-26 11:06:05.681792	INFO	Added a new client (6cb75fe5-d029-4699-b8d4-d26016d3a8a8) for WatchMessages
2026-02-26 11:06:05.681876	INFO	Added a new client (9af2d01f-58d2-4b18-83e7-ad63c1fa5be4, system) for WatchLogs
2026-02-26 11:06:05.681920	INFO	Added a new client (9501e85f-2821-43df-8b03-86f17c2dae6f, policy) for WatchAlerts
2026-02-26 11:06:05.682449	INFO	Added a new client (736075d9-fc8d-4fb6-8776-3e7ab2968ee9) for WatchState
```

-->