### PR TITLE
fix(cri): retry logic for container runtimes in case of failures

### DIFF
--- a/KubeArmor/core/containerdHandler.go
+++ b/KubeArmor/core/containerdHandler.go
@@ -138,11 +138,13 @@ func (ch *ContainerdHandler) Reconnect() error {
 	ch.client = client
 
 	// Resubscribe to docker namespace events
+	ch.docker = namespaces.WithNamespace(context.Background(), "moby")
 	dockerEventsCh, dockerErrCh := client.EventService().Subscribe(ch.docker, "")
 	ch.dockerEventsCh = dockerEventsCh
 	ch.dockerErrCh = dockerErrCh
 
 	// Resubscribe to k8s namespace events
+	ch.containerd = namespaces.WithNamespace(context.Background(), "k8s.io")
 	k8sEventsCh, k8sErrCh := client.EventService().Subscribe(ch.containerd, "")
 	ch.k8sEventsCh = k8sEventsCh
 	ch.k8sErrCh = k8sErrCh

--- a/KubeArmor/core/containerdHandler.go
+++ b/KubeArmor/core/containerdHandler.go
@@ -126,7 +126,9 @@ func NewContainerdHandler() *ContainerdHandler {
 func (ch *ContainerdHandler) Reconnect() error {
 	// Close existing client if present
 	if ch.client != nil {
-		ch.client.Close()
+		if err := ch.client.Close(); err != nil {
+			kg.Warnf("Failed to close old containerd client connection: %v", err)
+		}
 	}
 
 	client, err := v2.New(strings.TrimPrefix(cfg.GlobalCfg.CRISocket, "unix://"))

--- a/KubeArmor/core/containerdHandler.go
+++ b/KubeArmor/core/containerdHandler.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/containerd/typeurl/v2"
 	"google.golang.org/protobuf/proto"
@@ -85,6 +86,9 @@ type ContainerdHandler struct {
 
 	k8sEventsCh    <-chan *events.Envelope
 	dockerEventsCh <-chan *events.Envelope
+
+	k8sErrCh    <-chan error
+	dockerErrCh <-chan error
 }
 
 // NewContainerdHandler Function
@@ -102,19 +106,46 @@ func NewContainerdHandler() *ContainerdHandler {
 	// Subscribe to containerd events
 
 	// docker namespace
-	ch.docker = context.Background()
 	ch.docker = namespaces.WithNamespace(context.Background(), "moby")
 
-	dockerEventsCh, _ := client.EventService().Subscribe(ch.docker, "")
+	dockerEventsCh, dockerErrCh := client.EventService().Subscribe(ch.docker, "")
 	ch.dockerEventsCh = dockerEventsCh
+	ch.dockerErrCh = dockerErrCh
 
 	// containerd namespace
 	ch.containerd = namespaces.WithNamespace(context.Background(), "k8s.io")
 
-	k8sEventsCh, _ := client.EventService().Subscribe(ch.containerd, "")
+	k8sEventsCh, k8sErrCh := client.EventService().Subscribe(ch.containerd, "")
 	ch.k8sEventsCh = k8sEventsCh
+	ch.k8sErrCh = k8sErrCh
 
 	return ch
+}
+
+// Reconnect re-establishes the containerd client connection and resubscribes to events
+func (ch *ContainerdHandler) Reconnect() error {
+	// Close existing client if present
+	if ch.client != nil {
+		ch.client.Close()
+	}
+
+	client, err := v2.New(strings.TrimPrefix(cfg.GlobalCfg.CRISocket, "unix://"))
+	if err != nil {
+		return fmt.Errorf("unable to reconnect to containerd: %v", err)
+	}
+	ch.client = client
+
+	// Resubscribe to docker namespace events
+	dockerEventsCh, dockerErrCh := client.EventService().Subscribe(ch.docker, "")
+	ch.dockerEventsCh = dockerEventsCh
+	ch.dockerErrCh = dockerErrCh
+
+	// Resubscribe to k8s namespace events
+	k8sEventsCh, k8sErrCh := client.EventService().Subscribe(ch.containerd, "")
+	ch.k8sEventsCh = k8sEventsCh
+	ch.k8sErrCh = k8sErrCh
+
+	return nil
 }
 
 // Close Function
@@ -612,13 +643,78 @@ func (dm *KubeArmorDaemon) MonitorContainerdEvents() {
 		case <-StopChan:
 			return
 
-		case envelope := <-Containerd.k8sEventsCh:
+		case err := <-Containerd.k8sErrCh:
+			kg.Warnf("Containerd k8s event subscription error: %v", err)
+			if !dm.reconnectContainerd() {
+				return
+			}
+
+		case err := <-Containerd.dockerErrCh:
+			kg.Warnf("Containerd docker event subscription error: %v", err)
+			if !dm.reconnectContainerd() {
+				return
+			}
+
+		case envelope, ok := <-Containerd.k8sEventsCh:
+			if !ok {
+				kg.Warn("Containerd k8s event channel closed")
+				if !dm.reconnectContainerd() {
+					return
+				}
+				continue
+			}
 			dm.handleContainerdEvent(envelope, Containerd.containerd)
 
-		case envelope := <-Containerd.dockerEventsCh:
+		case envelope, ok := <-Containerd.dockerEventsCh:
+			if !ok {
+				kg.Warn("Containerd docker event channel closed")
+				if !dm.reconnectContainerd() {
+					return
+				}
+				continue
+			}
 			dm.handleContainerdEvent(envelope, Containerd.docker)
 
 		}
+	}
+}
+
+// reconnectContainerd attempts to reconnect to containerd with backoff.
+// Returns true on success, false if StopChan is signaled during retry.
+func (dm *KubeArmorDaemon) reconnectContainerd() bool {
+	const maxRetryInterval = 60 * time.Second
+	retryInterval := 5 * time.Second
+
+	for {
+		dm.Logger.Printf("Attempting to reconnect to containerd in %v...", retryInterval)
+
+		select {
+		case <-StopChan:
+			return false
+		case <-time.After(retryInterval):
+		}
+
+		if err := Containerd.Reconnect(); err != nil {
+			kg.Warnf("Failed to reconnect to containerd: %v", err)
+			// exponential backoff
+			retryInterval *= 2
+			if retryInterval > maxRetryInterval {
+				retryInterval = maxRetryInterval
+			}
+			continue
+		}
+
+		dm.Logger.Print("Successfully reconnected to containerd")
+
+		// re-sync existing containers after reconnection
+		containers := Containerd.GetContainerdContainers()
+		for containerID, context := range containers {
+			if err := dm.UpdateContainerdContainer(context, containerID, 0, "start"); err != nil {
+				kg.Warnf("Failed to update containerd container %s after reconnect: %s", containerID, err.Error())
+			}
+		}
+
+		return true
 	}
 }
 

--- a/KubeArmor/core/crioHandler.go
+++ b/KubeArmor/core/crioHandler.go
@@ -380,7 +380,11 @@ func (dm *KubeArmorDaemon) MonitorCrioEvents() {
 		default:
 			containers, err := Crio.GetCrioContainers()
 			if err != nil {
-				return
+				kg.Warnf("Failed to list CRI-O containers: %v", err)
+				if !dm.reconnectCrio() {
+					return
+				}
+				continue
 			}
 
 			invalidContainers := []string{}
@@ -411,5 +415,41 @@ func (dm *KubeArmorDaemon) MonitorCrioEvents() {
 		}
 
 		time.Sleep(time.Millisecond * 50)
+	}
+}
+
+// reconnectCrio attempts to reconnect to CRI-O with backoff.
+// Returns true on success, false if StopChan is signaled during retry.
+func (dm *KubeArmorDaemon) reconnectCrio() bool {
+	const maxRetryInterval = 60 * time.Second
+	retryInterval := 5 * time.Second
+
+	for {
+		dm.Logger.Printf("Attempting to reconnect to CRI-O in %v...", retryInterval)
+
+		select {
+		case <-StopChan:
+			return false
+		case <-time.After(retryInterval):
+		}
+
+		newCrio := NewCrioHandler()
+		if newCrio == nil {
+			kg.Warn("Failed to reconnect to CRI-O")
+			retryInterval *= 2
+			if retryInterval > maxRetryInterval {
+				retryInterval = maxRetryInterval
+			}
+			continue
+		}
+
+		// Close old connection and replace handler
+		Crio.Close()
+		// Preserve the existing container map so we can diff correctly
+		newCrio.containers = Crio.containers
+		Crio = newCrio
+
+		dm.Logger.Print("Successfully reconnected to CRI-O")
+		return true
 	}
 }

