### PR TITLE
Fix default posture update deadlock

### DIFF
--- a/KubeArmor/core/kubeUpdate.go
+++ b/KubeArmor/core/kubeUpdate.go
@@ -2827,18 +2827,14 @@ func (dm *KubeArmorDaemon) WatchNetworkSecurityPolicies(timeout time.Duration) {
 // ===================== //
 
 func (dm *KubeArmorDaemon) updatEndpointsWithCM(cm *corev1.ConfigMap, action string) {
-	dm.EndPointsLock.Lock()
-	defer dm.EndPointsLock.Unlock()
-
-	dm.DefaultPosturesLock.Lock()
-	defer dm.DefaultPosturesLock.Unlock()
-
 	// get all namespaces
 	nsList, err := K8s.K8sClient.CoreV1().Namespaces().List(context.Background(), metav1.ListOptions{})
 	if err != nil {
 		kg.Err("unable to fetch namespace list")
 		return
 	}
+
+	namespaceUpdates := make(map[string]defaultPostureUpdate, len(nsList.Items))
 
 	// for each namespace if needed change endpoint depfault posture
 	for _, ns := range nsList.Items {
@@ -2858,48 +2854,94 @@ func (dm *KubeArmorDaemon) updatEndpointsWithCM(cm *corev1.ConfigMap, action str
 			continue
 		}
 
-		for idx, endpoint := range dm.EndPoints {
-			// skip all endpoints not in current namespace
-			if endpoint.NamespaceName != ns.Name {
-				continue
-			}
+		namespaceUpdates[ns.Name] = defaultPostureUpdate{
+			DefaultPosture: posture,
+			Annotated:      annotated,
+		}
+	}
 
-			if endpoint.DefaultPosture != posture { // optimization, only if its needed to update the posture
-				dm.Logger.Printf("updating default posture for %s in %s", ns.Name, endpoint.EndPointName)
-				dm.UpdateDefaultPostureWithCM(&dm.EndPoints[idx], action, ns.Name, posture, annotated)
-			}
+	dm.applyDefaultPostureUpdates(action, namespaceUpdates)
+}
+
+type defaultPostureUpdate struct {
+	DefaultPosture tp.DefaultPosture
+	Annotated      bool
+}
+
+type endpointDefaultPostureUpdate struct {
+	EndPoint        tp.EndPoint
+	PreviousPosture tp.DefaultPosture
+	DefaultPosture  tp.DefaultPosture
+}
+
+func (dm *KubeArmorDaemon) applyDefaultPostureUpdates(action string, namespaceUpdates map[string]defaultPostureUpdate) {
+	if len(namespaceUpdates) == 0 {
+		return
+	}
+
+	dm.DefaultPosturesLock.Lock()
+	for namespace, update := range namespaceUpdates {
+		if action == deleteEvent {
+			delete(dm.DefaultPostures, namespace)
+		}
+		if update.Annotated {
+			dm.DefaultPostures[namespace] = update.DefaultPosture
+		}
+	}
+	dm.DefaultPosturesLock.Unlock()
+
+	for namespace, update := range namespaceUpdates {
+		dm.Logger.UpdateDefaultPosture(action, namespace, update.DefaultPosture)
+	}
+
+	endpointUpdates := dm.updateEndpointsDefaultPosture(namespaceUpdates)
+	for _, endpointUpdate := range endpointUpdates {
+		dm.Logger.Printf(
+			"Updating default posture for %s with %v namespace default %v",
+			endpointUpdate.EndPoint.EndPointName,
+			endpointUpdate.PreviousPosture,
+			endpointUpdate.DefaultPosture,
+		)
+
+		if !cfg.GlobalCfg.Policy || dm.RuntimeEnforcer == nil {
+			continue
 		}
 
+		if endpointUpdate.EndPoint.PolicyEnabled != tp.KubeArmorPolicyEnabled {
+			continue
+		}
+
+		if kl.ContainsElement(cfg.GlobalCfg.ConfigUntrackedNs.Load().([]string), endpointUpdate.EndPoint.NamespaceName) {
+			dm.Logger.Warnf("Policy cannot be enforced in untracked namespace %s", endpointUpdate.EndPoint.NamespaceName)
+			continue
+		}
+
+		dm.RuntimeEnforcer.UpdateSecurityPolicies(endpointUpdate.EndPoint)
 	}
 }
 
-// UpdateDefaultPostureWithCM Function
-func (dm *KubeArmorDaemon) UpdateDefaultPostureWithCM(endPoint *tp.EndPoint, action string, namespace string, defaultPosture tp.DefaultPosture, annotated bool) {
+func (dm *KubeArmorDaemon) updateEndpointsDefaultPosture(namespaceUpdates map[string]defaultPostureUpdate) []endpointDefaultPostureUpdate {
+	dm.EndPointsLock.Lock()
+	defer dm.EndPointsLock.Unlock()
 
-	// namespace is (partialy) annotated with posture annotation(s)
-	if annotated {
-		// update the dm.DefaultPosture[namespace]
-		dm.DefaultPostures[namespace] = defaultPosture
-	}
-	dm.Logger.UpdateDefaultPosture(action, namespace, defaultPosture)
-
-	// update the endpoint with updated default posture
-	endPoint.DefaultPosture = defaultPosture
-	dm.Logger.Printf("Updated default posture for %s with %v", endPoint.EndPointName, endPoint.DefaultPosture)
-	if cfg.GlobalCfg.Policy {
-		// update security policies
-		if dm.RuntimeEnforcer != nil {
-			if endPoint.PolicyEnabled == tp.KubeArmorPolicyEnabled {
-				// enforce security policies
-				if !kl.ContainsElement(cfg.GlobalCfg.ConfigUntrackedNs.Load().([]string), endPoint.NamespaceName) {
-					dm.RuntimeEnforcer.UpdateSecurityPolicies(*endPoint)
-				} else {
-					dm.Logger.Warnf("Policy cannot be enforced in untracked namespace %s", endPoint.NamespaceName)
-				}
-			}
+	endpointUpdates := make([]endpointDefaultPostureUpdate, 0)
+	for idx := range dm.EndPoints {
+		update, ok := namespaceUpdates[dm.EndPoints[idx].NamespaceName]
+		if !ok || dm.EndPoints[idx].DefaultPosture == update.DefaultPosture {
+			continue
 		}
+
+		previousPosture := dm.EndPoints[idx].DefaultPosture
+		dm.EndPoints[idx].DefaultPosture = update.DefaultPosture
+
+		endpointUpdates = append(endpointUpdates, endpointDefaultPostureUpdate{
+			EndPoint:        dm.EndPoints[idx],
+			PreviousPosture: previousPosture,
+			DefaultPosture:  update.DefaultPosture,
+		})
 	}
 
+	return endpointUpdates
 }
 
 // returns default posture and a boolean value states, if annotation is set or not
@@ -2923,67 +2965,12 @@ func validateDefaultPosture(key string, ns *corev1.Namespace, defaultPosture str
 
 // UpdateDefaultPosture Function
 func (dm *KubeArmorDaemon) UpdateDefaultPosture(action string, namespace string, defaultPosture tp.DefaultPosture, annotated bool) {
-	dm.DefaultPosturesLock.Lock()
-	defer dm.DefaultPosturesLock.Unlock()
-
-	// namespace deleted
-	if action == deleteEvent {
-		_, ok := dm.DefaultPostures[namespace]
-		if ok {
-			delete(dm.DefaultPostures, namespace)
-		}
-	}
-
-	// namespace is annotated with posture annotation(s)
-	if annotated {
-		dm.DefaultPostures[namespace] = defaultPosture
-	}
-	dm.Logger.UpdateDefaultPosture(action, namespace, defaultPosture)
-
-	// Copy endpoints under lock to prevent TOCTOU race condition
-	dm.EndPointsLock.RLock()
-	endPointsCopy := make([]tp.EndPoint, len(dm.EndPoints))
-	copy(endPointsCopy, dm.EndPoints)
-	dm.EndPointsLock.RUnlock()
-
-	for _, endPoint := range endPointsCopy {
-		// update a security policy
-		if namespace == endPoint.NamespaceName {
-			if endPoint.DefaultPosture == defaultPosture {
-				continue
-			}
-
-			dm.Logger.Printf("Updating default posture for %s with %v namespace default %v", endPoint.EndPointName, endPoint.DefaultPosture, defaultPosture)
-			endPoint.DefaultPosture = defaultPosture
-
-			// Find and update the original endpoint in the array by matching unique identifiers
-			dm.EndPointsLock.Lock()
-			for idx := range dm.EndPoints {
-				if dm.EndPoints[idx].NamespaceName == endPoint.NamespaceName &&
-					dm.EndPoints[idx].EndPointName == endPoint.EndPointName &&
-					dm.EndPoints[idx].ContainerName == endPoint.ContainerName {
-					dm.EndPoints[idx] = endPoint
-					break
-				}
-			}
-			dm.EndPointsLock.Unlock()
-
-			if cfg.GlobalCfg.Policy {
-				// update security policies
-				if dm.RuntimeEnforcer != nil {
-					if endPoint.PolicyEnabled == tp.KubeArmorPolicyEnabled {
-						// enforce security policies
-						if !kl.ContainsElement(cfg.GlobalCfg.ConfigUntrackedNs.Load().([]string), endPoint.NamespaceName) {
-							dm.RuntimeEnforcer.UpdateSecurityPolicies(endPoint)
-						} else {
-							dm.Logger.Warnf("Policy cannot be enforced in untracked namespace %s", endPoint.NamespaceName)
-						}
-
-					}
-				}
-			}
-		}
-	}
+	dm.applyDefaultPostureUpdates(action, map[string]defaultPostureUpdate{
+		namespace: {
+			DefaultPosture: defaultPosture,
+			Annotated:      annotated,
+		},
+	})
 }
 
 func validateGlobalDefaultPosture(posture string) string {
@@ -3085,12 +3072,6 @@ func (dm *KubeArmorDaemon) updateVisibilityWithCM(cm *corev1.ConfigMap, _ string
 
 // UpdateGlobalPosture Function
 func (dm *KubeArmorDaemon) UpdateGlobalPosture(posture tp.DefaultPosture) {
-	dm.EndPointsLock.Lock()
-	defer dm.EndPointsLock.Unlock()
-
-	dm.DefaultPosturesLock.Lock()
-	defer dm.DefaultPosturesLock.Unlock()
-
 	cfg.GlobalCfg.DefaultFilePosture = validateGlobalDefaultPosture(posture.FileAction)
 	cfg.GlobalCfg.DefaultNetworkPosture = validateGlobalDefaultPosture(posture.NetworkAction)
 	cfg.GlobalCfg.DefaultCapabilitiesPosture = validateGlobalDefaultPosture(posture.CapabilitiesAction)

--- a/KubeArmor/core/kubeUpdate_race_test.go
+++ b/KubeArmor/core/kubeUpdate_race_test.go
@@ -10,8 +10,25 @@ import (
 	"testing"
 	"time"
 
+	fd "github.com/kubearmor/KubeArmor/KubeArmor/feeder"
 	tp "github.com/kubearmor/KubeArmor/KubeArmor/types"
+	pb "github.com/kubearmor/KubeArmor/protobuf"
 )
+
+func newTestFeeder() *fd.Feeder {
+	return &fd.Feeder{
+		BaseFeeder: fd.BaseFeeder{
+			Node: &tp.Node{},
+			EventStructs: &fd.EventStructs{
+				MsgStructs:   map[string]fd.EventStruct[pb.Message]{},
+				AlertStructs: map[string]fd.EventStruct[pb.Alert]{},
+				LogStructs:   map[string]fd.EventStruct[pb.Log]{},
+			},
+		},
+		DefaultPostures:     map[string]tp.DefaultPosture{},
+		DefaultPosturesLock: &sync.Mutex{},
+	}
+}
 
 // TestUpdateSecurityPolicyRaceCondition tests that UpdateSecurityPolicy doesn't panic
 // when endpoints are concurrently added/removed during policy updates
@@ -200,14 +217,12 @@ func TestUpdateHostSecurityPoliciesRaceCondition(t *testing.T) {
 
 // TestUpdateDefaultPostureRaceCondition tests race conditions in UpdateDefaultPosture
 func TestUpdateDefaultPostureRaceCondition(t *testing.T) {
-	// Skip this test for now due to external dependencies (Logger)
-	t.Skip("Skipping UpdateDefaultPosture test due to external dependencies")
-
 	dm := &KubeArmorDaemon{
 		EndPoints:           []tp.EndPoint{},
 		EndPointsLock:       &sync.RWMutex{},
 		DefaultPostures:     map[string]tp.DefaultPosture{},
 		DefaultPosturesLock: &sync.Mutex{},
+		Logger:              newTestFeeder(),
 	}
 
 	// Initialize with test endpoints
@@ -276,6 +291,95 @@ func TestUpdateDefaultPostureRaceCondition(t *testing.T) {
 	wg.Wait()
 
 	t.Log("UpdateDefaultPosture race condition test completed without panics")
+}
+
+func TestDefaultPostureUpdatePathsRaceCondition(t *testing.T) {
+	dm := &KubeArmorDaemon{
+		EndPoints:           []tp.EndPoint{},
+		EndPointsLock:       &sync.RWMutex{},
+		DefaultPostures:     map[string]tp.DefaultPosture{},
+		DefaultPosturesLock: &sync.Mutex{},
+		Logger:              newTestFeeder(),
+	}
+
+	for i := 0; i < 40; i++ {
+		namespace := "test-namespace"
+		if i%2 == 1 {
+			namespace = "other-namespace"
+		}
+
+		dm.EndPoints = append(dm.EndPoints, tp.EndPoint{
+			NamespaceName:  namespace,
+			EndPointName:   fmt.Sprintf("endpoint-%d", i),
+			ContainerName:  fmt.Sprintf("container-%d", i),
+			DefaultPosture: tp.DefaultPosture{FileAction: "allow"},
+		})
+	}
+
+	namespaceUpdates := map[string]defaultPostureUpdate{
+		"test-namespace": {
+			DefaultPosture: tp.DefaultPosture{
+				FileAction:         "block",
+				NetworkAction:      "audit",
+				CapabilitiesAction: "block",
+			},
+			Annotated: true,
+		},
+		"other-namespace": {
+			DefaultPosture: tp.DefaultPosture{
+				FileAction:         "audit",
+				NetworkAction:      "block",
+				CapabilitiesAction: "audit",
+			},
+			Annotated: false,
+		},
+	}
+
+	var wg sync.WaitGroup
+	stopCh := make(chan struct{})
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stopCh:
+				return
+			default:
+				dm.UpdateDefaultPosture(updateEvent, "test-namespace", namespaceUpdates["test-namespace"].DefaultPosture, true)
+				time.Sleep(1 * time.Millisecond)
+			}
+		}
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stopCh:
+				return
+			default:
+				dm.applyDefaultPostureUpdates(updateEvent, namespaceUpdates)
+				time.Sleep(1 * time.Millisecond)
+			}
+		}
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+	close(stopCh)
+
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("default posture update paths deadlocked")
+	}
 }
 
 // TestConcurrentEndpointAccess tests general concurrent access patterns


### PR DESCRIPTION
## Summary

This PR fixes a deadlock risk in the default-posture update flow.

Previously, namespace posture updates and configmap posture updates could acquire `DefaultPosturesLock` and `EndPointsLock` in opposite orders, which created a lock-order inversion between the two code paths.

This change refactors default-posture handling so the shared update path no longer holds both locks at the same time.

## What changed

- removed the cross-locking pattern from the configmap default-posture path
- routed namespace and configmap default-posture updates through a shared helper
- updated endpoint default posture changes in a separate step from default posture map updates
- removed unnecessary locking from `UpdateGlobalPosture()`
- re-enabled the skipped default-posture race test
- added coverage for concurrent default-posture update paths

## Why

`WatchDefaultPosture()` and `WatchConfigMap()` both run during normal daemon startup and can update default posture concurrently.

Before this patch:
- `UpdateDefaultPosture()` updated posture state and then touched endpoints
- `updatEndpointsWithCM()` and `UpdateGlobalPosture()` took locks in the opposite order

That made deadlock possible when namespace and configmap updates happened at the same time.

## Testing

- `env GOOS=linux GOARCH=arm64 go test -c ./core`

## Notes

This keeps the existing posture behavior intact while making the update path safe under concurrent informer activity.
