### PR TITLE
fix icmpv6 protocol rule policy matching

### DIFF
--- a/KubeArmor/feeder/policyMatcher.go
+++ b/KubeArmor/feeder/policyMatcher.go
@@ -29,8 +29,8 @@ func GetProtocolFromName(proto string) string {
 		return "protocol=UDP type=SOCK_DGRAM"
 	case "icmp":
 		return "protocol=ICMP type=SOCK_RAW"
-	case "icmpv6", "ipv6-icmp":
-		return "protocol=ICMPV6 type=SOCK_RAW"
+	case "ipv6-icmp":
+		return "protocol=IPv6-ICMP type=SOCK_RAW"
 	case "sctp":
 		return "protocol=SCTP type=SOCK_STREAM|SOCK_SEQPACKET"
 	default:
@@ -64,7 +64,7 @@ func fetchProtocol(resource string) string {
 		return "tcp"
 	} else if strings.Contains(resource, "protocol=UDP") || (strings.Contains(resource, "SOCK_DGRAM") && strings.Contains(resource, "protocol=HOPOPT")) {
 		return "udp"
-	} else if strings.Contains(resource, "protocol=ICMPV6") {
+	} else if strings.Contains(resource, "protocol=IPv6-ICMP") {
 		return "icmpv6"
 	} else if strings.Contains(resource, "protocol=ICMP") {
 		return "icmp"


### PR DESCRIPTION
**Purpose of PR?**:

previously the same issue was partially fixed with https://github.com/kubearmor/KubeArmor/pull/2494 but the issue still persist if the event source is system monitor instead of bpflsm enforcer. this PR solves the issue for all scenarios.

**Does this PR introduce a breaking change?**
No
**If the changes in this PR are manually verified, list down the scenarios covered:**:

validate both Audit and Block based policy

```
kubectl run ipv6-test --rm -it --image=busybox -- sh
If you don't see a command prompt, try pressing enter.
/ # ping -6 ::1
PING ::1 (::1): 56 data bytes
64 bytes from ::1: seq=0 ttl=64 time=0.060 ms
64 bytes from ::1: seq=1 ttl=64 time=0.074 ms
64 bytes from ::1: seq=2 ttl=64 time=0.093 ms
^C
--- ::1 ping statistics ---
3 packets transmitted, 3 packets received, 0% packet loss
round-trip min/avg/max = 0.060/0.075/0.093 ms
/ # ping -6 ::1
PING ::1 (::1): 56 data bytes
ping: can't create raw socket: Permission denied
```
```
karmor logs --gRPC=:32767 --namespace default
Created a gRPC client (:32767)
Checked the liveness of the gRPC server
Started to watch alerts
== Alert / 2026-03-13 07:21:05.889078 ==
ClusterName: default
HostName: archlinux
NamespaceName: default
PodName: ipv6-test
Labels: run=ipv6-test
ContainerName: ipv6-test
ContainerID: 1749854f5ee028c154460a1c1b06667c6904034d1a6163ae984b0fba244fece5
ContainerImage: docker.io/library/busybox:latest@sha256:b3255e7dfbcd10cb367af0d409747d511aeb66dfac98cf30e97e87e4207dd76f
Type: MatchedPolicy
PolicyName: ksp-icmpv6
Severity: 8
Source: /bin/ping -6 ::1
Resource: protocol=IPv6-ICMP type=SOCK_RAW
Operation: Network
Action: Block
Data: lsm=SOCKET_CREATE protocol=IPv6-ICMP type=SOCK_RAW
EventData: map[Lsm:SOCKET_CREATE Protocol:IPv6-ICMP Type:SOCK_RAW]
Enforcer: BPFLSM
Result: Permission denied
Cwd: /
ExecEvent: map[ExecID:0 ExecutableName:ping]
HostPID: 718157
HostPPID: 708829
NodeID: 88ac5546ff974c7a8f5a619e7e1f8c0f
Owner: map[Name:ipv6-test Namespace:default]
PID: 10
PPID: 708829
ParentProcessName: /bin/sh
ProcessName: /bin/ping
TTY: pts0
UID: 0

== Alert / 2026-03-13 07:21:36.646348 ==
ClusterName: default
HostName: archlinux
NamespaceName: default
PodName: ipv6-test
Labels: run=ipv6-test
ContainerName: ipv6-test
ContainerID: 1749854f5ee028c154460a1c1b06667c6904034d1a6163ae984b0fba244fece5
ContainerImage: docker.io/library/busybox:latest@sha256:b3255e7dfbcd10cb367af0d409747d511aeb66dfac98cf30e97e87e4207dd76f
Type: MatchedPolicy
PolicyName: ksp-icmpv6
Severity: 8
Source: /bin/ping -6 ::1
Resource: domain=AF_INET6 type=SOCK_RAW protocol=IPv6-ICMP
Operation: Network
Action: Audit
Data: syscall=SYS_SOCKET
EventData: map[Domain:AF_INET6 Protocol:IPv6-ICMP Syscall:SYS_SOCKET Type:SOCK_RAW]
Enforcer: eBPF Monitor
Result: Passed
Cwd: /
ExecEvent: map[ExecID:0 ExecutableName:ping]
HostPID: 718330
HostPPID: 708829
Owner: map[Name:ipv6-test Namespace:default]
PID: 11
PPID: 1
ParentProcessName: /bin/sh
ProcessName: /bin/ping
TTY: pts0
UID: 0
```

**Checklist:**
- [x] Bug fix.
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Commit has unit tests
- [ ] Commit has integration tests

<!--

The PR title message must follow convention:
`<type>(<scope>): <subject>`.

Where: <br />
- `type` is to define what type of PR is this.
  Most common types are:
    - `feat`      - for new features, not a new feature for build script
    - `fix`       - for bug fixes or improvements, not a fix for build script
    - `chore`     - changes not related to production code
    - `docs`      - changes related to documentation
    - `style`     - formatting, missing semi colons, linting fix etc; no significant production code changes
    - `test`      - adding missing tests, refactoring tests; no production code change
    - `refactor`  - refactoring production code, eg. renaming a variable or function name, there should not be any significant production code changes

- `scope` is a single word that best describes where the changes fit.
    - feature(`monitor`,`enforcer`)
    - test(`tests`, `bdd`)
    - chore(`build`)
- `subject` is a single line brief description of the changes made in the pull request.

-->