--- a/KubeArmor/core/dockerHandler.go
+++ b/KubeArmor/core/dockerHandler.go
@@ -222,18 +222,33 @@ func (dh *DockerHandler) GetEventChannel(ctx context.Context, StopChan <-chan st
 
 		go func() {
 
-			eventStream, _ := dh.DockerClient.Events(ctx, events.ListOptions{})
+			eventStream, errCh := dh.DockerClient.Events(ctx, events.ListOptions{})
 			defer close(eventBuffer)
 
-			for event := range eventStream {
+			for {
 				select {
-				case eventBuffer <- event:
+				case event, ok := <-eventStream:
+					if !ok {
+						return
+					}
+					select {
+					case eventBuffer <- event:
+					case <-ctx.Done():
+						return
+					case <-StopChan:
+						return
+					default:
+						kg.Warnf("Docker channel full.")
+					}
+				case err, ok := <-errCh:
+					if ok && err != nil {
+						kg.Warnf("Docker event stream error: %v", err)
+					}
+					return
 				case <-ctx.Done():
 					return
 				case <-StopChan:
 					return
-				default:
-					kg.Warnf("Docker channel full.")
 				}
 			}
 		}()
@@ -807,6 +822,17 @@ func (dm *KubeArmorDaemon) MonitorDockerEvents() {
 
 		case msg, valid := <-EventChan:
 			if !valid {
+				kg.Warn("Docker event channel closed")
+				cancel()
+
+				if !dm.reconnectDocker() {
+					return
+				}
+
+				// create new context and event channel after reconnection
+				ctx, cancel = context.WithCancel(context.Background())
+				defer cancel()
+				EventChan = Docker.GetEventChannel(ctx, StopChan)
 				continue
 			}
 
@@ -815,5 +841,41 @@ func (dm *KubeArmorDaemon) MonitorDockerEvents() {
 				dm.UpdateDockerContainer(msg.ID, string(msg.Action))
 			}
 		}
+	}
+}
+
+// reconnectDocker attempts to reconnect to Docker with backoff.
+// Returns true on success, false if StopChan is signaled during retry.
+func (dm *KubeArmorDaemon) reconnectDocker() bool {
+	const maxRetryInterval = 60 * time.Second
+	retryInterval := 5 * time.Second
+
+	for {
+		dm.Logger.Printf("Attempting to reconnect to Docker in %v...", retryInterval)
+
+		select {
+		case <-StopChan:
+			return false
+		case <-time.After(retryInterval):
+		}
+
+		newDocker, err := NewDockerHandler()
+		if err != nil {
+			kg.Warnf("Failed to reconnect to Docker: %v", err)
+			retryInterval *= 2
+			if retryInterval > maxRetryInterval {
+				retryInterval = maxRetryInterval
+			}
+			continue
+		}
+
+		// Close old client
+		if Docker.DockerClient != nil {
+			Docker.DockerClient.Close()
+		}
+		Docker = newDocker
+
+		dm.Logger.Print("Successfully reconnected to Docker")
+		return true
 	}
 }

