### PR TITLE
fix: use correct protobuf type for /tasks/exit in containerd handler

### DIFF
--- a/KubeArmor/core/containerdHandler.go
+++ b/KubeArmor/core/containerdHandler.go
@@ -752,7 +752,7 @@ func (dm *KubeArmorDaemon) handleContainerdEvent(envelope *events.Envelope, cont
 		}
 
 	case "/tasks/exit":
-		exitTask := &apievents.TaskStart{}
+		exitTask := &apievents.TaskExit{}
 
 		err := proto.Unmarshal(envelope.Event.GetValue(), exitTask)
 		if err != nil {


### PR DESCRIPTION
## Summary

Fixes #2526

The `/tasks/exit` case in `handleContainerdEvent` (`KubeArmor/core/containerdHandler.go`) was unmarshaling the event payload into `apievents.TaskStart` instead of `apievents.TaskExit`.

## Root Cause

`TaskStart` and `TaskExit` have different protobuf field numbers:

| Field | TaskStart | TaskExit |
|-------|-----------|----------|
| 1 | ContainerID | ContainerID |
| 2 | Pid | ID (string) |
| 3 | - | Pid |
| 4 | - | ExitStatus |

When a `TaskExit` payload is unmarshaled into `TaskStart`, the `Pid` field (field 3 in TaskExit) has no counterpart in `TaskStart`, so protobuf silently drops it. `GetPid()` always returns `0`.

## Impact

- The guard `if pid == exitTask.GetPid()` always fails
- `UpdateContainerdContainer` with action `destroy` is never called
- Stale entries remain in `dm.Containers` and the eBPF NsMap

## Fix

One-line change: `apievents.TaskStart{}` → `apievents.TaskExit{}`

## Testing

Existing containerd integration tests should be verified. The fix is a straightforward protobuf type correction.