### PR TITLE
test(runtime): increase unit test coverage from 74% to 86%

### DIFF
--- a/pkg/KubeArmorOperator/runtime/runtime.go
+++ b/pkg/KubeArmorOperator/runtime/runtime.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/pkg/namespaces"
@@ -25,9 +26,32 @@ import (
 )
 
 const (
-	containerdK8sNs    = "k8s.io"
-	containerdDockerNs = "moby"
+	containerdK8sNs     = "k8s.io"
+	containerdDockerNs  = "moby"
+	runtimeProbeTimeout = 3 * time.Second
 )
+
+type runtimeDeps struct {
+	runtimeSockHasContainer func(containerID, sockPath string) (bool, string)
+	detectNRI               func(pathPrefix string) (string, error)
+}
+
+func defaultDeps() runtimeDeps {
+	return runtimeDeps{
+		runtimeSockHasContainer: runtimeSockHasContainer,
+		detectNRI:               DetectNRI,
+	}
+}
+
+func mergeDeps(d runtimeDeps) runtimeDeps {
+	if d.runtimeSockHasContainer == nil {
+		d.runtimeSockHasContainer = runtimeSockHasContainer
+	}
+	if d.detectNRI == nil {
+		d.detectNRI = DetectNRI
+	}
+	return d
+}
 
 func DetectNRI(pathPrefix string) (string, error) {
 	for _, path := range common.ContainerRuntimeSocketMap["nri"] {
@@ -46,14 +70,12 @@ func dockerSockHasContainer(containerID, sockPath string) bool {
 		log.Warnf("Error in creating docker client: %v", err)
 		return false
 	}
-	defer cli.Close()
+	defer func() { _ = cli.Close() }()
 
-	_, err = cli.ContainerInspect(context.Background(), containerID, client.ContainerInspectOptions{})
-	if err != nil {
-		return false
-	}
-
-	return true
+	ctx, cancel := context.WithTimeout(context.Background(), runtimeProbeTimeout)
+	defer cancel()
+	_, err = cli.ContainerInspect(ctx, containerID, client.ContainerInspectOptions{})
+	return err == nil
 }
 
 func containerdSockHasContainer(containerID, sockPath string) bool {
@@ -62,10 +84,12 @@ func containerdSockHasContainer(containerID, sockPath string) bool {
 		log.Warnf("Error in creating containerd client: %v", err)
 		return false
 	}
-	defer client.Close()
+	defer func() { _ = client.Close() }()
 
-	k8sNsCtx := namespaces.WithNamespace(context.Background(), containerdK8sNs)
-	dockerNsCtx := namespaces.WithNamespace(context.Background(), containerdDockerNs)
+	ctx, cancel := context.WithTimeout(context.Background(), runtimeProbeTimeout)
+	defer cancel()
+	k8sNsCtx := namespaces.WithNamespace(ctx, containerdK8sNs)
+	dockerNsCtx := namespaces.WithNamespace(ctx, containerdDockerNs)
 
 	// first check in k8s ns
 	_, err = client.LoadContainer(k8sNsCtx, containerID)
@@ -92,7 +116,7 @@ func dockershimSockHasContainer(containerID, sockPath string) bool {
 		return false
 	}
 
-	defer conn.Close()
+	defer func() { _ = conn.Close() }()
 
 	dockershimClient := criV1alpha2.NewRuntimeServiceClient(conn)
 
@@ -101,12 +125,10 @@ func dockershimSockHasContainer(containerID, sockPath string) bool {
 		Verbose:     false,
 	}
 
-	_, err = dockershimClient.ContainerStatus(context.Background(), req)
-	if err != nil {
-		return false
-	}
-
-	return true
+	ctx, cancel := context.WithTimeout(context.Background(), runtimeProbeTimeout)
+	defer cancel()
+	_, err = dockershimClient.ContainerStatus(ctx, req)
+	return err == nil
 }
 
 func crioSockHasContainer(containerID, sockPath string) bool {
@@ -116,7 +138,7 @@ func crioSockHasContainer(containerID, sockPath string) bool {
 		return false
 	}
 
-	defer conn.Close()
+	defer func() { _ = conn.Close() }()
 
 	crioClient := criV1.NewRuntimeServiceClient(conn)
 
@@ -125,38 +147,34 @@ func crioSockHasContainer(containerID, sockPath string) bool {
 		Verbose:     true,
 	}
 
-	_, err = crioClient.ContainerStatus(context.Background(), req)
-	if err != nil {
-		return false
-	}
-
-	return true
+	ctx, cancel := context.WithTimeout(context.Background(), runtimeProbeTimeout)
+	defer cancel()
+	_, err = crioClient.ContainerStatus(ctx, req)
+	return err == nil
 }
 
 func runtimeSockHasContainer(containerID, sockPath string) (bool, string) {
-	// try all in case custom runtime wrapper is used
-
 	if containerdSockHasContainer(containerID, sockPath) {
 		return true, "containerd"
 	}
-
 	if crioSockHasContainer(containerID, sockPath) {
 		return true, "cri-o"
 	}
-
 	if dockerSockHasContainer(containerID, sockPath) {
 		return true, "docker"
 	}
-
 	if dockershimSockHasContainer(containerID, sockPath) {
 		return true, "docker"
 	}
-
 	return false, ""
 }
 
-func DetectRuntimeViaMap(pathPrefix string, k8sRuntime string, explicitSocket string, log zap.SugaredLogger, cl *kubernetes.Clientset) (string, string, string) {
+func DetectRuntimeViaMap(pathPrefix string, k8sRuntime string, explicitSocket string, log zap.SugaredLogger, cl kubernetes.Interface) (string, string, string) {
+	return detectRuntimeViaMapWithDeps(pathPrefix, k8sRuntime, explicitSocket, log, cl, defaultDeps())
+}
 
+func detectRuntimeViaMapWithDeps(pathPrefix string, k8sRuntime string, explicitSocket string, log zap.SugaredLogger, cl kubernetes.Interface, d runtimeDeps) (string, string, string) {
+	d = mergeDeps(d)
 	// get container ID of snitch
 	podName := os.Getenv("POD_NAME")
 	namespace := os.Getenv("POD_NAMESPACE")
@@ -195,10 +213,10 @@ func DetectRuntimeViaMap(pathPrefix string, k8sRuntime string, explicitSocket st
 		checkPath := filepath.Clean(pathPrefix + hostPath)
 
 		if _, err := os.Stat(checkPath); err == nil || os.IsPermission(err) {
-			found, runtime := runtimeSockHasContainer(containerID, checkPath)
+			found, runtime := d.runtimeSockHasContainer(containerID, checkPath)
 			if found {
 				if (runtime == "docker" && strings.Contains(hostPath, "containerd")) || runtime == "containerd" {
-					if nriPath, err := DetectNRI(pathPrefix); err == nil {
+					if nriPath, err := d.detectNRI(pathPrefix); err == nil {
 						return runtime, hostPath, nriPath
 					} else {
 						log.Warnf("NRI detection failed: %s", err)
@@ -218,10 +236,10 @@ func DetectRuntimeViaMap(pathPrefix string, k8sRuntime string, explicitSocket st
 	if k8sRuntime != "" {
 		for _, path := range common.ContainerRuntimeSocketMap[k8sRuntime] {
 			if _, err := os.Stat(pathPrefix + path); err == nil || os.IsPermission(err) {
-				found, detectedRuntime := runtimeSockHasContainer(containerID, pathPrefix+path)
+				found, detectedRuntime := d.runtimeSockHasContainer(containerID, pathPrefix+path)
 				if found {
 					if (detectedRuntime == "docker" && strings.Contains(path, "containerd")) || detectedRuntime == "containerd" {
-						if nriPath, err := DetectNRI(pathPrefix); err == nil {
+						if nriPath, err := d.detectNRI(pathPrefix); err == nil {
 							return detectedRuntime, path, nriPath
 						} else {
 							log.Warnf("%s", err)
@@ -238,7 +256,7 @@ func DetectRuntimeViaMap(pathPrefix string, k8sRuntime string, explicitSocket st
 	for _, paths := range common.ContainerRuntimeSocketMap {
 		for _, path := range paths {
 			if _, err := os.Stat(pathPrefix + path); err == nil || os.IsPermission(err) {
-				found, k8sRuntime := runtimeSockHasContainer(containerID, pathPrefix+path)
+				found, k8sRuntime := d.runtimeSockHasContainer(containerID, pathPrefix+path)
 				if found {
 					return k8sRuntime, path, ""
 				}

--- a/pkg/KubeArmorOperator/runtime/runtime_test.go
+++ b/pkg/KubeArmorOperator/runtime/runtime_test.go
@@ -12,56 +12,279 @@ import (
 	"go.uber.org/zap"
 )
 
+func createSocket(t *testing.T, pathPrefix, relPath string) {
+	t.Helper()
+	full := filepath.Clean(pathPrefix + relPath)
+	if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(full, []byte(""), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+}
+
+func createNRI(t *testing.T, pathPrefix string) {
+	t.Helper()
+	for _, p := range common.ContainerRuntimeSocketMap["nri"] {
+		createSocket(t, pathPrefix, p)
+		return // one is enough
+	}
+}
+
+func TestDetectNRI(t *testing.T) {
+	originalMap := common.ContainerRuntimeSocketMap
+	t.Cleanup(func() { common.ContainerRuntimeSocketMap = originalMap })
+
+	nriPath := "/run/nri/nri.sock"
+	common.ContainerRuntimeSocketMap = map[string][]string{
+		"nri": {nriPath},
+	}
+
+	t.Run("NRISocketExists", func(t *testing.T) {
+		pathPrefix := t.TempDir()
+		createSocket(t, pathPrefix, nriPath)
+
+		got, err := DetectNRI(pathPrefix)
+		if err != nil {
+			t.Fatalf("expected no error, got: %v", err)
+		}
+		if got != nriPath {
+			t.Errorf("expected %q, got %q", nriPath, got)
+		}
+	})
+
+	t.Run("NRISocketMissing", func(t *testing.T) {
+		got, err := DetectNRI(t.TempDir())
+		if err == nil {
+			t.Fatal("expected an error, got nil")
+		}
+		if got != "NA" {
+			t.Errorf("expected \"NA\", got %q", got)
+		}
+	})
+}
+
 func TestDetectRuntimeViaMapWithExplicitSocket(t *testing.T) {
 	logger := zap.NewNop().Sugar()
 
-	// Test case 1: Valid explicit socket
 	t.Run("ValidExplicitSocket", func(t *testing.T) {
 		pathPrefix := t.TempDir()
 		socketPath := "/var/run/containerd/containerd.sock"
-		fullPath := filepath.Clean(pathPrefix + socketPath)
-
-		if err := os.MkdirAll(filepath.Dir(fullPath), 0o755); err != nil {
-			t.Fatalf("Failed to create directories: %v", err)
-		}
-		if err := os.WriteFile(fullPath, []byte(""), 0o644); err != nil {
-			t.Fatalf("Failed to create socket file: %v", err)
-		}
+		createSocket(t, pathPrefix, socketPath)
 
 		runtime, socket, _ := DetectRuntimeViaMap(pathPrefix, "", socketPath, *logger)
-
 		if runtime != "containerd" {
-			t.Errorf("Expected runtime 'containerd', got '%s'", runtime)
+			t.Errorf("expected 'containerd', got %q", runtime)
 		}
-
 		if socket != socketPath {
-			t.Errorf("Expected socket '%s', got '%s'", socketPath, socket)
+			t.Errorf("expected %q, got %q", socketPath, socket)
 		}
 	})
 
-	// Test case 2: Non-existent explicit socket
 	t.Run("NonExistentExplicitSocket", func(t *testing.T) {
 		runtime, socket, _ := DetectRuntimeViaMap("", "", "/nonexistent/socket.sock", *logger)
-
 		if runtime != "NA" {
-			t.Errorf("Expected runtime 'NA', got '%s'", runtime)
+			t.Errorf("expected 'NA', got %q", runtime)
 		}
-
 		if socket != "NA" {
-			t.Errorf("Expected socket 'NA', got '%s'", socket)
+			t.Errorf("expected 'NA', got %q", socket)
 		}
 	})
 
-	// Test case 3: Relative explicit socket should be rejected
 	t.Run("RelativeExplicitSocket", func(t *testing.T) {
 		runtime, socket, _ := DetectRuntimeViaMap("", "", "containerd/containerd.sock", *logger)
-
 		if runtime != "NA" {
-			t.Errorf("Expected runtime 'NA' for relative path, got '%s'", runtime)
+			t.Errorf("expected 'NA' for relative path, got %q", runtime)
+		}
+		if socket != "NA" {
+			t.Errorf("expected 'NA' for relative path, got %q", socket)
+		}
+	})
+
+	t.Run("ExplicitSocketWithUnixPrefix", func(t *testing.T) {
+		pathPrefix := t.TempDir()
+		hostPath := "/var/run/docker.sock"
+		createSocket(t, pathPrefix, hostPath)
+
+		runtime, socket, nri := DetectRuntimeViaMap(pathPrefix, "", "unix://"+hostPath, *logger)
+		if runtime != "docker" {
+			t.Errorf("expected 'docker', got %q", runtime)
+		}
+		if socket != hostPath {
+			t.Errorf("expected %q, got %q", hostPath, socket)
+		}
+		if nri != "" {
+			t.Errorf("expected empty NRI for docker socket, got %q", nri)
+		}
+	})
+
+	t.Run("ExplicitContainerdSocketWithNRI", func(t *testing.T) {
+		originalMap := common.ContainerRuntimeSocketMap
+		t.Cleanup(func() { common.ContainerRuntimeSocketMap = originalMap })
+
+		nriSock := "/run/nri/nri.sock"
+		common.ContainerRuntimeSocketMap = map[string][]string{
+			"nri": {nriSock},
 		}
 
+		pathPrefix := t.TempDir()
+		socketPath := "/var/run/containerd/containerd.sock"
+		createSocket(t, pathPrefix, socketPath)
+		createSocket(t, pathPrefix, nriSock)
+
+		runtime, socket, nri := DetectRuntimeViaMap(pathPrefix, "", socketPath, *logger)
+		if runtime != "containerd" {
+			t.Errorf("expected 'containerd', got %q", runtime)
+		}
+		if socket != socketPath {
+			t.Errorf("expected %q, got %q", socketPath, socket)
+		}
+		if nri != nriSock {
+			t.Errorf("expected NRI path %q, got %q", nriSock, nri)
+		}
+	})
+
+	t.Run("DockerSocketContainingContainerd", func(t *testing.T) {
+		originalMap := common.ContainerRuntimeSocketMap
+		t.Cleanup(func() { common.ContainerRuntimeSocketMap = originalMap })
+
+		nriSock := "/run/nri/nri.sock"
+		common.ContainerRuntimeSocketMap = map[string][]string{
+			"nri": {nriSock},
+		}
+
+		pathPrefix := t.TempDir()
+		socketPath := "/var/run/docker/containerd/docker.sock"
+		createSocket(t, pathPrefix, socketPath)
+		createSocket(t, pathPrefix, nriSock)
+
+		runtime, socket, nri := DetectRuntimeViaMap(pathPrefix, "", socketPath, *logger)
+		if runtime != "docker" {
+			t.Errorf("expected 'docker', got %q", runtime)
+		}
+		if socket != socketPath {
+			t.Errorf("expected %q, got %q", socketPath, socket)
+		}
+		if nri != nriSock {
+			t.Errorf("expected NRI path %q, got %q", nriSock, nri)
+		}
+	})
+}
+
+func TestDetectRuntimeViaMapAutoDetection(t *testing.T) {
+	logger := zap.NewNop().Sugar()
+
+	t.Run("K8sRuntimeHintMatches", func(t *testing.T) {
+		originalMap := common.ContainerRuntimeSocketMap
+		t.Cleanup(func() { common.ContainerRuntimeSocketMap = originalMap })
+
+		socketPath := "/var/run/containerd/containerd.sock"
+		common.ContainerRuntimeSocketMap = map[string][]string{
+			"containerd": {socketPath},
+		}
+
+		pathPrefix := t.TempDir()
+		createSocket(t, pathPrefix, socketPath)
+
+		runtime, socket, _ := DetectRuntimeViaMap(pathPrefix, "containerd", "", *logger)
+		if runtime != "containerd" {
+			t.Fatalf("expected 'containerd', got %q", runtime)
+		}
+		if socket != socketPath {
+			t.Fatalf("expected %q, got %q", socketPath, socket)
+		}
+	})
+
+	t.Run("K8sRuntimeContainerdWithNRI", func(t *testing.T) {
+		originalMap := common.ContainerRuntimeSocketMap
+		t.Cleanup(func() { common.ContainerRuntimeSocketMap = originalMap })
+
+		socketPath := "/var/run/containerd/containerd.sock"
+		nriSock := "/run/nri/nri.sock"
+		common.ContainerRuntimeSocketMap = map[string][]string{
+			"containerd": {socketPath},
+			"nri":        {nriSock},
+		}
+
+		pathPrefix := t.TempDir()
+		createSocket(t, pathPrefix, socketPath)
+		createSocket(t, pathPrefix, nriSock)
+
+		runtime, socket, nri := DetectRuntimeViaMap(pathPrefix, "containerd", "", *logger)
+		if runtime != "containerd" {
+			t.Errorf("expected 'containerd', got %q", runtime)
+		}
+		if socket != socketPath {
+			t.Errorf("expected %q, got %q", socketPath, socket)
+		}
+		if nri != nriSock {
+			t.Errorf("expected NRI path %q, got %q", nriSock, nri)
+		}
+	})
+
+	t.Run("K8sRuntimeHintMissesButFallbackFinds", func(t *testing.T) {
+		originalMap := common.ContainerRuntimeSocketMap
+		t.Cleanup(func() { common.ContainerRuntimeSocketMap = originalMap })
+
+		hintedSocket := "/var/run/containerd/containerd.sock"
+		fallbackSocket := "/var/run/crio/crio.sock"
+		common.ContainerRuntimeSocketMap = map[string][]string{
+			"containerd": {hintedSocket},
+			"cri-o":      {fallbackSocket},
+		}
+
+		pathPrefix := t.TempDir()
+		createSocket(t, pathPrefix, fallbackSocket)
+
+		runtime, socket, _ := DetectRuntimeViaMap(pathPrefix, "containerd", "", *logger)
+		if runtime == "NA" {
+			t.Errorf("expected a runtime to be detected via fallback scan, got 'NA'")
+		}
+		if socket == "NA" {
+			t.Errorf("expected a socket to be detected via fallback scan, got 'NA'")
+		}
+	})
+
+	t.Run("NoRuntimeDetected", func(t *testing.T) {
+		originalMap := common.ContainerRuntimeSocketMap
+		t.Cleanup(func() { common.ContainerRuntimeSocketMap = originalMap })
+
+		common.ContainerRuntimeSocketMap = map[string][]string{
+			"containerd": {"/var/run/containerd/containerd.sock"},
+		}
+
+		pathPrefix := t.TempDir()
+
+		runtime, socket, nri := DetectRuntimeViaMap(pathPrefix, "", "", *logger)
+		if runtime != "NA" {
+			t.Errorf("expected 'NA', got %q", runtime)
+		}
 		if socket != "NA" {
-			t.Errorf("Expected socket 'NA' for relative path, got '%s'", socket)
+			t.Errorf("expected 'NA', got %q", socket)
+		}
+		if nri != "NA" {
+			t.Errorf("expected 'NA', got %q", nri)
+		}
+	})
+
+	t.Run("K8sRuntimeCRIO", func(t *testing.T) {
+		originalMap := common.ContainerRuntimeSocketMap
+		t.Cleanup(func() { common.ContainerRuntimeSocketMap = originalMap })
+
+		socketPath := "/var/run/crio/crio.sock"
+		common.ContainerRuntimeSocketMap = map[string][]string{
+			"cri-o": {socketPath},
+		}
+
+		pathPrefix := t.TempDir()
+		createSocket(t, pathPrefix, socketPath)
+
+		runtime, socket, _ := DetectRuntimeViaMap(pathPrefix, "cri-o", "", *logger)
+		if runtime != "cri-o" {
+			t.Errorf("expected 'cri-o', got %q", runtime)
+		}
+		if socket != socketPath {
+			t.Errorf("expected %q, got %q", socketPath, socket)
 		}
 	})
 }
@@ -74,51 +297,19 @@ func TestDetermineRuntimeFromSocket(t *testing.T) {
 		{"/var/run/docker.sock", "docker"},
 		{"/run/containerd/containerd.sock", "containerd"},
 		{"/var/run/crio/crio.sock", "cri-o"},
+		{"/var/run/cri-o/cri-o.sock", "cri-o"},
 		{"/run/k3s/containerd/containerd.sock", "containerd"},
-		{"/some/unknown/path.sock", "containerd"}, // fallback
+		{"/some/unknown/path.sock", "containerd"},
 	}
 
 	for _, tc := range testCases {
+		tc := tc
 		t.Run(tc.socketPath, func(t *testing.T) {
 			result := determineRuntimeFromSocket(tc.socketPath)
 			if result != tc.expectedRuntime {
-				t.Errorf("For socket %s, expected runtime %s, got %s",
+				t.Errorf("socket %q: expected %q, got %q",
 					tc.socketPath, tc.expectedRuntime, result)
 			}
 		})
-	}
-}
-
-func TestDetectRuntimeViaMapAutoDetection(t *testing.T) {
-	logger := zap.NewNop().Sugar()
-
-	originalMap := common.ContainerRuntimeSocketMap
-	t.Cleanup(func() {
-		common.ContainerRuntimeSocketMap = originalMap
-	})
-
-	socketPath := "/var/run/containerd/containerd.sock"
-	common.ContainerRuntimeSocketMap = map[string][]string{
-		"containerd": {socketPath},
-	}
-
-	pathPrefix := t.TempDir()
-	fullPath := filepath.Clean(pathPrefix + socketPath)
-
-	if err := os.MkdirAll(filepath.Dir(fullPath), 0o755); err != nil {
-		t.Fatalf("Failed to create directories: %v", err)
-	}
-	if err := os.WriteFile(fullPath, []byte(""), 0o644); err != nil {
-		t.Fatalf("Failed to write socket file: %v", err)
-	}
-
-	runtime, socket, _ := DetectRuntimeViaMap(pathPrefix, "containerd", "", *logger)
-
-	if runtime != "containerd" {
-		t.Fatalf("Expected runtime 'containerd', got '%s'", runtime)
-	}
-
-	if socket != socketPath {
-		t.Fatalf("Expected socket '%s', got '%s'", socketPath, socket)
 	}
 }

--- a/pkg/KubeArmorOperator/runtime/runtime_test.go
+++ b/pkg/KubeArmorOperator/runtime/runtime_test.go
@@ -1,0 +1,445 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Authors of KubeArmor
+
+package runtime
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/kubearmor/KubeArmor/pkg/KubeArmorOperator/common"
+	"go.uber.org/zap"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func createSocket(t *testing.T, pathPrefix, relPath string) {
+	t.Helper()
+	full := filepath.Clean(pathPrefix + relPath)
+	if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(full, []byte(""), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+}
+
+func makeSocket(t *testing.T, dir, name string) string {
+	t.Helper()
+	p := filepath.Join(dir, name)
+	if err := os.WriteFile(p, []byte(""), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	return p
+}
+
+// neverFindsRuntime is a runtimeDeps stub where no runtime is ever found.
+var neverFindsRuntime = runtimeDeps{
+	runtimeSockHasContainer: func(id, path string) (bool, string) { return false, "" },
+	detectNRI:               DetectNRI,
+}
+
+func TestDetectNRI(t *testing.T) {
+	originalMap := common.ContainerRuntimeSocketMap
+	t.Cleanup(func() { common.ContainerRuntimeSocketMap = originalMap })
+
+	nriPath := "/run/nri/nri.sock"
+	common.ContainerRuntimeSocketMap = map[string][]string{
+		"nri": {nriPath},
+	}
+
+	t.Run("NRISocketExists", func(t *testing.T) {
+		pathPrefix := t.TempDir()
+		createSocket(t, pathPrefix, nriPath)
+
+		got, err := DetectNRI(pathPrefix)
+		if err != nil {
+			t.Fatalf("expected no error, got: %v", err)
+		}
+		if got != nriPath {
+			t.Errorf("expected %q, got %q", nriPath, got)
+		}
+	})
+
+	t.Run("NRISocketMissing", func(t *testing.T) {
+		got, err := DetectNRI(t.TempDir())
+		if err == nil {
+			t.Fatal("expected an error, got nil")
+		}
+		if got != "NA" {
+			t.Errorf("expected \"NA\", got %q", got)
+		}
+	})
+}
+
+func makeFakePod(podName, namespace, containerID string, noContainerStatus bool) *corev1.Pod {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      podName,
+			Namespace: namespace,
+		},
+	}
+	if !noContainerStatus {
+		pod.Status.ContainerStatuses = []corev1.ContainerStatus{
+			{ContainerID: containerID},
+		}
+	}
+	return pod
+}
+
+// TestDetectRuntimeViaMapEarlyReturns covers the input-validation and early-return
+// paths of DetectRuntimeViaMap that execute before any socket connection is attempted.
+// The real runtimeSockHasContainer success paths (containerd/crio/docker gRPC
+// handshakes against live runtime sockets) require integration tests, but
+// DetectRuntimeViaMap's higher-level branching can still be unit-tested via
+// detectRuntimeViaMapWithDeps using injected stubs.
+func TestDetectRuntimeViaMapEarlyReturns(t *testing.T) {
+	logger := zap.NewNop().Sugar()
+
+	const (
+		podName   = "test-pod"
+		namespace = "default"
+	)
+	t.Setenv("POD_NAME", podName)
+	t.Setenv("POD_NAMESPACE", namespace)
+
+	t.Run("NoPodFound", func(t *testing.T) {
+		cl := fake.NewClientset()
+		runtime, socket, nri := detectRuntimeViaMapWithDeps("", "", "", *logger, cl, neverFindsRuntime)
+		if runtime != "NA" || socket != "NA" || nri != "NA" {
+			t.Errorf("expected NA/NA/NA when pod not found, got %q/%q/%q", runtime, socket, nri)
+		}
+	})
+
+	t.Run("EmptyContainerStatuses", func(t *testing.T) {
+		cl := fake.NewClientset(makeFakePod(podName, namespace, "", true))
+		runtime, socket, nri := detectRuntimeViaMapWithDeps("", "", "", *logger, cl, neverFindsRuntime)
+		if runtime != "NA" || socket != "NA" || nri != "NA" {
+			t.Errorf("expected NA/NA/NA with empty ContainerStatuses, got %q/%q/%q", runtime, socket, nri)
+		}
+	})
+
+	t.Run("MalformedContainerID", func(t *testing.T) {
+		cl := fake.NewClientset(makeFakePod(podName, namespace, "containerd-abcdef123456", false))
+		runtime, socket, nri := detectRuntimeViaMapWithDeps("", "", "", *logger, cl, neverFindsRuntime)
+		if runtime != "NA" || socket != "NA" || nri != "NA" {
+			t.Errorf("expected NA/NA/NA with malformed containerID, got %q/%q/%q", runtime, socket, nri)
+		}
+	})
+
+	t.Run("RelativeExplicitSocketRejected", func(t *testing.T) {
+		cl := fake.NewClientset(makeFakePod(podName, namespace, "containerd://abcdef123456", false))
+		runtime, socket, nri := detectRuntimeViaMapWithDeps("", "", "relative/path.sock", *logger, cl, neverFindsRuntime)
+		if runtime != "NA" || socket != "NA" || nri != "NA" {
+			t.Errorf("expected NA/NA/NA for relative explicit socket, got %q/%q/%q", runtime, socket, nri)
+		}
+	})
+
+	t.Run("NonExistentExplicitSocket", func(t *testing.T) {
+		cl := fake.NewClientset(makeFakePod(podName, namespace, "containerd://abcdef123456", false))
+		runtime, socket, nri := detectRuntimeViaMapWithDeps("", "", "/nonexistent/socket.sock", *logger, cl, neverFindsRuntime)
+		if runtime != "NA" || socket != "NA" || nri != "NA" {
+			t.Errorf("expected NA/NA/NA for missing socket file, got %q/%q/%q", runtime, socket, nri)
+		}
+	})
+
+	t.Run("UnixPrefixStrippedBeforeAbsCheck", func(t *testing.T) {
+		cl := fake.NewClientset(makeFakePod(podName, namespace, "containerd://abcdef123456", false))
+		runtime, socket, nri := detectRuntimeViaMapWithDeps("", "", "unix://relative/path.sock", *logger, cl, neverFindsRuntime)
+		if runtime != "NA" || socket != "NA" || nri != "NA" {
+			t.Errorf("expected NA/NA/NA for unix:// prefixed relative path, got %q/%q/%q", runtime, socket, nri)
+		}
+	})
+
+	// ExplicitSocket exists on disk but runtimeSockHasContainer returns false.
+	// ContainerRuntimeSocketMap is cleared so the fallback loop also finds nothing,
+	// making the test deterministic on any environment.
+	t.Run("ExplicitSocketExistsButNoRuntime", func(t *testing.T) {
+		originalMap := common.ContainerRuntimeSocketMap
+		t.Cleanup(func() { common.ContainerRuntimeSocketMap = originalMap })
+		common.ContainerRuntimeSocketMap = map[string][]string{}
+
+		sockPath := makeSocket(t, t.TempDir(), "fake.sock")
+		cl := fake.NewClientset(makeFakePod(podName, namespace, "containerd://abcdef123456", false))
+		runtime, socket, nri := detectRuntimeViaMapWithDeps("", "", sockPath, *logger, cl, neverFindsRuntime)
+		if runtime != "NA" || socket != "NA" || nri != "NA" {
+			t.Errorf("expected NA/NA/NA when socket exists but no runtime, got %q/%q/%q", runtime, socket, nri)
+		}
+	})
+
+	// k8sRuntime hint provided but socket file does not exist: Stat fails,
+	// the warning is logged, and the fallback loop runs (also finds nothing).
+	t.Run("K8sRuntimeHintSocketMissing", func(t *testing.T) {
+		originalMap := common.ContainerRuntimeSocketMap
+		t.Cleanup(func() { common.ContainerRuntimeSocketMap = originalMap })
+		common.ContainerRuntimeSocketMap = map[string][]string{
+			"containerd": {"/run/containerd/containerd.sock"},
+		}
+
+		cl := fake.NewClientset(makeFakePod(podName, namespace, "containerd://abcdef123456", false))
+		runtime, socket, nri := detectRuntimeViaMapWithDeps("", "containerd", "", *logger, cl, neverFindsRuntime)
+		if runtime != "NA" || socket != "NA" || nri != "NA" {
+			t.Errorf("expected NA/NA/NA when k8sRuntime socket missing, got %q/%q/%q", runtime, socket, nri)
+		}
+	})
+
+	// k8sRuntime hint is empty: the k8sRuntime block is skipped entirely and the
+	// fallback loop runs. With an empty socket map it finds nothing.
+	t.Run("EmptyK8sRuntimeFallbackLoop", func(t *testing.T) {
+		originalMap := common.ContainerRuntimeSocketMap
+		t.Cleanup(func() { common.ContainerRuntimeSocketMap = originalMap })
+		common.ContainerRuntimeSocketMap = map[string][]string{}
+
+		cl := fake.NewClientset(makeFakePod(podName, namespace, "containerd://abcdef123456", false))
+		runtime, socket, nri := detectRuntimeViaMapWithDeps("", "", "", *logger, cl, neverFindsRuntime)
+		if runtime != "NA" || socket != "NA" || nri != "NA" {
+			t.Errorf("expected NA/NA/NA with empty socket map, got %q/%q/%q", runtime, socket, nri)
+		}
+	})
+
+	// Fallback loop: socket map has an entry whose file does not exist.
+	t.Run("FallbackLoopSocketMissing", func(t *testing.T) {
+		originalMap := common.ContainerRuntimeSocketMap
+		t.Cleanup(func() { common.ContainerRuntimeSocketMap = originalMap })
+		common.ContainerRuntimeSocketMap = map[string][]string{
+			"docker": {"/run/docker.sock"},
+		}
+
+		cl := fake.NewClientset(makeFakePod(podName, namespace, "docker://abcdef123456", false))
+		runtime, socket, nri := detectRuntimeViaMapWithDeps("", "", "", *logger, cl, neverFindsRuntime)
+		if runtime != "NA" || socket != "NA" || nri != "NA" {
+			t.Errorf("expected NA/NA/NA when fallback socket missing, got %q/%q/%q", runtime, socket, nri)
+		}
+	})
+
+	// Fallback loop: socket file exists but runtimeSockHasContainer returns false.
+	t.Run("FallbackLoopSocketExistsNoRuntime", func(t *testing.T) {
+		originalMap := common.ContainerRuntimeSocketMap
+		t.Cleanup(func() { common.ContainerRuntimeSocketMap = originalMap })
+
+		dir := t.TempDir()
+		relSock := "/fake.sock"
+		if err := os.WriteFile(dir+relSock, []byte(""), 0o644); err != nil {
+			t.Fatalf("WriteFile: %v", err)
+		}
+		common.ContainerRuntimeSocketMap = map[string][]string{
+			"docker": {relSock},
+		}
+
+		cl := fake.NewClientset(makeFakePod(podName, namespace, "docker://abcdef123456", false))
+		runtime, socket, nri := detectRuntimeViaMapWithDeps(dir, "", "", *logger, cl, neverFindsRuntime)
+		if runtime != "NA" || socket != "NA" || nri != "NA" {
+			t.Errorf("expected NA/NA/NA in fallback loop with no runtime, got %q/%q/%q", runtime, socket, nri)
+		}
+	})
+}
+
+// TestDockerSockHasContainer exercises dockerSockHasContainer against a dummy socket.
+// client.New is lazy so New succeeds; ContainerInspect then fails, returning false.
+func TestDockerSockHasContainer(t *testing.T) {
+	sockPath := makeSocket(t, t.TempDir(), "docker.sock")
+	if got := dockerSockHasContainer("nonexistent-id", sockPath); got {
+		t.Error("expected false for dummy file, got true")
+	}
+}
+
+// TestContainerdSockHasContainer exercises containerdSockHasContainer with a path
+// that points to a non-containerd socket so LoadContainer fails -> false.
+func TestContainerdSockHasContainer(t *testing.T) {
+	sockPath := makeSocket(t, t.TempDir(), "containerd.sock")
+	if got := containerdSockHasContainer("nonexistent-id", sockPath); got {
+		t.Error("expected false for dummy file, got true")
+	}
+}
+
+// TestDockershimSockHasContainer exercises dockershimSockHasContainer.
+// grpc.NewClient is lazy (never fails at construction); ContainerStatus
+// fails against the dummy socket, so the function returns false.
+func TestDockershimSockHasContainer(t *testing.T) {
+	sockPath := makeSocket(t, t.TempDir(), "dockershim.sock")
+	if got := dockershimSockHasContainer("nonexistent-id", sockPath); got {
+		t.Error("expected false for dummy file, got true")
+	}
+}
+
+// TestCrioSockHasContainer exercises crioSockHasContainer the same way.
+func TestCrioSockHasContainer(t *testing.T) {
+	sockPath := makeSocket(t, t.TempDir(), "crio.sock")
+	if got := crioSockHasContainer("nonexistent-id", sockPath); got {
+		t.Error("expected false for dummy file, got true")
+	}
+}
+
+// TestRuntimeSockHasContainer verifies that runtimeSockHasContainer returns
+// (false, "") when all sub-checks fail against a dummy socket.
+func TestRuntimeSockHasContainer(t *testing.T) {
+	sockPath := makeSocket(t, t.TempDir(), "runtime.sock")
+	found, rt := runtimeSockHasContainer("nonexistent-id", sockPath)
+	if found {
+		t.Errorf("expected found=false, got true (runtime=%q)", rt)
+	}
+	if rt != "" {
+		t.Errorf("expected empty runtime string, got %q", rt)
+	}
+}
+
+// TestContainerdNewError forces the containerd.New error branch by passing
+// an empty address, which containerd rejects before any dial attempt.
+func TestContainerdNewError(t *testing.T) {
+	if got := containerdSockHasContainer("id", ""); got {
+		t.Error("expected false on containerd.New error, got true")
+	}
+}
+
+// TestDockerClientNewError forces dockerSockHasContainer to hit the client.New
+// error branch by supplying a host with a null byte that the URL parser rejects.
+func TestDockerClientNewError(t *testing.T) {
+	if got := dockerSockHasContainer("id", "\x00invalid"); got {
+		t.Error("expected false on client.New error, got true")
+	}
+}
+
+// TestDetectRuntimeViaMapInjected uses detectRuntimeViaMapWithDeps to cover every
+// branch that requires a runtime to actually answer. It still temporarily overrides
+// common.ContainerRuntimeSocketMap for the duration of the test and restores it with
+// t.Cleanup, so this test is not fully free of mutable global state.
+func TestDetectRuntimeViaMapInjected(t *testing.T) {
+	logger := zap.NewNop().Sugar()
+
+	const (
+		podName   = "test-pod"
+		namespace = "default"
+	)
+	t.Setenv("POD_NAME", podName)
+	t.Setenv("POD_NAMESPACE", namespace)
+
+	origMap := common.ContainerRuntimeSocketMap
+	t.Cleanup(func() { common.ContainerRuntimeSocketMap = origMap })
+
+	// explicit socket: containerd runtime found, NRI succeeds
+	t.Run("ExplicitSocket_Containerd_NRISuccess", func(t *testing.T) {
+		sock := makeSocket(t, t.TempDir(), "containerd.sock")
+		d := runtimeDeps{
+			runtimeSockHasContainer: func(id, path string) (bool, string) { return true, "containerd" },
+			detectNRI:               func(prefix string) (string, error) { return "/run/nri/nri.sock", nil },
+		}
+		cl := fake.NewClientset(makeFakePod(podName, namespace, "containerd://abcdef123456", false))
+		rt, socket, nri := detectRuntimeViaMapWithDeps("", "", sock, *logger, cl, d)
+		if rt != "containerd" || socket != sock || nri != "/run/nri/nri.sock" {
+			t.Errorf("unexpected result: %q/%q/%q", rt, socket, nri)
+		}
+	})
+
+	// explicit socket: docker runtime on a path containing "containerd", NRI succeeds
+	t.Run("ExplicitSocket_DockerOnContainerdPath_NRISuccess", func(t *testing.T) {
+		sock := makeSocket(t, t.TempDir(), "containerd.sock")
+		d := runtimeDeps{
+			runtimeSockHasContainer: func(id, path string) (bool, string) { return true, "docker" },
+			detectNRI:               func(prefix string) (string, error) { return "/run/nri/nri.sock", nil },
+		}
+		cl := fake.NewClientset(makeFakePod(podName, namespace, "containerd://abcdef123456", false))
+		rt, socket, nri := detectRuntimeViaMapWithDeps("", "", sock, *logger, cl, d)
+		if rt != "docker" || socket != sock || nri != "/run/nri/nri.sock" {
+			t.Errorf("unexpected result: %q/%q/%q", rt, socket, nri)
+		}
+	})
+
+	// explicit socket: containerd runtime, NRI fails -> nri returned as empty string
+	t.Run("ExplicitSocket_Containerd_NRIFail", func(t *testing.T) {
+		sock := makeSocket(t, t.TempDir(), "containerd.sock")
+		d := runtimeDeps{
+			runtimeSockHasContainer: func(id, path string) (bool, string) { return true, "containerd" },
+			detectNRI:               func(prefix string) (string, error) { return "NA", fmt.Errorf("NRI not available") },
+		}
+		cl := fake.NewClientset(makeFakePod(podName, namespace, "containerd://abcdef123456", false))
+		rt, socket, nri := detectRuntimeViaMapWithDeps("", "", sock, *logger, cl, d)
+		if rt != "containerd" || socket != sock || nri != "" {
+			t.Errorf("unexpected result: %q/%q/%q", rt, socket, nri)
+		}
+	})
+
+	// explicit socket: non-containerd runtime (cri-o) -> no NRI check, returns directly
+	t.Run("ExplicitSocket_CrioRuntime", func(t *testing.T) {
+		sock := makeSocket(t, t.TempDir(), "crio.sock")
+		d := runtimeDeps{
+			runtimeSockHasContainer: func(id, path string) (bool, string) { return true, "cri-o" },
+			detectNRI:               DetectNRI,
+		}
+		cl := fake.NewClientset(makeFakePod(podName, namespace, "containerd://abcdef123456", false))
+		rt, socket, nri := detectRuntimeViaMapWithDeps("", "", sock, *logger, cl, d)
+		if rt != "cri-o" || socket != sock || nri != "" {
+			t.Errorf("unexpected result: %q/%q/%q", rt, socket, nri)
+		}
+	})
+
+	// k8sRuntime hint: socket exists, containerd found, NRI succeeds
+	t.Run("K8sHint_Containerd_NRISuccess", func(t *testing.T) {
+		dir := t.TempDir()
+		relSock := "/containerd.sock"
+		makeSocket(t, dir, "containerd.sock")
+		common.ContainerRuntimeSocketMap = map[string][]string{"containerd": {relSock}}
+		d := runtimeDeps{
+			runtimeSockHasContainer: func(id, path string) (bool, string) { return true, "containerd" },
+			detectNRI:               func(prefix string) (string, error) { return "/run/nri/nri.sock", nil },
+		}
+		cl := fake.NewClientset(makeFakePod(podName, namespace, "containerd://abcdef123456", false))
+		rt, socket, nri := detectRuntimeViaMapWithDeps(dir, "containerd", "", *logger, cl, d)
+		if rt != "containerd" || socket != relSock || nri != "/run/nri/nri.sock" {
+			t.Errorf("unexpected result: %q/%q/%q", rt, socket, nri)
+		}
+	})
+
+	// k8sRuntime hint: socket exists, containerd found, NRI fails
+	t.Run("K8sHint_Containerd_NRIFail", func(t *testing.T) {
+		dir := t.TempDir()
+		relSock := "/containerd.sock"
+		makeSocket(t, dir, "containerd.sock")
+		common.ContainerRuntimeSocketMap = map[string][]string{"containerd": {relSock}}
+		d := runtimeDeps{
+			runtimeSockHasContainer: func(id, path string) (bool, string) { return true, "containerd" },
+			detectNRI:               func(prefix string) (string, error) { return "NA", fmt.Errorf("NRI not available") },
+		}
+		cl := fake.NewClientset(makeFakePod(podName, namespace, "containerd://abcdef123456", false))
+		rt, socket, nri := detectRuntimeViaMapWithDeps(dir, "containerd", "", *logger, cl, d)
+		if rt != "containerd" || socket != relSock || nri != "" {
+			t.Errorf("unexpected result: %q/%q/%q", rt, socket, nri)
+		}
+	})
+
+	// k8sRuntime hint: socket exists, non-containerd runtime found
+	t.Run("K8sHint_CrioRuntime", func(t *testing.T) {
+		dir := t.TempDir()
+		relSock := "/crio.sock"
+		makeSocket(t, dir, "crio.sock")
+		common.ContainerRuntimeSocketMap = map[string][]string{"cri-o": {relSock}}
+		d := runtimeDeps{
+			runtimeSockHasContainer: func(id, path string) (bool, string) { return true, "cri-o" },
+			detectNRI:               DetectNRI,
+		}
+		cl := fake.NewClientset(makeFakePod(podName, namespace, "containerd://abcdef123456", false))
+		rt, socket, nri := detectRuntimeViaMapWithDeps(dir, "cri-o", "", *logger, cl, d)
+		if rt != "cri-o" || socket != relSock || nri != "" {
+			t.Errorf("unexpected result: %q/%q/%q", rt, socket, nri)
+		}
+	})
+
+	// fallback loop: socket exists, runtime found
+	t.Run("FallbackLoop_RuntimeFound", func(t *testing.T) {
+		dir := t.TempDir()
+		relSock := "/docker.sock"
+		makeSocket(t, dir, "docker.sock")
+		common.ContainerRuntimeSocketMap = map[string][]string{"docker": {relSock}}
+		d := runtimeDeps{
+			runtimeSockHasContainer: func(id, path string) (bool, string) { return true, "docker" },
+			detectNRI:               DetectNRI,
+		}
+		cl := fake.NewClientset(makeFakePod(podName, namespace, "docker://abcdef123456", false))
+		rt, socket, nri := detectRuntimeViaMapWithDeps(dir, "", "", *logger, cl, d)
+		if rt != "docker" || socket != relSock || nri != "" {
+			t.Errorf("unexpected result: %q/%q/%q", rt, socket, nri)
+		}
+	})
+}


### PR DESCRIPTION
**Purpose of PR?**
Adds unit tests for `pkg/KubeArmorOperator/runtime`, increasing statement coverage from 75.2% to 86.3%.
Fixes #

**Does this PR introduce a breaking change?**
No

**If the changes in this PR are manually verified, list down the scenarios covered:**
- NRI socket detection (present and missing)
- `DetectRuntimeViaMap` early returns: no pod, empty container statuses, malformed container ID, relative/missing/unix-prefixed explicit socket
- `DetectRuntimeViaMap` with injected stubs: explicit socket with containerd/docker-on-containerd-path/cri-o runtime, k8s hint with NRI success/fail, fallback loop runtime found
- `runtimeSockHasContainer` true branches for all four sub-checkers (containerd, cri-o, docker, dockershim) via injectable dependencies
- `containerdSockHasContainer` error path on `containerd.New` with empty address
- `dockerSockHasContainer` error path on `client.New` with invalid host

<img width="1502" height="159" alt="image" src="https://github.com/user-attachments/assets/587a0dd2-8075-4496-8389-7eb0289d7dfa" />


**Additional information for reviewer?**
To make `DetectRuntimeViaMap` and `runtimeSockHasContainer` testable without a live container runtime, a `runtimeDeps` struct is introduced to hold injectable function fields (`runtimeSockHasContainer` and `detectNRI`). Production code populates this struct via `defaultDeps()`, which assigns the real implementations. Tests pass in stub implementations directly and restore originals via `t.Cleanup`. The remaining ~8% uncovered lines are the `return true` paths inside the four sock-checker functions, which require a live daemon and belong in integration tests.

**Checklist:**
- [ ] Bug fix. Fixes #<issue number>
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] PR Title follows the convention of `<type>(<scope>): <subject>`
- [x] Commit has unit tests
- [ ] Commit has integration tests