### PR TITLE
fix(operator): create kubearmor namespace before operator resources

### DIFF
--- a/pkg/KubeArmorOperator/config/default/kustomization.yaml
+++ b/pkg/KubeArmorOperator/config/default/kustomization.yaml
@@ -4,6 +4,7 @@ kind: Kustomization
 namespace: kubearmor
 
 resources:
+- namespace.yaml
 - ../crd
 - ../rbac
 - ../operator

--- a/pkg/KubeArmorOperator/config/default/namespace.yaml
+++ b/pkg/KubeArmorOperator/config/default/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kubearmor


### PR DESCRIPTION
**Purpose of PR?**:

When deploying the KubeArmor operator via `make deploy`, kustomize applies resources into the `kubearmor` namespace but that namespace doesn't exist yet, causing:
`Error from server (NotFound): error when creating "STDIN": namespaces "kubearmor" not found`

Added `namespace.yaml` to `config/default` and listed it first in `kustomization.yaml` so the namespace is created before any resources that depend on it

Fixes #1767

**Does this PR introduce a breaking change?**
No

**If the changes in this PR are manually verified, list down the scenarios covered:**:
Running `make deploy` from `pkg/KubeArmorOperator` on a fresh cluster without a pre-existing `kubearmor` namespace no longer errors out.

**Additional information for reviewer?** :
This fix was suggested by @kranurag7  in the original issue. The namespace is added to `config/default` rather than `config/operator` since `config/default/kustomization.yaml` is the one setting `namespace: kubearmor` it should own creating it too.

**Checklist:**
- [x] Bug fix. Fixes #1767 
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Commit has unit tests
- [ ] Commit has integration tests