### PR TITLE
fix(enforcer): icmpv6 protocol rule with bpflsm enforcer

### DIFF
--- a/KubeArmor/enforcer/bpflsm/rulesHandling.go
+++ b/KubeArmor/enforcer/bpflsm/rulesHandling.go
@@ -53,7 +53,7 @@ var protocols = map[string]uint16{
 	"ICMP":   1,
 	"TCP":    6,
 	"UDP":    17,
-	"ICMPv6": 58,
+	"ICMPV6": 58,
 	"SCTP":   132,
 }
 

--- a/KubeArmor/feeder/policyMatcher.go
+++ b/KubeArmor/feeder/policyMatcher.go
@@ -24,15 +24,15 @@ import (
 func GetProtocolFromName(proto string) string {
 	switch strings.ToLower(proto) {
 	case "tcp":
-		return "protocol=TCP,type=SOCK_STREAM"
+		return "protocol=TCP type=SOCK_STREAM"
 	case "udp":
-		return "protocol=UDP,type=SOCK_DGRAM"
+		return "protocol=UDP type=SOCK_DGRAM"
 	case "icmp":
-		return "protocol=ICMP,type=SOCK_RAW"
-	case "icmpv6":
-		return "protocol=ICMPv6,type=SOCK_RAW"
+		return "protocol=ICMP type=SOCK_RAW"
+	case "icmpv6", "ipv6-icmp":
+		return "protocol=ICMPV6 type=SOCK_RAW"
 	case "sctp":
-		return "protocol=SCTP,type=SOCK_STREAM|SOCK_SEQPACKET"
+		return "protocol=SCTP type=SOCK_STREAM|SOCK_SEQPACKET"
 	default:
 		return proto
 	}
@@ -64,14 +64,14 @@ func fetchProtocol(resource string) string {
 		return "tcp"
 	} else if strings.Contains(resource, "protocol=UDP") || (strings.Contains(resource, "SOCK_DGRAM") && strings.Contains(resource, "protocol=HOPOPT")) {
 		return "udp"
+	} else if strings.Contains(resource, "protocol=ICMPV6") {
+		return "icmpv6"
 	} else if strings.Contains(resource, "protocol=ICMP") {
 		return "icmp"
-	} else if strings.Contains(resource, "SOCK_RAW") {
-		return "raw"
-	} else if strings.Contains(resource, "protocol=ICMPv6") {
-		return "icmpv6"
 	} else if strings.Contains(resource, "protocol=SCTP") {
 		return "sctp"
+	} else if strings.Contains(resource, "SOCK_RAW") {
+		return "raw"
 	} else if strings.Contains(resource, "SOCK_STREAM") {
 		return "stream"
 	} else if strings.Contains(resource, "SOCK_DGRAM") {


### PR DESCRIPTION
**Purpose of PR?**:
icmpv6 protocol rule enforcement was broken due to an character case issue, this PR fixes that issue by updating ICMPv6 to ICMPV6.  

**Does this PR introduce a breaking change?**
No
**If the changes in this PR are manually verified, list down the scenarios covered:**:

tested the following policy:

```yaml
apiVersion: security.kubearmor.com/v1
kind: KubeArmorPolicy
metadata:
  name: ksp-icmpv6
spec:
  severity: 8
  selector:
    matchLabels:
      run: ipv6-test
  network:
    matchProtocols:
    - protocol: icmpv6
  action: Block
```
```
kubectl run ipv6-test --rm -it --image=busybox -- sh
If you don't see a command prompt, try pressing enter.
/ # ping -6 ::1
PING ::1 (::1): 56 data bytes
ping: can't create raw socket: Permission denied
```
```
== Alert / 2026-03-10 18:13:56.591721 ==
ClusterName: default
HostName: archlinux
NamespaceName: default
PodName: ipv6-test
Labels: run=ipv6-test
ContainerName: ipv6-test
ContainerID: e14e66592e00d3ee66041ef086927e4669ed0b421a560f2303a1d9c91139b75c
ContainerImage: docker.io/library/busybox:latest@sha256:b3255e7dfbcd10cb367af0d409747d511aeb66dfac98cf30e97e87e4207dd76f
Type: MatchedPolicy
PolicyName: ksp-icmpv6
Severity: 8
Source: /bin/ping -6 ::1
Resource: protocol=ICMPV6 type=SOCK_RAW
Operation: Network
Action: Block
Data: lsm=SOCKET_CREATE protocol=ICMPV6 type=SOCK_RAW
EventData: map[Lsm:SOCKET_CREATE Protocol:ICMPV6 Type:SOCK_RAW]
Enforcer: BPFLSM
Result: Permission denied
Cwd: /
ExecEvent: map[ExecID:0 ExecutableName:ping]
HostPID: 381318
HostPPID: 381136
Owner: map[Name:ipv6-test Namespace:default]
PID: 7
PPID: 381136
ParentProcessName: /bin/sh
ProcessName: /bin/ping
TTY: pts0
UID: 0
```



**Checklist:**
- [x] Bug fix. Fixes
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Commit has unit tests
- [ ] Commit has integration tests

<!--

The PR title message must follow convention:
`<type>(<scope>): <subject>`.

Where: <br />
- `type` is to define what type of PR is this.
  Most common types are:
    - `feat`      - for new features, not a new feature for build script
    - `fix`       - for bug fixes or improvements, not a fix for build script
    - `chore`     - changes not related to production code
    - `docs`      - changes related to documentation
    - `style`     - formatting, missing semi colons, linting fix etc; no significant production code changes
    - `test`      - adding missing tests, refactoring tests; no production code change
    - `refactor`  - refactoring production code, eg. renaming a variable or function name, there should not be any significant production code changes

- `scope` is a single word that best describes where the changes fit.
    - feature(`monitor`,`enforcer`)
    - test(`tests`, `bdd`)
    - chore(`build`)
- `subject` is a single line brief description of the changes made in the pull request.

-->