### PR TITLE
fix(operator): guard InitContainers[0] access when init container is disabled

### DIFF
--- a/pkg/KubeArmorOperator/internal/controller/cluster.go
+++ b/pkg/KubeArmorOperator/internal/controller/cluster.go
@@ -600,12 +600,14 @@ func (clusterWatcher *ClusterWatcher) UpdateKubeArmorImages(images []string) err
 						ds.Spec.Template.Spec.Tolerations = append(ds.Spec.Template.Spec.Tolerations, common.KubeArmorInitTolerations...)
 					}
 
-					// update with global env
-					AddOrUpdateEnv(&ds.Spec.Template.Spec.InitContainers[0].Env, common.GlobalEnv)
-					// add/override with kubearmor-init specific env
-					if len(common.KubeArmorInitEnv) > 0 {
-						defer RemoveDeletedEntriesForEnv(&common.KubeArmorInitEnv)
-						AddOrUpdateEnv(&ds.Spec.Template.Spec.InitContainers[0].Env, common.KubeArmorInitEnv)
+					if len(ds.Spec.Template.Spec.InitContainers) != 0 {
+						// update with global env
+						AddOrUpdateEnv(&ds.Spec.Template.Spec.InitContainers[0].Env, common.GlobalEnv)
+						// add/override with kubearmor-init specific env
+						if len(common.KubeArmorInitEnv) > 0 {
+							defer RemoveDeletedEntriesForEnv(&common.KubeArmorInitEnv)
+							AddOrUpdateEnv(&ds.Spec.Template.Spec.InitContainers[0].Env, common.KubeArmorInitEnv)
+						}
 					}
 
 					NRIVolume, NRIVolumeMount := common.GenerateNRIvol(ds.Spec.Selector.MatchLabels["kubearmor.io/nri-socket"])

--- a/pkg/KubeArmorOperator/internal/controller/resources.go
+++ b/pkg/KubeArmorOperator/internal/controller/resources.go
@@ -131,8 +131,10 @@ func generateDaemonset(name, enforcer, runtime, socket, nriSocket, btfPresent, a
 
 	AddOrUpdateEnv(&daemonset.Spec.Template.Spec.Containers[0].Env, common.GlobalEnv)
 	AddOrUpdateEnv(&daemonset.Spec.Template.Spec.Containers[0].Env, common.KubeArmorEnv)
-	AddOrUpdateEnv(&daemonset.Spec.Template.Spec.InitContainers[0].Env, common.GlobalEnv)
-	AddOrUpdateEnv(&daemonset.Spec.Template.Spec.InitContainers[0].Env, common.KubeArmorInitEnv)
+	if len(daemonset.Spec.Template.Spec.InitContainers) != 0 {
+		AddOrUpdateEnv(&daemonset.Spec.Template.Spec.InitContainers[0].Env, common.GlobalEnv)
+		AddOrUpdateEnv(&daemonset.Spec.Template.Spec.InitContainers[0].Env, common.KubeArmorInitEnv)
+	}
 
 	// TODO: handle passing annotateResource flag to kubearmor
 	// ideally this configuration should be part of kubearmoconfig to avoid hardcoding version checks
@@ -196,8 +198,10 @@ func generateDaemonset(name, enforcer, runtime, socket, nriSocket, btfPresent, a
 	}
 	daemonset.Spec.Template.Spec.Containers[0].Args = append(daemonset.Spec.Template.Spec.Containers[0].Args, ociArgs...)
 	daemonset.Spec.Template.Spec.Containers[0].Args = append(daemonset.Spec.Template.Spec.Containers[0].Args, LsmFlagString)
-	daemonset.Spec.Template.Spec.InitContainers[0].Image = common.GetApplicationImage(common.KubeArmorInitName)
-	daemonset.Spec.Template.Spec.InitContainers[0].ImagePullPolicy = corev1.PullPolicy(common.KubeArmorInitImagePullPolicy)
+	if len(daemonset.Spec.Template.Spec.InitContainers) != 0 {
+		daemonset.Spec.Template.Spec.InitContainers[0].Image = common.GetApplicationImage(common.KubeArmorInitName)
+		daemonset.Spec.Template.Spec.InitContainers[0].ImagePullPolicy = corev1.PullPolicy(common.KubeArmorInitImagePullPolicy)
+	}
 
 	daemonset = addOwnership(daemonset).(*appsv1.DaemonSet)
 	fmt.Printf("generated daemonset: %v", daemonset)


### PR DESCRIPTION
Fixes #2536

On BTF-enabled nodes with `initDeploy=false`, the daemonset intentionally clears `InitContainers`, but a few unconditional `InitContainers[0]` updates still execute and can panic. This change adds length guards around all remaining init-container env/image updates in both daemonset generation and image refresh paths.

Greetings, saschabuehrle