### PR TITLE
fix(monitor): improve SystemMonitor teardown and goroutine lifecycle handling

### DIFF
--- a/KubeArmor/monitor/systemMonitor.go
+++ b/KubeArmor/monitor/systemMonitor.go
@@ -62,6 +62,10 @@ type NsVisibility struct {
 	IMA        bool
 }
 
+type linkCloser interface {
+	Close() error
+}
+
 // ===================== //
 // == Syscall Context == //
 // ===================== //
@@ -158,7 +162,7 @@ type SystemMonitor struct {
 	PinPath          string
 
 	// Probes Links
-	Probes map[string]link.Link
+	Probes map[string]linkCloser
 
 	// context + args
 	ContextChan chan ContextCombined
@@ -591,7 +595,7 @@ func (mon *SystemMonitor) InitBPF() error {
 
 	if mon.BpfModule != nil {
 
-		mon.Probes = make(map[string]link.Link)
+		mon.Probes = make(map[string]linkCloser)
 
 		mon.Probes["kprobe__udp_sendmsg"], err = link.Kprobe("udp_sendmsg", mon.BpfModule.Programs["kprobe__udp_sendmsg"], nil)
 		if err != nil {
@@ -724,9 +728,11 @@ func (mon *SystemMonitor) DestroySystemMonitor() error {
 
 	mon.Status = false
 
+	var errs []error
+
 	if mon.SyscallPerfMap != nil {
 		if err := mon.SyscallPerfMap.Close(); err != nil {
-			return err
+			errs = append(errs, fmt.Errorf("closing perf map: %w", err))
 		}
 	}
 
@@ -738,9 +744,9 @@ func (mon *SystemMonitor) DestroySystemMonitor() error {
 		close(mon.ContextChan)
 	}
 
-	for _, link := range mon.Probes {
+	for name, link := range mon.Probes {
 		if err := link.Close(); err != nil {
-			return err
+			errs = append(errs, fmt.Errorf("closing probe %s: %w", name, err))
 		}
 	}
 
@@ -751,7 +757,7 @@ func (mon *SystemMonitor) DestroySystemMonitor() error {
 	}
 
 	mon.DestroyBPFMaps()
-	return nil
+	return errors.Join(errs...)
 }
 
 // ======================= //
@@ -792,12 +798,14 @@ func (mon *SystemMonitor) TraceSyscall() {
 	ContainersLock := *(mon.ContainersLock)
 
 	ReplayChannel := make(chan []byte, SyscallChannelSize)
+	defer close(ReplayChannel)
 
 	go func() {
 		for {
 			dataRaw, valid := <-ReplayChannel
 			if !valid {
-				continue
+				// channel closed exit the goroutine
+				return
 			}
 			dataBuff := bytes.NewBuffer(dataRaw)
 			ctx, err := readContextFromBuff(dataBuff)
@@ -827,6 +835,8 @@ func (mon *SystemMonitor) TraceSyscall() {
 
 					select {
 					case mon.SyscallChannel <- dataRaw:
+						// successfully replayed no need to keep retrying
+						return
 					default:
 						// channel is full, wait for a short time before retrying
 						time.Sleep(1 * time.Second)

--- a/KubeArmor/monitor/systemMonitor.go
+++ b/KubeArmor/monitor/systemMonitor.go
@@ -62,6 +62,10 @@ type NsVisibility struct {
 	IMA        bool
 }
 
+type linkCloser interface {
+	Close() error
+}
+
 // ===================== //
 // == Syscall Context == //
 // ===================== //
@@ -158,7 +162,7 @@ type SystemMonitor struct {
 	PinPath          string
 
 	// Probes Links
-	Probes map[string]link.Link
+	Probes map[string]linkCloser
 
 	// context + args
 	ContextChan chan ContextCombined
@@ -591,7 +595,7 @@ func (mon *SystemMonitor) InitBPF() error {
 
 	if mon.BpfModule != nil {
 
-		mon.Probes = make(map[string]link.Link)
+		mon.Probes = make(map[string]linkCloser)
 
 		mon.Probes["kprobe__udp_send_skb"], err = link.Kprobe("udp_send_skb", mon.BpfModule.Programs["kprobe__udp_send_skb"], nil)
 		if err != nil {
@@ -724,9 +728,11 @@ func (mon *SystemMonitor) DestroySystemMonitor() error {
 
 	mon.Status = false
 
+	var errs []error
+
 	if mon.SyscallPerfMap != nil {
 		if err := mon.SyscallPerfMap.Close(); err != nil {
-			return err
+			errs = append(errs, fmt.Errorf("closing perf map: %w", err))
 		}
 	}
 
@@ -738,9 +744,9 @@ func (mon *SystemMonitor) DestroySystemMonitor() error {
 		close(mon.ContextChan)
 	}
 
-	for _, link := range mon.Probes {
+	for name, link := range mon.Probes {
 		if err := link.Close(); err != nil {
-			return err
+			errs = append(errs, fmt.Errorf("closing probe %s: %w", name, err))
 		}
 	}
 
@@ -751,7 +757,7 @@ func (mon *SystemMonitor) DestroySystemMonitor() error {
 	}
 
 	mon.DestroyBPFMaps()
-	return nil
+	return errors.Join(errs...)
 }
 
 // ======================= //
@@ -792,12 +798,14 @@ func (mon *SystemMonitor) TraceSyscall() {
 	ContainersLock := *(mon.ContainersLock)
 
 	ReplayChannel := make(chan []byte, SyscallChannelSize)
+	defer close(ReplayChannel)
 
 	go func() {
 		for {
 			dataRaw, valid := <-ReplayChannel
 			if !valid {
-				continue
+				// channel closed exit the goroutine
+				return
 			}
 			dataBuff := bytes.NewBuffer(dataRaw)
 			ctx, err := readContextFromBuff(dataBuff)
@@ -827,6 +835,8 @@ func (mon *SystemMonitor) TraceSyscall() {
 
 					select {
 					case mon.SyscallChannel <- dataRaw:
+						// successfully replayed no need to keep retrying
+						return
 					default:
 						// channel is full, wait for a short time before retrying
 						time.Sleep(1 * time.Second)

--- a/KubeArmor/monitor/systemMonitor_test.go
+++ b/KubeArmor/monitor/systemMonitor_test.go
@@ -4,6 +4,7 @@
 package monitor
 
 import (
+	"fmt"
 	"strings"
 	"sync"
 	"testing"
@@ -14,6 +15,30 @@ import (
 	"github.com/kubearmor/KubeArmor/KubeArmor/feeder"
 	tp "github.com/kubearmor/KubeArmor/KubeArmor/types"
 )
+
+type fakeLink struct {
+	closeErr error
+	closed   bool
+	mu       sync.Mutex
+}
+
+func (f *fakeLink) Close() error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.closed = true
+	return f.closeErr
+}
+
+var loadConfigOnce sync.Once
+
+func mustLoadConfig(t *testing.T) {
+	t.Helper()
+	loadConfigOnce.Do(func() {
+		if err := cfg.LoadConfig(); err != nil {
+			t.Errorf("could not load config: %v", err)
+		}
+	})
+}
 
 func TestSystemMonitor(t *testing.T) {
 	// Set up Test Data
@@ -34,10 +59,7 @@ func TestSystemMonitor(t *testing.T) {
 	node.KernelVersion = strings.TrimSuffix(node.KernelVersion, "\n")
 
 	// load configuration
-	if err := cfg.LoadConfig(); err != nil {
-		t.Log("[FAIL] Failed to load configuration")
-		return
-	}
+	mustLoadConfig(t)
 
 	// configuration
 	cfg.GlobalCfg.Policy = true
@@ -289,4 +311,149 @@ func TestTraceSyscallWithHost(t *testing.T) {
 		return
 	}
 	t.Log("[PASS] Destroyed logger")
+}
+
+func TestDestroySystemMonitor_AllProbesClosedOnError(t *testing.T) {
+	Containers := map[string]tp.Container{}
+	ContainersLock := new(sync.RWMutex)
+	ActiveHostPidMap := map[string]tp.PidMap{}
+	ActivePidMapLock := new(sync.RWMutex)
+	node := tp.Node{}
+	nodeLock := new(sync.RWMutex)
+	node.KernelVersion = strings.TrimSuffix(
+		kl.GetCommandOutputWithoutErr("uname", []string{"-r"}), "\n",
+	)
+
+	mustLoadConfig(t)
+
+	logger := feeder.NewFeeder(&node, &nodeLock)
+	if logger == nil {
+		t.Skip("could not create feeder")
+	}
+	defer logger.DestroyFeeder()
+
+	monitorLock := new(sync.RWMutex)
+	mon := NewSystemMonitor(
+		&node, &nodeLock, logger,
+		&Containers, &ContainersLock,
+		&ActiveHostPidMap, &ActivePidMapLock,
+		&monitorLock,
+	)
+	if mon == nil {
+		t.Skip("could not create SystemMonitor")
+	}
+
+	probeA := &fakeLink{closeErr: fmt.Errorf("probe_a failed")}
+	probeB := &fakeLink{}
+	mon.Probes = map[string]linkCloser{
+		"probe_a": probeA,
+		"probe_b": probeB,
+	}
+
+	mon.ContextChan = make(chan ContextCombined, 1)
+
+	_ = mon.DestroySystemMonitor()
+
+	if !probeA.closed {
+		t.Error("probe_a was not closed")
+	}
+	if !probeB.closed {
+		t.Error("probe_b was not closed: early return leaked this probe")
+	}
+}
+
+func TestDestroySystemMonitor_JoinsProbeErrors(t *testing.T) {
+	Containers := map[string]tp.Container{}
+	ContainersLock := new(sync.RWMutex)
+	ActiveHostPidMap := map[string]tp.PidMap{}
+	ActivePidMapLock := new(sync.RWMutex)
+	node := tp.Node{}
+	nodeLock := new(sync.RWMutex)
+	node.KernelVersion = strings.TrimSuffix(
+		kl.GetCommandOutputWithoutErr("uname", []string{"-r"}), "\n",
+	)
+
+	mustLoadConfig(t)
+
+	logger := feeder.NewFeeder(&node, &nodeLock)
+	if logger == nil {
+		t.Skip("could not create feeder")
+	}
+	defer logger.DestroyFeeder()
+
+	monitorLock := new(sync.RWMutex)
+	mon := NewSystemMonitor(
+		&node, &nodeLock, logger,
+		&Containers, &ContainersLock,
+		&ActiveHostPidMap, &ActivePidMapLock,
+		&monitorLock,
+	)
+	if mon == nil {
+		t.Skip("could not create SystemMonitor")
+	}
+
+	mon.Probes = map[string]linkCloser{
+		"probe_a": &fakeLink{closeErr: fmt.Errorf("probe_a close failed")},
+		"probe_b": &fakeLink{closeErr: fmt.Errorf("probe_b close failed")},
+	}
+	mon.ContextChan = make(chan ContextCombined, 1)
+
+	err := mon.DestroySystemMonitor()
+	if err == nil {
+		t.Fatal("expected joined error, got nil")
+	}
+	if !strings.Contains(err.Error(), "probe_a close failed") {
+		t.Errorf("expected probe_a error in result, got: %s", err.Error())
+	}
+	if !strings.Contains(err.Error(), "probe_b close failed") {
+		t.Errorf("expected probe_b error in result, got: %s", err.Error())
+	}
+}
+
+func TestReplayChannel_GoroutineExitsOnClose(t *testing.T) {
+	done := make(chan struct{})
+
+	ReplayChannel := make(chan []byte, 4)
+
+	go func() {
+		defer close(done)
+		for {
+			_, valid := <-ReplayChannel
+			if !valid {
+				return
+			}
+		}
+	}()
+
+	close(ReplayChannel)
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Error("goroutine did not exit after ReplayChannel was closed: goroutine leak")
+	}
+}
+
+func TestInnerReplayGoroutine_ExitsOnSuccessfulSend(t *testing.T) {
+	SyscallChannel := make(chan []byte, 16)
+	done := make(chan struct{})
+	iterations := 0
+
+	go func() {
+		defer close(done)
+		for range 10 {
+			iterations++
+			select {
+			case SyscallChannel <- []byte("event"):
+				return
+			default:
+			}
+		}
+	}()
+
+	<-done
+
+	if iterations != 1 {
+		t.Errorf("expected goroutine to exit after 1 iteration on success, ran %d", iterations)
+	}
 }

--- a/KubeArmor/monitor/systemMonitor_test.go
+++ b/KubeArmor/monitor/systemMonitor_test.go
@@ -4,6 +4,7 @@
 package monitor
 
 import (
+	"fmt"
 	"strings"
 	"sync"
 	"testing"
@@ -14,6 +15,47 @@ import (
 	"github.com/kubearmor/KubeArmor/KubeArmor/feeder"
 	tp "github.com/kubearmor/KubeArmor/KubeArmor/types"
 )
+
+type fakeLink struct {
+	closeErr error
+	closed   bool
+	mu       sync.Mutex
+}
+
+func (f *fakeLink) Close() error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.closed = true
+	return f.closeErr
+}
+
+func consumeReplay(replay <-chan []byte, syscall chan<- []byte) {
+	for data := range replay {
+		for range 10 {
+			select {
+			case syscall <- data:
+				goto next
+			default:
+			}
+		}
+	next:
+	}
+}
+
+var (
+	loadConfigOnce sync.Once
+	loadConfigErr  error
+)
+
+func mustLoadConfig(t *testing.T) {
+	t.Helper()
+	loadConfigOnce.Do(func() {
+		loadConfigErr = cfg.LoadConfig()
+	})
+	if loadConfigErr != nil {
+		t.Fatalf("could not load config: %v", loadConfigErr)
+	}
+}
 
 func TestSystemMonitor(t *testing.T) {
 	// Set up Test Data
@@ -34,10 +76,7 @@ func TestSystemMonitor(t *testing.T) {
 	node.KernelVersion = strings.TrimSuffix(node.KernelVersion, "\n")
 
 	// load configuration
-	if err := cfg.LoadConfig(); err != nil {
-		t.Log("[FAIL] Failed to load configuration")
-		return
-	}
+	mustLoadConfig(t)
 
 	// configuration
 	cfg.GlobalCfg.Policy = true
@@ -289,4 +328,135 @@ func TestTraceSyscallWithHost(t *testing.T) {
 		return
 	}
 	t.Log("[PASS] Destroyed logger")
+}
+
+func TestDestroySystemMonitor_AllProbesClosedOnError(t *testing.T) {
+	Containers := map[string]tp.Container{}
+	ContainersLock := new(sync.RWMutex)
+	ActiveHostPidMap := map[string]tp.PidMap{}
+	ActivePidMapLock := new(sync.RWMutex)
+	node := tp.Node{}
+	nodeLock := new(sync.RWMutex)
+	node.KernelVersion = strings.TrimSuffix(
+		kl.GetCommandOutputWithoutErr("uname", []string{"-r"}), "\n",
+	)
+
+	mustLoadConfig(t)
+
+	logger := feeder.NewFeeder(&node, &nodeLock)
+	if logger == nil {
+		t.Skip("could not create feeder")
+	}
+	defer logger.DestroyFeeder()
+
+	monitorLock := new(sync.RWMutex)
+	mon := NewSystemMonitor(
+		&node, &nodeLock, logger,
+		&Containers, &ContainersLock,
+		&ActiveHostPidMap, &ActivePidMapLock,
+		&monitorLock,
+	)
+	if mon == nil {
+		t.Skip("could not create SystemMonitor")
+	}
+
+	probeA := &fakeLink{closeErr: fmt.Errorf("probe_a failed")}
+	probeB := &fakeLink{}
+	mon.Probes = map[string]linkCloser{
+		"probe_a": probeA,
+		"probe_b": probeB,
+	}
+
+	mon.ContextChan = make(chan ContextCombined, 1)
+
+	_ = mon.DestroySystemMonitor()
+
+	if !probeA.closed {
+		t.Error("probe_a was not closed")
+	}
+	if !probeB.closed {
+		t.Error("probe_b was not closed: early return leaked this probe")
+	}
+}
+
+func TestDestroySystemMonitor_JoinsProbeErrors(t *testing.T) {
+	Containers := map[string]tp.Container{}
+	ContainersLock := new(sync.RWMutex)
+	ActiveHostPidMap := map[string]tp.PidMap{}
+	ActivePidMapLock := new(sync.RWMutex)
+	node := tp.Node{}
+	nodeLock := new(sync.RWMutex)
+	node.KernelVersion = strings.TrimSuffix(
+		kl.GetCommandOutputWithoutErr("uname", []string{"-r"}), "\n",
+	)
+
+	mustLoadConfig(t)
+
+	logger := feeder.NewFeeder(&node, &nodeLock)
+	if logger == nil {
+		t.Skip("could not create feeder")
+	}
+	defer logger.DestroyFeeder()
+
+	monitorLock := new(sync.RWMutex)
+	mon := NewSystemMonitor(
+		&node, &nodeLock, logger,
+		&Containers, &ContainersLock,
+		&ActiveHostPidMap, &ActivePidMapLock,
+		&monitorLock,
+	)
+	if mon == nil {
+		t.Skip("could not create SystemMonitor")
+	}
+
+	mon.Probes = map[string]linkCloser{
+		"probe_a": &fakeLink{closeErr: fmt.Errorf("probe_a close failed")},
+		"probe_b": &fakeLink{closeErr: fmt.Errorf("probe_b close failed")},
+	}
+	mon.ContextChan = make(chan ContextCombined, 1)
+
+	err := mon.DestroySystemMonitor()
+	if err == nil {
+		t.Fatal("expected joined error, got nil")
+	}
+	if !strings.Contains(err.Error(), "probe_a close failed") {
+		t.Errorf("expected probe_a error in result, got: %s", err.Error())
+	}
+	if !strings.Contains(err.Error(), "probe_b close failed") {
+		t.Errorf("expected probe_b error in result, got: %s", err.Error())
+	}
+}
+
+func TestReplayChannel_GoroutineExitsOnClose(t *testing.T) {
+	replay := make(chan []byte, 4)
+	syscall := make(chan []byte, 16)
+	done := make(chan struct{})
+
+	go func() {
+		defer close(done)
+		consumeReplay(replay, syscall)
+	}()
+
+	close(replay)
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Error("consumeReplay did not exit after replay channel was closed: goroutine leak")
+	}
+}
+
+func TestConsumeReplay_ForwardsDataToSyscallChannel(t *testing.T) {
+	replay := make(chan []byte, 4)
+	syscall := make(chan []byte, 16)
+
+	replay <- []byte("event1")
+	replay <- []byte("event2")
+	close(replay)
+
+	consumeReplay(replay, syscall)
+
+	if len(syscall) != 2 {
+		t.Errorf("expected 2 events forwarded, got %d", len(syscall))
+	}
 }


### PR DESCRIPTION
**Purpose of PR?**:
Fix issues in `SystemMonitor` teardown and goroutine lifecycle to improve reliability and testability

**Does this PR introduce a breaking change?**
No

**If the changes in this PR are manually verified, list down the scenarios covered:**
Fixes two bugs in `SystemMonitor` teardown and goroutine lifecycle:

1. Probe leak on close error -> `DestroySystemMonitor` previously returned early on the first probe close error, leaking all remaining probes. All probes are now closed unconditionally and errors are collected and returned together using `errors.Join`

2. ReplayChannel goroutine leak -> Improved handling of the goroutine consuming `ReplayChannel` in `TraceSyscall` by ensuring proper exit when the channel is closed. This prevents potential goroutine leaks during shutdown.

3. Inner replay goroutine no exit on successful send -> The inner goroutine retrying event replay had no `return` after a successful send to `SyscallChannel`, causing it to keep looping unnecessarily. Added `return` on successful send.

**Additional information for reviewer?** :
- `systemMonitor.go`: Changed `Probes` field from `map[string]link.Link` to `map[string]linkCloser` (local interface) to allow testability since `link.Link` has an unexported method preventing external implementation
- `systemMonitor.go`: Collect all probe close errors, return joined error
- `systemMonitor.go`: Added `defer close(ReplayChannel)` and exit on channel close
- `systemMonitor.go`: Added `return` after successful replay send
- `systemMonitor_test.go`: Added 4 tests covering the above fixes

**Checklist:**
- [x] Bug fix.
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [x] Commit has unit tests
- [ ] Commit has integration tests