### PR TITLE
fix(enforcer): correct key deletion in RemoveDeletedEntriesForNodeSelector

### DIFF
--- a/pkg/KubeArmorOperator/internal/controller/cluster.go
+++ b/pkg/KubeArmorOperator/internal/controller/cluster.go
@@ -1014,17 +1014,15 @@ func AddOrUpdateEnv(dst *[]corev1.EnvVar, src []corev1.EnvVar) {
 }
 
 func RemoveDeletedEntriesForNodeSelector(ns map[string]string) {
-	deletedEntries := []string{}
-
-	for _, v := range ns {
-		if v == "-" {
-			deletedEntries = append(deletedEntries, v)
-		}
-	}
-
-	for _, k := range deletedEntries {
-		delete(ns, k)
-	}
+    deletedEntries := []string{}
+    for k, v := range ns {        
+        if v == "-" {
+            deletedEntries = append(deletedEntries, k)  
+        }
+    }
+    for _, k := range deletedEntries {
+        delete(ns, k)
+    }
 }
 
 func RemoveDeletedEntriesForEnv(env *[]corev1.EnvVar) {

--- a/pkg/KubeArmorOperator/internal/controller/cluster.go
+++ b/pkg/KubeArmorOperator/internal/controller/cluster.go
@@ -1014,16 +1014,10 @@ func AddOrUpdateEnv(dst *[]corev1.EnvVar, src []corev1.EnvVar) {
 }
 
 func RemoveDeletedEntriesForNodeSelector(ns map[string]string) {
-	deletedEntries := []string{}
-
-	for _, v := range ns {
+	for k, v := range ns {
 		if v == "-" {
-			deletedEntries = append(deletedEntries, v)
+			delete(ns, k)
 		}
-	}
-
-	for _, k := range deletedEntries {
-		delete(ns, k)
 	}
 }
 

--- a/pkg/KubeArmorOperator/internal/controller/cluster_test.go
+++ b/pkg/KubeArmorOperator/internal/controller/cluster_test.go
@@ -5,7 +5,7 @@ package controller
 
 import (
 	"testing"
-
+	"reflect"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 )
@@ -183,4 +183,41 @@ func TestAddorUpdateNodeSelector(t *testing.T) {
 			"env": "test",
 		})
 	})
+}
+
+func TestRemoveDeletedEntriesForNodeSelector(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    map[string]string
+		expected map[string]string
+	}{
+		{
+			name: "remove single deleted entry",
+			input: map[string]string{
+				"hostname": "worker1",
+				"env":      "-",
+			},
+			expected: map[string]string{
+				"hostname": "worker1",
+			},
+		},
+		{
+			name: "no entries to remove",
+			input: map[string]string{
+				"app": "nginx",
+			},
+			expected: map[string]string{
+				"app": "nginx",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			RemoveDeletedEntriesForNodeSelector(tt.input)
+			if !reflect.DeepEqual(tt.input, tt.expected) {
+				t.Errorf("Test '%s' failed: got %v, want %v", tt.name, tt.input, tt.expected)
+			}
+		})
+	}
 }

--- a/pkg/KubeArmorOperator/internal/controller/cluster_test.go
+++ b/pkg/KubeArmorOperator/internal/controller/cluster_test.go
@@ -184,3 +184,49 @@ func TestAddorUpdateNodeSelector(t *testing.T) {
 		})
 	})
 }
+
+func TestRemoveDeletedEntriesForNodeSelector(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    map[string]string
+		expected map[string]string
+	}{
+		{
+			name: "remove single deleted entry",
+			input: map[string]string{
+				"hostname": "worker1",
+				"env":      "-",
+			},
+			expected: map[string]string{
+				"hostname": "worker1",
+			},
+		},
+		{
+			name: "no entries to remove",
+			input: map[string]string{
+				"app": "nginx",
+			},
+			expected: map[string]string{
+				"app": "nginx",
+			},
+		},
+		{
+			name: "remove multiple deleted entries",
+			input: map[string]string{
+				"hostname": "worker1",
+				"env":      "-",
+				"region":   "-",
+			},
+			expected: map[string]string{
+				"hostname": "worker1",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			RemoveDeletedEntriesForNodeSelector(tt.input)
+			assert.Equal(t, tt.expected, tt.input)
+		})
+	}
+}


### PR DESCRIPTION
**Purpose of PR?**:
This PR fixes a logical error in the RemoveDeletedEntriesForNodeSelector function where the code incorrectly attempted to delete map entries using the value (-) as the key. This prevented the intended cleanup of node selector entries.

Fixes #2520

**Does this PR introduce a breaking change?**
No

**If the changes in this PR are manually verified, list down the scenarios covered:**:

1. Single deletion: Verified that passing a map with one entry set to "-" results in that entry being removed.
2. No deletion: Verified that a map with standard key-value pairs remains untouched.
3. Multiple entries: Verified that only the entries marked with "-" are removed while others persist.
4. Unit Tests: Added `TestRemoveDeletedEntriesForNodeSelector` to automate these scenarios.


**Checklist:**
- [x] Bug fix. Fixes #2520
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [x] Commit has unit tests
- [ ] Commit has integration tests

**Output of the test before editing the function**
<img width="1866" height="1053" alt="Screenshot from 2026-04-04 23-08-00" src="https://github.com/user-attachments/assets/582eefef-13fa-4804-a51d-02ae3dba7fca" />


**Output of the test after editing the function**
<img width="1866" height="1053" alt="Screenshot from 2026-04-04 23-07-23" src="https://github.com/user-attachments/assets/c2d2fae2-c683-4292-9708-7546e3e25b66" />
