### PR TITLE
Fix TCP Accept Event Visibility

### DIFF
--- a/KubeArmor/BPF/system_monitor.c
+++ b/KubeArmor/BPF/system_monitor.c
@@ -2393,7 +2393,7 @@ int kretprobe__tcp_connect(struct pt_regs *ctx)
     context->argnum = get_arg_num(types);
     context->retval = PT_REGS_RC(ctx);
 
-    if (context->retval >= 0 && drop_syscall(_NETWORK_PROBE))
+    if (get_kubearmor_config(_ENFORCER_BPFLSM) && drop_syscall(_NETWORK_PROBE))
     {
         return 0;
     }
@@ -2495,7 +2495,7 @@ int kretprobe__inet_csk_accept(struct pt_regs *ctx)
     int *err_ptr = (int *)PT_REGS_PARM3(ctx);
     bpf_probe_read(&context->retval, sizeof(context->retval), err_ptr);
 
-    if (context->retval >= 0 && drop_syscall(_NETWORK_PROBE))
+    if (get_kubearmor_config(_ENFORCER_BPFLSM) && drop_syscall(_NETWORK_PROBE))
     {
         return 0;
     }

--- a/tests/k8s_env/networktests/network_test.go
+++ b/tests/k8s_env/networktests/network_test.go
@@ -295,4 +295,48 @@ var _ = Describe("Network Tests", func() {
 		})
 	})
 
+	Describe("Network ingress tcp_accept events", func() {
+		var ub1 string
+		var ub2 string
+		BeforeEach(func() {
+			ub1 = getUbuntuPod("ubuntu-1", "kubearmor-policy: enabled")
+			ub2 = getUbuntuPod("ubuntu-2", "kubearmor-policy: enabled")
+		})
+
+		AfterEach(func() {
+			KarmorLogStop()
+		})
+
+		Describe("TCP accept event for ingress connections", func() {
+			It("should emit tcp_accept event on ingress connection from another pod", func() {
+				go AssertCommand(
+					ub2, "multiubuntu", []string{"bash", "-c", "echo 'test' | nc -l -p 9999"},
+					MatchRegexp(""), false,
+				)
+
+				time.Sleep(2 * time.Second)
+
+				err := KarmorLogStart("system", "multiubuntu", "Network", ub2)
+				Expect(err).To(BeNil())
+
+				ub2IP := GetPodIP("ubuntu-2", "multiubuntu")
+				Expect(ub2IP).NotTo(Equal(""))
+
+				AssertCommand(
+					ub1, "multiubuntu", []string{"bash", "-c", "timeout 2 curl -v http://" + ub2IP + ":80 2>&1 || true"},
+					MatchRegexp(""), true,
+				)
+
+				expectLog := protobuf.Log{
+					Source:    "curl",
+					Operation: "Network",
+				}
+
+				res, err := KarmorGetTargetLogs(5*time.Second, &expectLog)
+				Expect(err).To(BeNil())
+				Expect(len(res.Logs)).To(BeGreaterThan(0))
+			})
+		})
+	})
+
 })


### PR DESCRIPTION
KubeArmor was not capturing `tcp_accept` kprobe events on ingress TCP connections, resulting in complete loss of visibility for server-side network activity. Only outgoing `tcp_connect` events were visible.

Fix: #2025