--- a/KubeArmor/core/dockerHandler.go
+++ b/KubeArmor/core/dockerHandler.go
@@ -871,7 +871,10 @@ func (dm *KubeArmorDaemon) reconnectDocker() bool {
 
 		// Close old client
 		if Docker.DockerClient != nil {
-			Docker.DockerClient.Close()
+			if err := Docker.DockerClient.Close(); err != nil {
+				dm.Logger.Warnf("Failed to close old docker client connection: %v", err)
+			}
+
 		}
 		Docker = newDocker
 

--- a/KubeArmor/core/kubeUpdate.go
+++ b/KubeArmor/core/kubeUpdate.go
@@ -3270,7 +3270,6 @@ func (dm *KubeArmorDaemon) WatchConfigMap() cache.InformerSynced {
 				dm.SystemMonitor.UpdateThrottlingConfig()
 				if _, ok := cm.Data[cfg.ConfigArgMatching]; ok {
 					cfg.GlobalCfg.MatchArgs, _ = strconv.ParseBool(cm.Data[cfg.ConfigArgMatching])
-					fmt.Println("Updated Match argr in configmap ", cfg.GlobalCfg.MatchArgs)
 				}
 				dm.SystemMonitor.UpdateMatchArgsConfig()
 				dm.UpdateIMA(cfg.GlobalCfg.EnableIMA)
@@ -3347,7 +3346,6 @@ func (dm *KubeArmorDaemon) WatchConfigMap() cache.InformerSynced {
 				}
 				if _, ok := cm.Data[cfg.ConfigArgMatching]; ok {
 					cfg.GlobalCfg.MatchArgs, _ = strconv.ParseBool(cm.Data[cfg.ConfigArgMatching])
-					fmt.Println("Updated Match argr in configmap ", cfg.GlobalCfg.MatchArgs)
 				}
 				dm.SystemMonitor.UpdateMatchArgsConfig()
 				dm.UpdateIMA(cfg.GlobalCfg.EnableIMA)

--- a/KubeArmor/core/nriHandler.go
+++ b/KubeArmor/core/nriHandler.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/containerd/nri/pkg/api"
 	"github.com/containerd/nri/pkg/stub"
@@ -52,6 +53,10 @@ type NRIHandler struct {
 
 	handleDeletedContainer func(tp.Container)
 	handleNewContainer     func(tp.Container)
+
+	// disconnectChan is closed/sent-to when the NRI stub connection is lost,
+	// signalling MonitorNRIEvents to create a fresh handler.
+	disconnectChan chan struct{}
 }
 
 // NewNRIHandler creates a new NRIHandler with the given event callbacks.
@@ -59,14 +64,20 @@ func (dm *KubeArmorDaemon) NewNRIHandler(
 	handleDeletedContainer func(tp.Container),
 	handleNewContainer func(tp.Container),
 ) *NRIHandler {
-	nri := &NRIHandler{dm: dm}
+	nri := &NRIHandler{
+		dm:             dm,
+		disconnectChan: make(chan struct{}, 1),
+	}
 
 	opts := []stub.Option{
 		stub.WithSocketPath(cfg.GlobalCfg.NRISocket),
 		stub.WithPluginIdx(cfg.GlobalCfg.NRIIndex),
 		stub.WithOnClose(func() {
-			kg.Printf("restarting NRI")
-			nri.Start()
+			// Signal MonitorNRIEvents that the connection was lost so it can attempt reconnection. WithOnClose may not fire if the connection was never fully established, so we also signal disconnectChan in the goroutine running stub.Run() to ensure MonitorNRIEvents always wakes up to retry.
+			select {
+			case nri.disconnectChan <- struct{}{}:
+			default:
+			}
 		}),
 	}
 
@@ -91,6 +102,12 @@ func (nh *NRIHandler) Start() {
 		err := nh.stub.Run(context.Background())
 		if err != nil {
 			kg.Errf("Failed to connect to NRI: %s", err.Error())
+		}
+		// Signal disconnectChan when stub.Run() exits (error or clean close).
+		// Ensures reconnect loop wakes up even if WithOnClose doesn’t fire.
+		select {
+		case nh.disconnectChan <- struct{}{}:
+		default:
 		}
 	}()
 }
@@ -434,13 +451,59 @@ func (dm *KubeArmorDaemon) MonitorNRIEvents() {
 	}
 
 	NRI = dm.NewNRIHandler(handleDeletedContainer, handleNewContainer)
-
-	// check if NRI exists
 	if NRI == nil {
 		return
 	}
-
 	NRI.Start()
-
 	dm.Logger.Print("Started to monitor NRI events")
+
+	for {
+		select {
+		case <-StopChan:
+			return
+		case <-NRI.disconnectChan:
+			kg.Warn("NRI connection lost")
+			if !dm.reconnectNRI(handleDeletedContainer, handleNewContainer) {
+				return
+			}
+		}
+	}
+}
+
+// reconnectNRI attempts to reconnect to the NRI socket with exponential backoff.
+// Returns true on success, false if StopChan is signalled during retry.
+func (dm *KubeArmorDaemon) reconnectNRI(
+	handleDeletedContainer func(tp.Container),
+	handleNewContainer func(tp.Container),
+) bool {
+	const maxRetryInterval = 60 * time.Second
+	retryInterval := 5 * time.Second
+
+	for {
+		dm.Logger.Printf("Attempting to reconnect to NRI in %v...", retryInterval)
+
+		select {
+		case <-StopChan:
+			return false
+		case <-time.After(retryInterval):
+		}
+
+		// Stop the old stub BEFORE creating a new one.
+		NRI.Close()
+
+		newNRI := dm.NewNRIHandler(handleDeletedContainer, handleNewContainer)
+		if newNRI == nil {
+			kg.Warnf("Failed to create NRI handler")
+			retryInterval *= 2
+			if retryInterval > maxRetryInterval {
+				retryInterval = maxRetryInterval
+			}
+			continue
+		}
+
+		NRI = newNRI
+		NRI.Start()
+		dm.Logger.Print("Successfully reconnected to NRI")
+		return true
+	}
 }

--- a/pkg/KubeArmorOperator/internal/controller/resources.go
+++ b/pkg/KubeArmorOperator/internal/controller/resources.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"path/filepath"
 	"reflect"
 	"regexp"
 	"strconv"
@@ -218,20 +219,24 @@ func genRuntimeVolumes(runtime, runtimeSocket, nriSocket string) (vol []corev1.V
 	// lookup socket
 	for _, socket := range common.ContainerRuntimeSocketMap[runtime] {
 		if strings.ReplaceAll(socket[1:], "/", "_") == runtimeSocket {
+			// Mount the socket's parent directory instead of the file.
+			// Socket files are recreated on runtime restart (new inode),
+			// so file mounts can become stale, while directory mounts stay valid.
+			socketDir := filepath.Dir(socket)
 			vol = append(vol, corev1.Volume{
 				Name: runtime + "-socket",
 				VolumeSource: corev1.VolumeSource{
 					HostPath: &corev1.HostPathVolumeSource{
-						Path: socket,
-						Type: &common.HostPathSocket,
+						Path: socketDir,
+						Type: &common.HostPathDirectory,
 					},
 				},
 			})
 
-			socket = common.RuntimeSocketLocation[runtime]
+			mountDir := filepath.Dir(common.RuntimeSocketLocation[runtime])
 			volMnt = append(volMnt, corev1.VolumeMount{
 				Name:      runtime + "-socket",
-				MountPath: socket,
+				MountPath: mountDir,
 				ReadOnly:  true,
 			})
 			break
@@ -241,20 +246,21 @@ func genRuntimeVolumes(runtime, runtimeSocket, nriSocket string) (vol []corev1.V
 		runtime = "nri"
 		for _, socket := range common.ContainerRuntimeSocketMap[runtime] {
 			if strings.ReplaceAll(socket[1:], "/", "_") == nriSocket {
+				socketDir := filepath.Dir(socket)
 				vol = append(vol, corev1.Volume{
 					Name: runtime + "-socket",
 					VolumeSource: corev1.VolumeSource{
 						HostPath: &corev1.HostPathVolumeSource{
-							Path: socket,
-							Type: &common.HostPathSocket,
+							Path: socketDir,
+							Type: &common.HostPathDirectory,
 						},
 					},
 				})
 
-				socket = common.RuntimeSocketLocation[runtime]
+				mountDir := filepath.Dir(common.RuntimeSocketLocation[runtime])
 				volMnt = append(volMnt, corev1.VolumeMount{
 					Name:      runtime + "-socket",
-					MountPath: socket,
+					MountPath: mountDir,
 					ReadOnly:  true,
 				})
 				break


### PR DESCRIPTION
**Purpose of PR?**:

There is an issue in KubeArmor wherein if the container runtime socket is interrupted, then the container events are not seen anymore. Thus any new pods that are added are seen but the corresponding containers are not seen by kubearmor. Thus visibility/enforcement, nothing works on these containers.

**Does this PR introduce a breaking change?**
No

**If the changes in this PR are manually verified, list down the scenarios covered:**:

Install kubearmor in k3s cluster.
```
systemctl stop k3s
systemctl start k3s
# After this new container events should not be seen
```

**Additional information for reviewer?** 
NA


**Checklist:**
- [x] Bug fix. Fixes #<issue number>
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [x] Commit has unit tests
- [x] Commit has integration tests

<!--

The PR title message must follow convention:
`<type>(<scope>): <subject>`.

Where: <br />
- `type` is to define what type of PR is this.
  Most common types are:
    - `feat`      - for new features, not a new feature for build script
    - `fix`       - for bug fixes or improvements, not a fix for build script
    - `chore`     - changes not related to production code
    - `docs`      - changes related to documentation
    - `style`     - formatting, missing semi colons, linting fix etc; no significant production code changes
    - `test`      - adding missing tests, refactoring tests; no production code change
    - `refactor`  - refactoring production code, eg. renaming a variable or function name, there should not be any significant production code changes

- `scope` is a single word that best describes where the changes fit.
    - feature(`monitor`,`enforcer`)
    - test(`tests`, `bdd`)
    - chore(`build`)
- `subject` is a single line brief description of the changes made in the pull request.

-->