### PR TITLE
fix(kubearmor-relay): RBAC kubearmor-relay roles.yaml

### DIFF
--- a/deployments/helm/KubeArmor/templates/RBAC/roles.yaml
+++ b/deployments/helm/KubeArmor/templates/RBAC/roles.yaml
@@ -70,7 +70,9 @@ rules:
   - ""
   resources:
   - pods
+  - services
   verbs:
+  - get
   - list
   - watch
 ---


### PR DESCRIPTION
Based on this commit https://github.com/kubearmor/kubearmor-relay-server/commit/cefdc046792a9eecadb6c80bd06322c412a315a5 from 10 months ago, kubearmor-relay require services get permission.

**Purpose of PR?**:

Fixes 
 [x] Fix missing permission on RBAC
Ref: https://github.com/kubearmor/kubearmor-relay-server/blob/main/deployments/relay-deployment.yaml#L28

**Does this PR introduce a breaking change?**
No.

**If the changes in this PR are manually verified, list down the scenarios covered:**:
N/A

**Additional information for reviewer?** :
No

**Checklist:**
- [X] Bug fix. Fixes missing RBAC permission from kubearmor-relay-server project introduced 10 months ago