### PR TITLE
fix: verifier bug for kernel 5.4 oracle linux 7.9

### DIFF
--- a/KubeArmor/BPF/system_monitor.c
+++ b/KubeArmor/BPF/system_monitor.c
@@ -21,6 +21,12 @@
 #pragma clang diagnostic ignored "-Wunused-label"
 #endif
 
+#ifndef volatile_reg
+/* Prevent 64-bit stack spill of u32 that causes BPF verifier to lose
+ * bounds tracking on kernels 5.4 */
+#define volatile_reg(var) asm volatile("" : "+r"(var))
+#endif
+
 #ifdef BTF_SUPPORTED
 #include "vmlinux.h"
 #include "vmlinux_macro.h"
@@ -1019,7 +1025,10 @@ static __always_inline int save_all_hashes_to_the_buffer(bufs_t *bufs_p, bool ad
     if (num_of_hashes_idx >= MAX_BUFFER_SIZE || num_of_hashes_idx + num_of_hashes >= MAX_BUFFER_SIZE)
         return -1;
 
-    if (bpf_probe_read(&(bufs_p->buf[num_of_hashes_idx]), sizeof(u8), &num_of_hashes) != 0)
+    u32 idx = num_of_hashes_idx & (MAX_BUFFER_SIZE - 1);
+    volatile_reg(idx);
+
+    if (bpf_probe_read(&(bufs_p->buf[idx]), sizeof(u8), &num_of_hashes) != 0)
     {
         return -1;
     }


### PR DESCRIPTION
**Purpose of PR?**:

Fixes #
``` 2026-03-10 12:46:49.026848	INFO	Arguments [alertThrottling:true annotateResources:false bpfFsPath:/sys/fs/bpf cluster:default coverageTest:false criSocket: debug:false defaultCapabilitiesPosture:audit defaultFilePosture:audit defaultNetworkPosture:audit defaultPostureLogs:true dropResourceFromProcessLogs:false enableIMA:false enableKubeArmorHostPolicy:false enableKubeArmorPolicy:true enableKubeArmorStateAgent:false enableKubeArmorVm:false enableNRI:false enableUSBDeviceHandler:false enforcerAlerts:true gRPC:32767 host:aryan-vm hostDefaultCapabilitiesPosture:audit hostDefaultDevicePosture:audit hostDefaultFilePosture:audit hostDefaultNetworkPosture:audit hostVisibility:default initTimeout:60s k8s:true kubeconfig: logPath:none lsm:bpf,apparmor,selinux machineIDPath:/etc/machine-id matchArgs:true maxAlertPerSec:10 nriIndex:99 nriSocket: procfsMount:/proc seLinuxProfileDir:/tmp/kubearmor.selinux throttleSec:30 tlsCertPath:/var/lib/kubearmor/tls tlsCertProvider:self tlsEnabled:false untrackedNs:kube-system,kubearmor useOCIHooks:false visibility:process,file,network,capabilities]
2026-03-10 12:46:49.027022	INFO	Configuration [{Cluster: Host: GRPC: TLSEnabled:false TLSCertPath: TLSCertProvider: LogPath: SELinuxProfileDir: CRISocket: NRISocket: NRIIndex: NRIEnabled:false Visibility: HostVisibility: EnableIMA:false Policy:false HostPolicy:false KVMAgent:false K8sEnv:false Debug:false DefaultFilePosture: DefaultNetworkPosture: DefaultCapabilitiesPosture: HostDefaultFilePosture: HostDefaultNetworkPosture: HostDefaultCapabilitiesPosture: HostDefaultDevicePosture: CoverageTest:false ConfigUntrackedNs:{v:<nil>} LsmOrder:[] BPFFsPath: EnforcerAlerts:false DefaultPostureLogs:false InitTimeout: StateAgent:false UseOCIHooks:false AlertThrottling:false MaxAlertPerSec:0 ThrottleSec:0 AnnotateResources:false ProcFsMount: DropResourceFromProcessLogs:false MachineIDPath: USBDeviceHandler:false MatchArgs:false}]
2026-03-10 12:46:49.027147	INFO	Final Configuration [{Cluster:default Host:aryan-vm GRPC:32767 TLSEnabled:false TLSCertPath:/var/lib/kubearmor/tls TLSCertProvider:self LogPath:none SELinuxProfileDir:/tmp/kubearmor.selinux CRISocket:unix:///var/run/docker.sock NRISocket: NRIIndex:99 NRIEnabled:false Visibility:process,network HostVisibility:process,network EnableIMA:false Policy:true HostPolicy:true KVMAgent:false K8sEnv:false Debug:false DefaultFilePosture:audit DefaultNetworkPosture:audit DefaultCapabilitiesPosture:audit HostDefaultFilePosture:audit HostDefaultNetworkPosture:audit HostDefaultCapabilitiesPosture:audit HostDefaultDevicePosture:audit CoverageTest:false ConfigUntrackedNs:{v:[kube-system kubearmor]} LsmOrder:[bpf apparmor selinux] BPFFsPath:/sys/fs/bpf EnforcerAlerts:true DefaultPostureLogs:true InitTimeout:60s StateAgent:true UseOCIHooks:false AlertThrottling:true MaxAlertPerSec:10 ThrottleSec:30 AnnotateResources:false ProcFsMount:/proc DropResourceFromProcessLogs:false MachineIDPath:/etc/machine-id USBDeviceHandler:false MatchArgs:true}]
2026-03-10 12:46:49.027261	INFO	Final Configuration [{Cluster:default Host:aryan-vm GRPC:32767 TLSEnabled:false TLSCertPath:/var/lib/kubearmor/tls TLSCertProvider:self LogPath:none SELinuxProfileDir:/tmp/kubearmor.selinux CRISocket:unix:///var/run/docker.sock NRISocket: NRIIndex:99 NRIEnabled:false Visibility:process,network HostVisibility:process,network EnableIMA:false Policy:true HostPolicy:true KVMAgent:false K8sEnv:false Debug:false DefaultFilePosture:audit DefaultNetworkPosture:audit DefaultCapabilitiesPosture:audit HostDefaultFilePosture:audit HostDefaultNetworkPosture:audit HostDefaultCapabilitiesPosture:audit HostDefaultDevicePosture:audit CoverageTest:false ConfigUntrackedNs:{v:[kube-system kubearmor]} LsmOrder:[bpf apparmor selinux] BPFFsPath:/sys/fs/bpf EnforcerAlerts:true DefaultPostureLogs:true InitTimeout:60s StateAgent:true UseOCIHooks:false AlertThrottling:true MaxAlertPerSec:10 ThrottleSec:30 AnnotateResources:false ProcFsMount:/proc DropResourceFromProcessLogs:false MachineIDPath:/etc/machine-id USBDeviceHandler:false MatchArgs:true}]
2026-03-10 12:46:49.124117	INFO	Node Name: aryan-vm
2026-03-10 12:46:49.124535	INFO	Node IP: 172.20.32.2
2026-03-10 12:46:49.124612	INFO	Node ID: aryan-vm
2026-03-10 12:46:49.124683	INFO	OS Image: 
2026-03-10 12:46:49.124732	INFO	Kernel Version: 5.4.17-2136.348.3.el7uek.x86_64
2026-03-10 12:46:49.125600	INFO	Initialized KubeArmor Logger
2026-03-10 12:46:49.125713	INFO	Initialized State Agent Server
2026-03-10 12:46:49.323304	WARN	BPF filesystem is going to be mounted automatically in /sys/fs/bpf. However, it probably means that Kubearmor is running inside container and BPFFS is not mounted on the host. 
2026-03-10 12:46:49.323600	INFO	Mounting BPF Filesystem at /run/kubearmor/bpffs
2026-03-10 12:46:49.324360	INFO	Detected mounted BPF filesystem at /run/kubearmor/bpffs
2026-03-10 12:46:49.324962	INFO	Initializing eBPF system monitor
2026-03-10 12:46:49.335200	INFO	Successfully added visibility map with key={PidNS:0 MntNS:0} to the kernel
2026-03-10 12:46:49.342166	INFO	Successfully added visibility map with key={PidNS:12648430 MntNS:12648430} to the kernel
2026-03-10 12:46:49.342286	INFO	Alert Throttling configured {alertThrottling:true, maxAlertPerSec:10, throttleSec:30}
2026-03-10 12:46:49.342301	INFO	Argument matching configured {matchArgs:true}
2026-03-10 12:46:49.342330	INFO	eBPF system monitor object file path: /opt/kubearmor/BPF/system_monitor.bpf.o
2026-03-10 12:47:06.525279	INFO	Initialized the eBPF system monitor
[opc@aryan-vm ~]$ docker logs kubearmor
2026-03-10 12:46:49.026352	WARN	Error creating kubernetes config, invalid configuration: no configuration has been provided, try setting KUBERNETES_MASTER environment variable
2026-03-10 12:46:49.026605	INFO	BUILD-INFO: version: v1.6.8-31-gb91cdf83-dirty, branch: fix-verifier-bug, date: 2026-03-10T12:35:44Z
latest build aryan test new
2026-03-10 12:46:49.026848	INFO	Arguments [alertThrottling:true annotateResources:false bpfFsPath:/sys/fs/bpf cluster:default coverageTest:false criSocket: debug:false defaultCapabilitiesPosture:audit defaultFilePosture:audit defaultNetworkPosture:audit defaultPostureLogs:true dropResourceFromProcessLogs:false enableIMA:false enableKubeArmorHostPolicy:false enableKubeArmorPolicy:true enableKubeArmorStateAgent:false enableKubeArmorVm:false enableNRI:false enableUSBDeviceHandler:false enforcerAlerts:true gRPC:32767 host:aryan-vm hostDefaultCapabilitiesPosture:audit hostDefaultDevicePosture:audit hostDefaultFilePosture:audit hostDefaultNetworkPosture:audit hostVisibility:default initTimeout:60s k8s:true kubeconfig: logPath:none lsm:bpf,apparmor,selinux machineIDPath:/etc/machine-id matchArgs:true maxAlertPerSec:10 nriIndex:99 nriSocket: procfsMount:/proc seLinuxProfileDir:/tmp/kubearmor.selinux throttleSec:30 tlsCertPath:/var/lib/kubearmor/tls tlsCertProvider:self tlsEnabled:false untrackedNs:kube-system,kubearmor useOCIHooks:false visibility:process,file,network,capabilities]
2026-03-10 12:46:49.027022	INFO	Configuration [{Cluster: Host: GRPC: TLSEnabled:false TLSCertPath: TLSCertProvider: LogPath: SELinuxProfileDir: CRISocket: NRISocket: NRIIndex: NRIEnabled:false Visibility: HostVisibility: EnableIMA:false Policy:false HostPolicy:false KVMAgent:false K8sEnv:false Debug:false DefaultFilePosture: DefaultNetworkPosture: DefaultCapabilitiesPosture: HostDefaultFilePosture: HostDefaultNetworkPosture: HostDefaultCapabilitiesPosture: HostDefaultDevicePosture: CoverageTest:false ConfigUntrackedNs:{v:<nil>} LsmOrder:[] BPFFsPath: EnforcerAlerts:false DefaultPostureLogs:false InitTimeout: StateAgent:false UseOCIHooks:false AlertThrottling:false MaxAlertPerSec:0 ThrottleSec:0 AnnotateResources:false ProcFsMount: DropResourceFromProcessLogs:false MachineIDPath: USBDeviceHandler:false MatchArgs:false}]
2026-03-10 12:46:49.027147	INFO	Final Configuration [{Cluster:default Host:aryan-vm GRPC:32767 TLSEnabled:false TLSCertPath:/var/lib/kubearmor/tls TLSCertProvider:self LogPath:none SELinuxProfileDir:/tmp/kubearmor.selinux CRISocket:unix:///var/run/docker.sock NRISocket: NRIIndex:99 NRIEnabled:false Visibility:process,network HostVisibility:process,network EnableIMA:false Policy:true HostPolicy:true KVMAgent:false K8sEnv:false Debug:false DefaultFilePosture:audit DefaultNetworkPosture:audit DefaultCapabilitiesPosture:audit HostDefaultFilePosture:audit HostDefaultNetworkPosture:audit HostDefaultCapabilitiesPosture:audit HostDefaultDevicePosture:audit CoverageTest:false ConfigUntrackedNs:{v:[kube-system kubearmor]} LsmOrder:[bpf apparmor selinux] BPFFsPath:/sys/fs/bpf EnforcerAlerts:true DefaultPostureLogs:true InitTimeout:60s StateAgent:true UseOCIHooks:false AlertThrottling:true MaxAlertPerSec:10 ThrottleSec:30 AnnotateResources:false ProcFsMount:/proc DropResourceFromProcessLogs:false MachineIDPath:/etc/machine-id USBDeviceHandler:false MatchArgs:true}]
2026-03-10 12:46:49.027261	INFO	Final Configuration [{Cluster:default Host:aryan-vm GRPC:32767 TLSEnabled:false TLSCertPath:/var/lib/kubearmor/tls TLSCertProvider:self LogPath:none SELinuxProfileDir:/tmp/kubearmor.selinux CRISocket:unix:///var/run/docker.sock NRISocket: NRIIndex:99 NRIEnabled:false Visibility:process,network HostVisibility:process,network EnableIMA:false Policy:true HostPolicy:true KVMAgent:false K8sEnv:false Debug:false DefaultFilePosture:audit DefaultNetworkPosture:audit DefaultCapabilitiesPosture:audit HostDefaultFilePosture:audit HostDefaultNetworkPosture:audit HostDefaultCapabilitiesPosture:audit HostDefaultDevicePosture:audit CoverageTest:false ConfigUntrackedNs:{v:[kube-system kubearmor]} LsmOrder:[bpf apparmor selinux] BPFFsPath:/sys/fs/bpf EnforcerAlerts:true DefaultPostureLogs:true InitTimeout:60s StateAgent:true UseOCIHooks:false AlertThrottling:true MaxAlertPerSec:10 ThrottleSec:30 AnnotateResources:false ProcFsMount:/proc DropResourceFromProcessLogs:false MachineIDPath:/etc/machine-id USBDeviceHandler:false MatchArgs:true}]
2026-03-10 12:46:49.124117	INFO	Node Name: aryan-vm
2026-03-10 12:46:49.124535	INFO	Node IP: 172.20.32.2
2026-03-10 12:46:49.124612	INFO	Node ID: aryan-vm
2026-03-10 12:46:49.124683	INFO	OS Image: 
2026-03-10 12:46:49.124732	INFO	Kernel Version: 5.4.17-2136.348.3.el7uek.x86_64
2026-03-10 12:46:49.125600	INFO	Initialized KubeArmor Logger
2026-03-10 12:46:49.125713	INFO	Initialized State Agent Server
2026-03-10 12:46:49.323304	WARN	BPF filesystem is going to be mounted automatically in /sys/fs/bpf. However, it probably means that Kubearmor is running inside container and BPFFS is not mounted on the host. 
2026-03-10 12:46:49.323600	INFO	Mounting BPF Filesystem at /run/kubearmor/bpffs
2026-03-10 12:46:49.324360	INFO	Detected mounted BPF filesystem at /run/kubearmor/bpffs
2026-03-10 12:46:49.324962	INFO	Initializing eBPF system monitor
2026-03-10 12:46:49.335200	INFO	Successfully added visibility map with key={PidNS:0 MntNS:0} to the kernel
2026-03-10 12:46:49.342166	INFO	Successfully added visibility map with key={PidNS:12648430 MntNS:12648430} to the kernel
2026-03-10 12:46:49.342286	INFO	Alert Throttling configured {alertThrottling:true, maxAlertPerSec:10, throttleSec:30}
2026-03-10 12:46:49.342301	INFO	Argument matching configured {matchArgs:true}
2026-03-10 12:46:49.342330	INFO	eBPF system monitor object file path: /opt/kubearmor/BPF/system_monitor.bpf.o
2026-03-10 12:47:06.525279	INFO	Initialized the eBPF system monitor
2026-03-10 12:47:26.523886	WARN	error loading kprobe security_path_mknod: creating perf_kprobe PMU (arch-specific fallback for "security_path_mknod"): token __x64_security_path_mknod: not found: no such file or directory
2026-03-10 12:47:26.923851	WARN	error loading kprobe security_path_unlink: creating perf_kprobe PMU (arch-specific fallback for "security_path_unlink"): token __x64_security_path_unlink: not found: no such file or directory
[opc@aryan-vm ~]$ 
[opc@aryan-vm ~]$ docker logs kubearmor
2026-03-10 12:46:49.026352	WARN	Error creating kubernetes config, invalid configuration: no configuration has been provided, try setting KUBERNETES_MASTER environment variable
2026-03-10 12:46:49.026605	INFO	BUILD-INFO: version: v1.6.8-31-gb91cdf83-dirty, branch: fix-verifier-bug, date: 2026-03-10T12:35:44Z
latest build aryan test new
2026-03-10 12:46:49.026848	INFO	Arguments [alertThrottling:true annotateResources:false bpfFsPath:/sys/fs/bpf cluster:default coverageTest:false criSocket: debug:false defaultCapabilitiesPosture:audit defaultFilePosture:audit defaultNetworkPosture:audit defaultPostureLogs:true dropResourceFromProcessLogs:false enableIMA:false enableKubeArmorHostPolicy:false enableKubeArmorPolicy:true enableKubeArmorStateAgent:false enableKubeArmorVm:false enableNRI:false enableUSBDeviceHandler:false enforcerAlerts:true gRPC:32767 host:aryan-vm hostDefaultCapabilitiesPosture:audit hostDefaultDevicePosture:audit hostDefaultFilePosture:audit hostDefaultNetworkPosture:audit hostVisibility:default initTimeout:60s k8s:true kubeconfig: logPath:none lsm:bpf,apparmor,selinux machineIDPath:/etc/machine-id matchArgs:true maxAlertPerSec:10 nriIndex:99 nriSocket: procfsMount:/proc seLinuxProfileDir:/tmp/kubearmor.selinux throttleSec:30 tlsCertPath:/var/lib/kubearmor/tls tlsCertProvider:self tlsEnabled:false untrackedNs:kube-system,kubearmor useOCIHooks:false visibility:process,file,network,capabilities]
2026-03-10 12:46:49.027022	INFO	Configuration [{Cluster: Host: GRPC: TLSEnabled:false TLSCertPath: TLSCertProvider: LogPath: SELinuxProfileDir: CRISocket: NRISocket: NRIIndex: NRIEnabled:false Visibility: HostVisibility: EnableIMA:false Policy:false HostPolicy:false KVMAgent:false K8sEnv:false Debug:false DefaultFilePosture: DefaultNetworkPosture: DefaultCapabilitiesPosture: HostDefaultFilePosture: HostDefaultNetworkPosture: HostDefaultCapabilitiesPosture: HostDefaultDevicePosture: CoverageTest:false ConfigUntrackedNs:{v:<nil>} LsmOrder:[] BPFFsPath: EnforcerAlerts:false DefaultPostureLogs:false InitTimeout: StateAgent:false UseOCIHooks:false AlertThrottling:false MaxAlertPerSec:0 ThrottleSec:0 AnnotateResources:false ProcFsMount: DropResourceFromProcessLogs:false MachineIDPath: USBDeviceHandler:false MatchArgs:false}]
2026-03-10 12:46:49.027147	INFO	Final Configuration [{Cluster:default Host:aryan-vm GRPC:32767 TLSEnabled:false TLSCertPath:/var/lib/kubearmor/tls TLSCertProvider:self LogPath:none SELinuxProfileDir:/tmp/kubearmor.selinux CRISocket:unix:///var/run/docker.sock NRISocket: NRIIndex:99 NRIEnabled:false Visibility:process,network HostVisibility:process,network EnableIMA:false Policy:true HostPolicy:true KVMAgent:false K8sEnv:false Debug:false DefaultFilePosture:audit DefaultNetworkPosture:audit DefaultCapabilitiesPosture:audit HostDefaultFilePosture:audit HostDefaultNetworkPosture:audit HostDefaultCapabilitiesPosture:audit HostDefaultDevicePosture:audit CoverageTest:false ConfigUntrackedNs:{v:[kube-system kubearmor]} LsmOrder:[bpf apparmor selinux] BPFFsPath:/sys/fs/bpf EnforcerAlerts:true DefaultPostureLogs:true InitTimeout:60s StateAgent:true UseOCIHooks:false AlertThrottling:true MaxAlertPerSec:10 ThrottleSec:30 AnnotateResources:false ProcFsMount:/proc DropResourceFromProcessLogs:false MachineIDPath:/etc/machine-id USBDeviceHandler:false MatchArgs:true}]
2026-03-10 12:46:49.027261	INFO	Final Configuration [{Cluster:default Host:aryan-vm GRPC:32767 TLSEnabled:false TLSCertPath:/var/lib/kubearmor/tls TLSCertProvider:self LogPath:none SELinuxProfileDir:/tmp/kubearmor.selinux CRISocket:unix:///var/run/docker.sock NRISocket: NRIIndex:99 NRIEnabled:false Visibility:process,network HostVisibility:process,network EnableIMA:false Policy:true HostPolicy:true KVMAgent:false K8sEnv:false Debug:false DefaultFilePosture:audit DefaultNetworkPosture:audit DefaultCapabilitiesPosture:audit HostDefaultFilePosture:audit HostDefaultNetworkPosture:audit HostDefaultCapabilitiesPosture:audit HostDefaultDevicePosture:audit CoverageTest:false ConfigUntrackedNs:{v:[kube-system kubearmor]} LsmOrder:[bpf apparmor selinux] BPFFsPath:/sys/fs/bpf EnforcerAlerts:true DefaultPostureLogs:true InitTimeout:60s StateAgent:true UseOCIHooks:false AlertThrottling:true MaxAlertPerSec:10 ThrottleSec:30 AnnotateResources:false ProcFsMount:/proc DropResourceFromProcessLogs:false MachineIDPath:/etc/machine-id USBDeviceHandler:false MatchArgs:true}]
2026-03-10 12:46:49.124117	INFO	Node Name: aryan-vm
2026-03-10 12:46:49.124535	INFO	Node IP: 172.20.32.2
2026-03-10 12:46:49.124612	INFO	Node ID: aryan-vm
2026-03-10 12:46:49.124683	INFO	OS Image: 
2026-03-10 12:46:49.124732	INFO	Kernel Version: 5.4.17-2136.348.3.el7uek.x86_64
2026-03-10 12:46:49.125600	INFO	Initialized KubeArmor Logger
2026-03-10 12:46:49.125713	INFO	Initialized State Agent Server
2026-03-10 12:46:49.323304	WARN	BPF filesystem is going to be mounted automatically in /sys/fs/bpf. However, it probably means that Kubearmor is running inside container and BPFFS is not mounted on the host. 
2026-03-10 12:46:49.323600	INFO	Mounting BPF Filesystem at /run/kubearmor/bpffs
2026-03-10 12:46:49.324360	INFO	Detected mounted BPF filesystem at /run/kubearmor/bpffs
2026-03-10 12:46:49.324962	INFO	Initializing eBPF system monitor
2026-03-10 12:46:49.335200	INFO	Successfully added visibility map with key={PidNS:0 MntNS:0} to the kernel
2026-03-10 12:46:49.342166	INFO	Successfully added visibility map with key={PidNS:12648430 MntNS:12648430} to the kernel
2026-03-10 12:46:49.342286	INFO	Alert Throttling configured {alertThrottling:true, maxAlertPerSec:10, throttleSec:30}
2026-03-10 12:46:49.342301	INFO	Argument matching configured {matchArgs:true}
2026-03-10 12:46:49.342330	INFO	eBPF system monitor object file path: /opt/kubearmor/BPF/system_monitor.bpf.o
2026-03-10 12:47:06.525279	INFO	Initialized the eBPF system monitor
2026-03-10 12:47:26.523886	WARN	error loading kprobe security_path_mknod: creating perf_kprobe PMU (arch-specific fallback for "security_path_mknod"): token __x64_security_path_mknod: not found: no such file or directory
2026-03-10 12:47:26.923851	WARN	error loading kprobe security_path_unlink: creating perf_kprobe PMU (arch-specific fallback for "security_path_unlink"): token __x64_security_path_unlink: not found: no such file or directory
2026-03-10 12:47:27.323907	WARN	error loading kprobe security_path_rmdir: creating perf_kprobe PMU (arch-specific fallback for "security_path_rmdir"): token __x64_security_path_rmdir: not found: no such file or directory
2026-03-10 12:47:28.729916	INFO	Initialized KubeArmor Monitor
2026-03-10 12:47:28.729967	INFO	Started to monitor system events
2026-03-10 12:47:28.823614	WARN	BPF LSM not supported field TestMemfd: program test_memfd: attach LSM/LSMMac: mmap_file LSM hook not supported
2026-03-10 12:47:28.823663	INFO	Supported LSMs: lockdown,capability,yama,selinux
2026-03-10 12:47:28.823839	ERROR	Failed to find /usr/sbin/semanage (stat /usr/sbin/semanage: no such file or directory)
github.com/kubearmor/KubeArmor/KubeArmor/log.Err
	/usr/src/KubeArmor/KubeArmor/log/logger.go:103
github.com/kubearmor/KubeArmor/KubeArmor/feeder.(*Feeder).Errf
	/usr/src/KubeArmor/KubeArmor/feeder/feeder.go:501
github.com/kubearmor/KubeArmor/KubeArmor/enforcer.NewSELinuxEnforcer
	/usr/src/KubeArmor/KubeArmor/enforcer/SELinuxEnforcer.go:50
github.com/kubearmor/KubeArmor/KubeArmor/enforcer.selectLsm
	/usr/src/KubeArmor/KubeArmor/enforcer/runtimeEnforcer.go:85
github.com/kubearmor/KubeArmor/KubeArmor/enforcer.NewRuntimeEnforcer
	/usr/src/KubeArmor/KubeArmor/enforcer/runtimeEnforcer.go:175
github.com/kubearmor/KubeArmor/KubeArmor/core.(*KubeArmorDaemon).InitRuntimeEnforcer
	/usr/src/KubeArmor/KubeArmor/core/kubeArmor.go:321
github.com/kubearmor/KubeArmor/KubeArmor/core.KubeArmor
	/usr/src/KubeArmor/KubeArmor/core/kubeArmor.go:653
main.main
	/usr/src/KubeArmor/KubeArmor/main.go:76
runtime.main
	/usr/local/go/src/runtime/proc.go:283
2026-03-10 12:47:28.823911	ERROR	Failed to find /usr/sbin/semanage (stat /usr/sbin/semanage: no such file or directory)
github.com/kubearmor/KubeArmor/KubeArmor/log.Err
	/usr/src/KubeArmor/KubeArmor/log/logger.go:103
github.com/kubearmor/KubeArmor/KubeArmor/feeder.(*Feeder).Errf
	/usr/src/KubeArmor/KubeArmor/feeder/feeder.go:501
github.com/kubearmor/KubeArmor/KubeArmor/enforcer.NewSELinuxEnforcer
	/usr/src/KubeArmor/KubeArmor/enforcer/SELinuxEnforcer.go:50
github.com/kubearmor/KubeArmor/KubeArmor/enforcer.selectLsm
	/usr/src/KubeArmor/KubeArmor/enforcer/runtimeEnforcer.go:85
github.com/kubearmor/KubeArmor/KubeArmor/enforcer.NewRuntimeEnforcer
	/usr/src/KubeArmor/KubeArmor/enforcer/runtimeEnforcer.go:175
github.com/kubearmor/KubeArmor/KubeArmor/core.(*KubeArmorDaemon).InitRuntimeEnforcer
	/usr/src/KubeArmor/KubeArmor/core/kubeArmor.go:321
github.com/kubearmor/KubeArmor/KubeArmor/core.KubeArmor
	/usr/src/KubeArmor/KubeArmor/core/kubeArmor.go:653
main.main
	/usr/src/KubeArmor/KubeArmor/main.go:76
runtime.main
	/usr/local/go/src/runtime/proc.go:283
2026-03-10 12:47:28.823954	INFO	Disabled KubeArmor Enforcer: failed to create runtime enforcer
2026-03-10 12:47:28.823987	INFO	Disabled Presets: failed to create presets
2026-03-10 12:47:28.824102	INFO	Namespace container_namespace visibiliy configured {File:false Process:true Network:true Capabilities:false DNS:false IMA:false}
2026-03-10 12:47:28.825427	INFO	Verifying Docker API client version: 1.45
2026-03-10 12:47:28.924171	INFO	Initialized Docker Handler (version: 1.45)
2026-03-10 12:47:28.932171	INFO	Successfully added visibility map with key={PidNS:4026532704 MntNS:4026532701} to the kernel
2026-03-10 12:47:28.932192	INFO	Detected a container (added/fffc1ac03b2a)
2026-03-10 12:47:28.942181	INFO	Successfully added visibility map with key={PidNS:4026531836 MntNS:4026532622} to the kernel
2026-03-10 12:47:28.942200	INFO	Detected a container (added/1ec8abcbbff8)
2026-03-10 12:47:28.942219	INFO	Using unix:///var/run/docker.sock for monitoring containers
2026-03-10 12:47:28.942242	INFO	Started to monitor Docker events
2026-03-10 12:47:29.942321	INFO	Started to monitor container security policies on gRPC
2026-03-10 12:47:29.942363	INFO	Started to monitor host security policies on gRPC
2026-03-10 12:47:29.942420	INFO	Started to serve gRPC-based log feeds
2026-03-10 12:47:29.942429	INFO	Initialized KubeArmor
2026-03-10 12:47:29.942465	WARN	Policies dir not found for restoration
2026-03-10 12:47:30.028208	INFO	Added a new client (fb536b2e-aeb1-4811-a2dc-1d94b7f234fb) for WatchState
2026-03-10 12:47:30.029256	INFO	Added a new client (931b2601-325f-40cd-a759-fe3b40775353) for WatchMessages
2026-03-10 12:47:30.029296	INFO	Added a new client (2b8ffc50-4bb8-4d21-8ac8-90c4231bac34, system) for WatchLogs
2026-03-10 12:47:30.029333	INFO	Added a new client (7e75eeef-f8fe-4fdd-a5b7-0ea24ea5ed8e, policy) for WatchAlerts
```

**Does this PR introduce a breaking change?**

**If the changes in this PR are manually verified, list down the scenarios covered:**:

**Additional information for reviewer?** :
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [ ] Bug fix. Fixes #<issue number>
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Commit has unit tests
- [ ] Commit has integration tests

<!--

The PR title message must follow convention:
`<type>(<scope>): <subject>`.

Where: <br />
- `type` is to define what type of PR is this.
  Most common types are:
    - `feat`      - for new features, not a new feature for build script
    - `fix`       - for bug fixes or improvements, not a fix for build script
    - `chore`     - changes not related to production code
    - `docs`      - changes related to documentation
    - `style`     - formatting, missing semi colons, linting fix etc; no significant production code changes
    - `test`      - adding missing tests, refactoring tests; no production code change
    - `refactor`  - refactoring production code, eg. renaming a variable or function name, there should not be any significant production code changes

- `scope` is a single word that best describes where the changes fit.
    - feature(`monitor`,`enforcer`)
    - test(`tests`, `bdd`)
    - chore(`build`)
- `subject` is a single line brief description of the changes made in the pull request.

-->