### PR TITLE
fix(operator): forward annotateResource flag to KubeArmor daemonset args

### DIFF
--- a/pkg/KubeArmorOperator/internal/controller/resources.go
+++ b/pkg/KubeArmorOperator/internal/controller/resources.go
@@ -134,15 +134,11 @@ func generateDaemonset(name, enforcer, runtime, socket, nriSocket, btfPresent, a
 	AddOrUpdateEnv(&daemonset.Spec.Template.Spec.InitContainers[0].Env, common.GlobalEnv)
 	AddOrUpdateEnv(&daemonset.Spec.Template.Spec.InitContainers[0].Env, common.KubeArmorInitEnv)
 
-	// TODO: handle passing annotateResource flag to kubearmor
-	// ideally this configuration should be part of kubearmoconfig to avoid hardcoding version checks
-	// to detect flag compatibility
-
-	// if annotateResource {
-	// 	common.AddOrReplaceArg("-annotateResource=true", "-annotateResource=false", &daemonset.Spec.Template.Spec.Containers[0].Args)
-	// } else {
-	// 	common.AddOrReplaceArg("-annotateResource=false", "-annotateResource=true", &daemonset.Spec.Template.Spec.Containers[0].Args)
-	// }
+	if annotateResource {
+		common.AddOrReplaceArg("-annotateResource=true", "-annotateResource=false", &daemonset.Spec.Template.Spec.Containers[0].Args)
+	} else {
+		common.AddOrReplaceArg("-annotateResource=false", "-annotateResource=true", &daemonset.Spec.Template.Spec.Containers[0].Args)
+	}
 
 	if common.EnableTls {
 		vols = append(vols, common.KubeArmorCaVolume...)


### PR DESCRIPTION
**Purpose of PR?**:

The operator accepts `--annotateResource` and correctly extends the ClusterRole RBAC rules when the flag is set, but never passes the flag as a container argument to the KubeArmor daemonset. This uncommments the arg-forwarding block that was left behind a TODO, using the same `AddOrReplaceArg` pattern already used for `tlsEnabled`.

Fixes #2514

**Does this PR introduce a breaking change?**

No

**If the changes in this PR are manually verified, list down the scenarios covered:**:

1. Deploy operator with `--annotateResource=true`, verify daemonset container args include `-annotateResource=true`
2. Deploy operator without the flag, verify daemonset container args include `-annotateResource=false`

**Additional information for reviewer?** :

The commented-out code already existed with a TODO at `resources.go:137-145`. This PR simply uncomments it — no new logic introduced.

**Checklist:**
- [x] Bug fix. Fixes #2514
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Commit has unit tests
- [ ] Commit has integration tests