### PR TITLE
fix(operator): persist CA certificate in k8s secret during TLS rotation

### DIFF
--- a/deployments/get/objects.go
+++ b/deployments/get/objects.go
@@ -793,7 +793,7 @@ func GetKubeArmorControllerMutationAdmissionConfiguration(namespace string, caCe
 	}
 }
 
-// GetKubeArmorControllerTLSSecret Functionn
+// GetKubeArmorControllerTLSSecret Function
 func GetKubeArmorControllerTLSSecret(namespace string, caCert string, caKey string, tlsCrt string, tlsKey string) *corev1.Secret {
 	data := make(map[string]string)
 	data["ca.crt"] = caCert

--- a/deployments/get/objects.go
+++ b/deployments/get/objects.go
@@ -794,9 +794,10 @@ func GetKubeArmorControllerMutationAdmissionConfiguration(namespace string, caCe
 }
 
 // GetKubeArmorControllerTLSSecret Functionn
-func GetKubeArmorControllerTLSSecret(namespace string, caCert string, tlsCrt string, tlsKey string) *corev1.Secret {
+func GetKubeArmorControllerTLSSecret(namespace string, caCert string, caKey string, tlsCrt string, tlsKey string) *corev1.Secret {
 	data := make(map[string]string)
 	data["ca.crt"] = caCert
+	data["ca.key"] = caKey
 	data["tls.crt"] = tlsCrt
 	data["tls.key"] = tlsKey
 	return &corev1.Secret{

--- a/deployments/get/objects.go
+++ b/deployments/get/objects.go
@@ -796,9 +796,10 @@ func GetKubeArmorControllerMutationAdmissionConfiguration(namespace string, caCe
 }
 
 // GetKubeArmorControllerTLSSecret Functionn
-func GetKubeArmorControllerTLSSecret(namespace string, caCert string, tlsCrt string, tlsKey string) *corev1.Secret {
+func GetKubeArmorControllerTLSSecret(namespace string, caCert string, caKey string, tlsCrt string, tlsKey string) *corev1.Secret {
 	data := make(map[string]string)
 	data["ca.crt"] = caCert
+	data["ca.key"] = caKey
 	data["tls.crt"] = tlsCrt
 	data["tls.key"] = tlsKey
 	return &corev1.Secret{

--- a/deployments/get/objects.go
+++ b/deployments/get/objects.go
@@ -795,7 +795,7 @@ func GetKubeArmorControllerMutationAdmissionConfiguration(namespace string, caCe
 	}
 }
 
-// GetKubeArmorControllerTLSSecret Functionn
+// GetKubeArmorControllerTLSSecret Function
 func GetKubeArmorControllerTLSSecret(namespace string, caCert string, caKey string, tlsCrt string, tlsKey string) *corev1.Secret {
 	data := make(map[string]string)
 	data["ca.crt"] = caCert

--- a/pkg/KubeArmorOperator/common/tls.go
+++ b/pkg/KubeArmorOperator/common/tls.go
@@ -16,49 +16,53 @@ import (
 )
 
 // GeneratePki - generate pub/priv keypair
-func GeneratePki(namespace string, serviceName string) (*bytes.Buffer, *bytes.Buffer, *bytes.Buffer, error) {
+func GeneratePki(namespace string, serviceName string) (*bytes.Buffer, *bytes.Buffer, *bytes.Buffer, *bytes.Buffer, error) {
 	ca, cakey, err := GenerateCA()
 	if err != nil {
-		return bytes.NewBuffer([]byte{}), bytes.NewBuffer([]byte{}), bytes.NewBuffer([]byte{}), err
+		empty := bytes.NewBuffer([]byte{})
+		return empty, empty, empty, empty, err
 	}
 	csr, csrkey, err := GenerateCSR(namespace, serviceName)
 	if err != nil {
-		return bytes.NewBuffer([]byte{}), bytes.NewBuffer([]byte{}), bytes.NewBuffer([]byte{}), err
+		empty := bytes.NewBuffer([]byte{})
+		return empty, empty, empty, empty, err
 	}
 	crt, err := SignCSR(ca, cakey, csr, csrkey)
 	if err != nil {
-		return bytes.NewBuffer([]byte{}), bytes.NewBuffer([]byte{}), bytes.NewBuffer([]byte{}), err
+		empty := bytes.NewBuffer([]byte{})
+		return empty, empty, empty, empty, err
 	}
 
 	caBytes, err := x509.CreateCertificate(rand.Reader, ca, ca, &cakey.PublicKey, cakey)
 	if err != nil {
-		return bytes.NewBuffer([]byte{}), bytes.NewBuffer([]byte{}), bytes.NewBuffer([]byte{}), err
+		empty := bytes.NewBuffer([]byte{})
+		return empty, empty, empty, empty, err
 	}
 	caPEM := new(bytes.Buffer)
-	err = pem.Encode(caPEM, &pem.Block{
-		Type:  "CERTIFICATE",
-		Bytes: caBytes,
-	})
-	if err != nil {
-		return bytes.NewBuffer([]byte{}), bytes.NewBuffer([]byte{}), bytes.NewBuffer([]byte{}), err
+	if err = pem.Encode(caPEM, &pem.Block{Type: "CERTIFICATE", Bytes: caBytes}); err != nil {
+		empty := bytes.NewBuffer([]byte{})
+		return empty, empty, empty, empty, err
 	}
+
+	caKeyPEM := new(bytes.Buffer)
+	if err = pem.Encode(caKeyPEM, &pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(cakey)}); err != nil {
+		empty := bytes.NewBuffer([]byte{})
+		return empty, empty, empty, empty, err
+	}
+
 	crtPEM := new(bytes.Buffer)
-	err = pem.Encode(crtPEM, &pem.Block{
-		Type:  "CERTIFICATE",
-		Bytes: crt,
-	})
-	if err != nil {
-		return bytes.NewBuffer([]byte{}), bytes.NewBuffer([]byte{}), bytes.NewBuffer([]byte{}), err
+	if err = pem.Encode(crtPEM, &pem.Block{Type: "CERTIFICATE", Bytes: crt}); err != nil {
+		empty := bytes.NewBuffer([]byte{})
+		return empty, empty, empty, empty, err
 	}
+
 	crtKeyPEM := new(bytes.Buffer)
-	err = pem.Encode(crtKeyPEM, &pem.Block{
-		Type:  "RSA PRIVATE KEY",
-		Bytes: x509.MarshalPKCS1PrivateKey(csrkey),
-	})
-	if err != nil {
-		return bytes.NewBuffer([]byte{}), bytes.NewBuffer([]byte{}), bytes.NewBuffer([]byte{}), err
+	if err = pem.Encode(crtKeyPEM, &pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(csrkey)}); err != nil {
+		empty := bytes.NewBuffer([]byte{})
+		return empty, empty, empty, empty, err
 	}
-	return caPEM, crtPEM, crtKeyPEM, nil
+
+	return caPEM, caKeyPEM, crtPEM, crtKeyPEM, nil
 }
 
 // GenerateCA - generate private key and a cert for a CA
@@ -121,4 +125,57 @@ func SignCSR(caCrt *x509.Certificate, caKey *rsa.PrivateKey, csrCrt *x509.Certif
 		return []byte{}, errors.New("cannot sign the csr")
 	}
 	return certBytes, nil
+}
+
+// GeneratePkiWithExistingCA generates a new leaf cert signed by an existing CA,
+// rather than generating a fresh CA. This is used during TLS rotation to keep
+// the CA stable so existing clients don't need to re-trust a new CA.
+func GeneratePkiWithExistingCA(namespace string, serviceName string, caCertPEM []byte, caKeyPEM []byte) (*bytes.Buffer, *bytes.Buffer, *bytes.Buffer, error) {
+	// Decode and parse the existing CA cert
+	caBlock, _ := pem.Decode(caCertPEM)
+	if caBlock == nil {
+		return bytes.NewBuffer([]byte{}), bytes.NewBuffer([]byte{}), bytes.NewBuffer([]byte{}), errors.New("failed to decode CA cert PEM")
+	}
+	ca, err := x509.ParseCertificate(caBlock.Bytes)
+	if err != nil {
+		return bytes.NewBuffer([]byte{}), bytes.NewBuffer([]byte{}), bytes.NewBuffer([]byte{}), err
+	}
+
+	// Decode and parse the existing CA private key
+	caKeyBlock, _ := pem.Decode(caKeyPEM)
+	if caKeyBlock == nil {
+		return bytes.NewBuffer([]byte{}), bytes.NewBuffer([]byte{}), bytes.NewBuffer([]byte{}), errors.New("failed to decode CA key PEM")
+	}
+	caKey, err := x509.ParsePKCS1PrivateKey(caKeyBlock.Bytes)
+	if err != nil {
+		return bytes.NewBuffer([]byte{}), bytes.NewBuffer([]byte{}), bytes.NewBuffer([]byte{}), err
+	}
+
+	// Generate a new leaf cert signed by the existing CA
+	csr, csrKey, err := GenerateCSR(namespace, serviceName)
+	if err != nil {
+		return bytes.NewBuffer([]byte{}), bytes.NewBuffer([]byte{}), bytes.NewBuffer([]byte{}), err
+	}
+	crt, err := SignCSR(ca, caKey, csr, csrKey)
+	if err != nil {
+		return bytes.NewBuffer([]byte{}), bytes.NewBuffer([]byte{}), bytes.NewBuffer([]byte{}), err
+	}
+
+	// Re-encode the existing CA cert as PEM (unchanged)
+	caPEM := new(bytes.Buffer)
+	if err := pem.Encode(caPEM, &pem.Block{Type: "CERTIFICATE", Bytes: ca.Raw}); err != nil {
+		return bytes.NewBuffer([]byte{}), bytes.NewBuffer([]byte{}), bytes.NewBuffer([]byte{}), err
+	}
+
+	crtPEM := new(bytes.Buffer)
+	if err := pem.Encode(crtPEM, &pem.Block{Type: "CERTIFICATE", Bytes: crt}); err != nil {
+		return bytes.NewBuffer([]byte{}), bytes.NewBuffer([]byte{}), bytes.NewBuffer([]byte{}), err
+	}
+
+	crtKeyPEM := new(bytes.Buffer)
+	if err := pem.Encode(crtKeyPEM, &pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(csrKey)}); err != nil {
+		return bytes.NewBuffer([]byte{}), bytes.NewBuffer([]byte{}), bytes.NewBuffer([]byte{}), err
+	}
+
+	return caPEM, crtPEM, crtKeyPEM, nil
 }

--- a/pkg/KubeArmorOperator/common/tls.go
+++ b/pkg/KubeArmorOperator/common/tls.go
@@ -19,47 +19,39 @@ import (
 func GeneratePki(namespace string, serviceName string) (*bytes.Buffer, *bytes.Buffer, *bytes.Buffer, *bytes.Buffer, error) {
 	ca, cakey, err := GenerateCA()
 	if err != nil {
-		empty := bytes.NewBuffer([]byte{})
-		return empty, empty, empty, empty, err
+		return bytes.NewBuffer([]byte{}), bytes.NewBuffer([]byte{}), bytes.NewBuffer([]byte{}), bytes.NewBuffer([]byte{}), err
 	}
 	csr, csrkey, err := GenerateCSR(namespace, serviceName)
 	if err != nil {
-		empty := bytes.NewBuffer([]byte{})
-		return empty, empty, empty, empty, err
+		return bytes.NewBuffer([]byte{}), bytes.NewBuffer([]byte{}), bytes.NewBuffer([]byte{}), bytes.NewBuffer([]byte{}), err
 	}
 	crt, err := SignCSR(ca, cakey, csr, csrkey)
 	if err != nil {
-		empty := bytes.NewBuffer([]byte{})
-		return empty, empty, empty, empty, err
+		return bytes.NewBuffer([]byte{}), bytes.NewBuffer([]byte{}), bytes.NewBuffer([]byte{}), bytes.NewBuffer([]byte{}), err
 	}
 
 	caBytes, err := x509.CreateCertificate(rand.Reader, ca, ca, &cakey.PublicKey, cakey)
 	if err != nil {
-		empty := bytes.NewBuffer([]byte{})
-		return empty, empty, empty, empty, err
+		return bytes.NewBuffer([]byte{}), bytes.NewBuffer([]byte{}), bytes.NewBuffer([]byte{}), bytes.NewBuffer([]byte{}), err
 	}
 	caPEM := new(bytes.Buffer)
 	if err = pem.Encode(caPEM, &pem.Block{Type: "CERTIFICATE", Bytes: caBytes}); err != nil {
-		empty := bytes.NewBuffer([]byte{})
-		return empty, empty, empty, empty, err
+		return bytes.NewBuffer([]byte{}), bytes.NewBuffer([]byte{}), bytes.NewBuffer([]byte{}), bytes.NewBuffer([]byte{}), err
 	}
 
 	caKeyPEM := new(bytes.Buffer)
 	if err = pem.Encode(caKeyPEM, &pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(cakey)}); err != nil {
-		empty := bytes.NewBuffer([]byte{})
-		return empty, empty, empty, empty, err
+		return bytes.NewBuffer([]byte{}), bytes.NewBuffer([]byte{}), bytes.NewBuffer([]byte{}), bytes.NewBuffer([]byte{}), err
 	}
 
 	crtPEM := new(bytes.Buffer)
 	if err = pem.Encode(crtPEM, &pem.Block{Type: "CERTIFICATE", Bytes: crt}); err != nil {
-		empty := bytes.NewBuffer([]byte{})
-		return empty, empty, empty, empty, err
+		return bytes.NewBuffer([]byte{}), bytes.NewBuffer([]byte{}), bytes.NewBuffer([]byte{}), bytes.NewBuffer([]byte{}), err
 	}
 
 	crtKeyPEM := new(bytes.Buffer)
 	if err = pem.Encode(crtKeyPEM, &pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(csrkey)}); err != nil {
-		empty := bytes.NewBuffer([]byte{})
-		return empty, empty, empty, empty, err
+		return bytes.NewBuffer([]byte{}), bytes.NewBuffer([]byte{}), bytes.NewBuffer([]byte{}), bytes.NewBuffer([]byte{}), err
 	}
 
 	return caPEM, caKeyPEM, crtPEM, crtKeyPEM, nil
@@ -149,6 +141,15 @@ func GeneratePkiWithExistingCA(namespace string, serviceName string, caCertPEM [
 	caKey, err := x509.ParsePKCS1PrivateKey(caKeyBlock.Bytes)
 	if err != nil {
 		return bytes.NewBuffer([]byte{}), bytes.NewBuffer([]byte{}), bytes.NewBuffer([]byte{}), err
+	}
+
+	// Verify the cert is actually a CA and the key matches the cert's public key
+	if !ca.IsCA {
+		return bytes.NewBuffer([]byte{}), bytes.NewBuffer([]byte{}), bytes.NewBuffer([]byte{}), errors.New("provided certificate is not a CA")
+	}
+	caRSAPub, ok := ca.PublicKey.(*rsa.PublicKey)
+	if !ok || caRSAPub.N.Cmp(caKey.PublicKey.N) != 0 {
+		return bytes.NewBuffer([]byte{}), bytes.NewBuffer([]byte{}), bytes.NewBuffer([]byte{}), errors.New("CA private key does not match CA certificate public key")
 	}
 
 	// Generate a new leaf cert signed by the existing CA

--- a/pkg/KubeArmorOperator/internal/controller/resources.go
+++ b/pkg/KubeArmorOperator/internal/controller/resources.go
@@ -797,7 +797,7 @@ func (clusterWatcher *ClusterWatcher) GetClusterName(providerHostname, providerE
 }
 
 func (clusterWatcher *ClusterWatcher) WatchRequiredResources() {
-	var caCert, tlsCrt, tlsKey *bytes.Buffer
+	var caCert, caKey, tlsCrt, tlsKey *bytes.Buffer
 	var kGenErr, err, installErr error
 	RotateTls := false
 	srvAccs := []*corev1.ServiceAccount{
@@ -1055,7 +1055,7 @@ func (clusterWatcher *ClusterWatcher) WatchRequiredResources() {
 	configmap.Data["cluster"] = clusterWatcher.GetClusterName(ProviderHostname, ProviderEndpoint)
 
 	for {
-		caCert, tlsCrt, tlsKey, kGenErr = common.GeneratePki(common.Namespace, deployments.KubeArmorControllerWebhookServiceName)
+		caCert, caKey, tlsCrt, tlsKey, kGenErr = common.GeneratePki(common.Namespace, deployments.KubeArmorControllerWebhookServiceName)
 		if kGenErr == nil {
 			break
 		}
@@ -1072,7 +1072,7 @@ func (clusterWatcher *ClusterWatcher) WatchRequiredResources() {
 		}
 	}
 
-	secret := deployments.GetKubeArmorControllerTLSSecret(common.Namespace, caCert.String(), tlsCrt.String(), tlsKey.String())
+	secret := deployments.GetKubeArmorControllerTLSSecret(common.Namespace, caCert.String(), caKey.String(), tlsCrt.String(), tlsKey.String())
 	secret = addOwnership(secret).(*corev1.Secret)
 	mutationhook := deployments.GetKubeArmorControllerMutationAdmissionConfiguration(common.Namespace, caCert.Bytes())
 	mutationhook = addOwnership(mutationhook).(*v1.MutatingWebhookConfiguration)
@@ -1254,50 +1254,90 @@ func (clusterWatcher *ClusterWatcher) WatchRequiredResources() {
 }
 
 func (clusterWatcher *ClusterWatcher) RotateTlsCerts() {
-	var caCert, tlsCrt, tlsKey *bytes.Buffer
+	var caPEM, caKeyPEM, tlsCrt, tlsKey *bytes.Buffer
 	var err error
 
-	origdeploy, err := clusterWatcher.Client.AppsV1().Deployments(common.Namespace).Get(context.Background(), deployments.KubeArmorControllerDeploymentName, metav1.GetOptions{})
+	origdeploy, err := clusterWatcher.Client.AppsV1().Deployments(common.Namespace).Get(
+		context.Background(), deployments.KubeArmorControllerDeploymentName, metav1.GetOptions{})
 	if err != nil {
 		clusterWatcher.Log.Warnf("cannot get controller deployment, error=%s", err.Error())
 	}
-
-	caCert, tlsCrt, tlsKey, _ = common.GeneratePki(common.Namespace, deployments.KubeArmorControllerWebhookServiceName)
 	replicas := origdeploy.Spec.Replicas
 
-	// TODO: Keep CA certificate in k8s secret
+	// Try to reuse the existing CA from the k8s secret so clients don't need
+	// to re-trust a new CA on every rotation.
+	existingSecret, secretErr := clusterWatcher.Client.CoreV1().Secrets(common.Namespace).Get(
+		context.Background(), deployments.KubeArmorControllerSecretName, metav1.GetOptions{})
+
+	if secretErr == nil &&
+		len(existingSecret.Data["ca.crt"]) > 0 &&
+		len(existingSecret.Data["ca.key"]) > 0 {
+
+		clusterWatcher.Log.Info("Reusing existing CA from secret for TLS rotation")
+		caPEM, tlsCrt, tlsKey, err = common.GeneratePkiWithExistingCA(
+			common.Namespace,
+			deployments.KubeArmorControllerWebhookServiceName,
+			existingSecret.Data["ca.crt"],
+			existingSecret.Data["ca.key"],
+		)
+		// caKeyPEM stays as the existing key - re-encode it for storing back
+		caKeyPEM = bytes.NewBuffer(existingSecret.Data["ca.key"])
+	} else {
+		// No existing CA found - generate a fresh one (first run or secret missing)
+		clusterWatcher.Log.Info("Generating new CA for TLS rotation")
+		caPEM, caKeyPEM, tlsCrt, tlsKey, err = common.GeneratePki(
+			common.Namespace,
+			deployments.KubeArmorControllerWebhookServiceName,
+		)
+	}
+
+	if err != nil {
+		clusterWatcher.Log.Warnf("cannot generate PKI for TLS rotation, error=%s", err.Error())
+		return
+	}
 
 	// == CLEANUP ==
-	// scale down controller deployment to 0
 	controllerDeployment := deployments.GetKubeArmorControllerDeployment(common.Namespace)
 	controllerDeployment = addOwnership(controllerDeployment).(*appsv1.Deployment)
 	zeroReplicas := int32(0)
 	controllerDeployment.Spec.Replicas = &zeroReplicas
-	if _, err := clusterWatcher.Client.AppsV1().Deployments(common.Namespace).Update(context.Background(), controllerDeployment, metav1.UpdateOptions{}); err != nil {
+	if _, err := clusterWatcher.Client.AppsV1().Deployments(common.Namespace).Update(
+		context.Background(), controllerDeployment, metav1.UpdateOptions{}); err != nil {
 		clusterWatcher.Log.Warnf("cannot scale down controller %s, error=%s", controllerDeployment.Name, err.Error())
 	}
-	// delete mutation webhook configuration
-	mutationWebhook := deployments.GetKubeArmorControllerMutationAdmissionConfiguration(common.Namespace, caCert.Bytes())
+
+	mutationWebhook := deployments.GetKubeArmorControllerMutationAdmissionConfiguration(common.Namespace, caPEM.Bytes())
 	mutationWebhook = addOwnership(mutationWebhook).(*v1.MutatingWebhookConfiguration)
-	if err := clusterWatcher.Client.AdmissionregistrationV1().MutatingWebhookConfigurations().Delete(context.Background(), mutationWebhook.Name, metav1.DeleteOptions{}); err != nil {
+	if err := clusterWatcher.Client.AdmissionregistrationV1().MutatingWebhookConfigurations().Delete(
+		context.Background(), mutationWebhook.Name, metav1.DeleteOptions{}); err != nil {
 		clusterWatcher.Log.Warnf("cannot delete mutation webhook %s, error=%s", mutationWebhook.Name, err.Error())
 	}
+
 	// == ROTATE ==
-	// update controller tls secret
-	controllerSecret := deployments.GetKubeArmorControllerTLSSecret(common.Namespace, caCert.String(), tlsCrt.String(), tlsKey.String())
+	controllerSecret := deployments.GetKubeArmorControllerTLSSecret(
+		common.Namespace,
+		caPEM.String(),
+		caKeyPEM.String(),
+		tlsCrt.String(),
+		tlsKey.String(),
+	)
 	controllerSecret = addOwnership(controllerSecret).(*corev1.Secret)
-	if _, err := clusterWatcher.Client.CoreV1().Secrets(common.Namespace).Update(context.Background(), controllerSecret, metav1.UpdateOptions{}); err != nil {
+	if _, err := clusterWatcher.Client.CoreV1().Secrets(common.Namespace).Update(
+		context.Background(), controllerSecret, metav1.UpdateOptions{}); err != nil {
 		clusterWatcher.Log.Warnf("cannot update controller tls secret %s, error=%s", controllerSecret.Name, err.Error())
 	}
+
 	// == ROLLOUT ==
-	// create mutation webhook configuration
-	if _, err := clusterWatcher.Client.AdmissionregistrationV1().MutatingWebhookConfigurations().Create(context.Background(), mutationWebhook, metav1.CreateOptions{}); err != nil {
+	if _, err := clusterWatcher.Client.AdmissionregistrationV1().MutatingWebhookConfigurations().Create(
+		context.Background(), mutationWebhook, metav1.CreateOptions{}); err != nil {
 		clusterWatcher.Log.Warnf("Cannot create mutation webhook %s, error=%s", mutationWebhook.Name, err.Error())
 	}
-	// scale up controller deployment to previous settings
+
 	controllerDeployment.Spec.Replicas = replicas
-	if _, err := clusterWatcher.Client.AppsV1().Deployments(common.Namespace).Update(context.Background(), controllerDeployment, metav1.UpdateOptions{}); err != nil {
-		clusterWatcher.Log.Warnf("cannot scale down controller %s, error=%s", controllerDeployment.Name, err.Error())
+	if _, err := clusterWatcher.Client.AppsV1().Deployments(common.Namespace).Update(
+		context.Background(), controllerDeployment, metav1.UpdateOptions{}); err != nil {
+		clusterWatcher.Log.Warnf("cannot scale up controller %s, error=%s", controllerDeployment.Name, err.Error())
 	}
+
 	clusterWatcher.Log.Info("Tls rotation completed")
 }

--- a/pkg/KubeArmorOperator/internal/controller/resources.go
+++ b/pkg/KubeArmorOperator/internal/controller/resources.go
@@ -1261,6 +1261,7 @@ func (clusterWatcher *ClusterWatcher) RotateTlsCerts() {
 		context.Background(), deployments.KubeArmorControllerDeploymentName, metav1.GetOptions{})
 	if err != nil {
 		clusterWatcher.Log.Warnf("cannot get controller deployment, error=%s", err.Error())
+		return
 	}
 	replicas := origdeploy.Spec.Replicas
 

--- a/pkg/KubeArmorOperator/internal/controller/resources.go
+++ b/pkg/KubeArmorOperator/internal/controller/resources.go
@@ -1264,6 +1264,7 @@ func (clusterWatcher *ClusterWatcher) RotateTlsCerts() {
 		context.Background(), deployments.KubeArmorControllerDeploymentName, metav1.GetOptions{})
 	if err != nil {
 		clusterWatcher.Log.Warnf("cannot get controller deployment, error=%s", err.Error())
+		return
 	}
 	replicas := origdeploy.Spec.Replicas
 

--- a/pkg/KubeArmorOperator/internal/controller/resources.go
+++ b/pkg/KubeArmorOperator/internal/controller/resources.go
@@ -800,7 +800,7 @@ func (clusterWatcher *ClusterWatcher) GetClusterName(providerHostname, providerE
 }
 
 func (clusterWatcher *ClusterWatcher) WatchRequiredResources() {
-	var caCert, tlsCrt, tlsKey *bytes.Buffer
+	var caCert, caKey, tlsCrt, tlsKey *bytes.Buffer
 	var kGenErr, err, installErr error
 	RotateTls := false
 	srvAccs := []*corev1.ServiceAccount{
@@ -1058,7 +1058,7 @@ func (clusterWatcher *ClusterWatcher) WatchRequiredResources() {
 	configmap.Data["cluster"] = clusterWatcher.GetClusterName(ProviderHostname, ProviderEndpoint)
 
 	for {
-		caCert, tlsCrt, tlsKey, kGenErr = common.GeneratePki(common.Namespace, deployments.KubeArmorControllerWebhookServiceName)
+		caCert, caKey, tlsCrt, tlsKey, kGenErr = common.GeneratePki(common.Namespace, deployments.KubeArmorControllerWebhookServiceName)
 		if kGenErr == nil {
 			break
 		}
@@ -1075,7 +1075,7 @@ func (clusterWatcher *ClusterWatcher) WatchRequiredResources() {
 		}
 	}
 
-	secret := deployments.GetKubeArmorControllerTLSSecret(common.Namespace, caCert.String(), tlsCrt.String(), tlsKey.String())
+	secret := deployments.GetKubeArmorControllerTLSSecret(common.Namespace, caCert.String(), caKey.String(), tlsCrt.String(), tlsKey.String())
 	secret = addOwnership(secret).(*corev1.Secret)
 	mutationhook := deployments.GetKubeArmorControllerMutationAdmissionConfiguration(common.Namespace, caCert.Bytes())
 	mutationhook = addOwnership(mutationhook).(*v1.MutatingWebhookConfiguration)
@@ -1257,50 +1257,90 @@ func (clusterWatcher *ClusterWatcher) WatchRequiredResources() {
 }
 
 func (clusterWatcher *ClusterWatcher) RotateTlsCerts() {
-	var caCert, tlsCrt, tlsKey *bytes.Buffer
+	var caPEM, caKeyPEM, tlsCrt, tlsKey *bytes.Buffer
 	var err error
 
-	origdeploy, err := clusterWatcher.Client.AppsV1().Deployments(common.Namespace).Get(context.Background(), deployments.KubeArmorControllerDeploymentName, metav1.GetOptions{})
+	origdeploy, err := clusterWatcher.Client.AppsV1().Deployments(common.Namespace).Get(
+		context.Background(), deployments.KubeArmorControllerDeploymentName, metav1.GetOptions{})
 	if err != nil {
 		clusterWatcher.Log.Warnf("cannot get controller deployment, error=%s", err.Error())
 	}
-
-	caCert, tlsCrt, tlsKey, _ = common.GeneratePki(common.Namespace, deployments.KubeArmorControllerWebhookServiceName)
 	replicas := origdeploy.Spec.Replicas
 
-	// TODO: Keep CA certificate in k8s secret
+	// Try to reuse the existing CA from the k8s secret so clients don't need
+	// to re-trust a new CA on every rotation.
+	existingSecret, secretErr := clusterWatcher.Client.CoreV1().Secrets(common.Namespace).Get(
+		context.Background(), deployments.KubeArmorControllerSecretName, metav1.GetOptions{})
+
+	if secretErr == nil &&
+		len(existingSecret.Data["ca.crt"]) > 0 &&
+		len(existingSecret.Data["ca.key"]) > 0 {
+
+		clusterWatcher.Log.Info("Reusing existing CA from secret for TLS rotation")
+		caPEM, tlsCrt, tlsKey, err = common.GeneratePkiWithExistingCA(
+			common.Namespace,
+			deployments.KubeArmorControllerWebhookServiceName,
+			existingSecret.Data["ca.crt"],
+			existingSecret.Data["ca.key"],
+		)
+		// caKeyPEM stays as the existing key - re-encode it for storing back
+		caKeyPEM = bytes.NewBuffer(existingSecret.Data["ca.key"])
+	} else {
+		// No existing CA found - generate a fresh one (first run or secret missing)
+		clusterWatcher.Log.Info("Generating new CA for TLS rotation")
+		caPEM, caKeyPEM, tlsCrt, tlsKey, err = common.GeneratePki(
+			common.Namespace,
+			deployments.KubeArmorControllerWebhookServiceName,
+		)
+	}
+
+	if err != nil {
+		clusterWatcher.Log.Warnf("cannot generate PKI for TLS rotation, error=%s", err.Error())
+		return
+	}
 
 	// == CLEANUP ==
-	// scale down controller deployment to 0
 	controllerDeployment := deployments.GetKubeArmorControllerDeployment(common.Namespace)
 	controllerDeployment = addOwnership(controllerDeployment).(*appsv1.Deployment)
 	zeroReplicas := int32(0)
 	controllerDeployment.Spec.Replicas = &zeroReplicas
-	if _, err := clusterWatcher.Client.AppsV1().Deployments(common.Namespace).Update(context.Background(), controllerDeployment, metav1.UpdateOptions{}); err != nil {
+	if _, err := clusterWatcher.Client.AppsV1().Deployments(common.Namespace).Update(
+		context.Background(), controllerDeployment, metav1.UpdateOptions{}); err != nil {
 		clusterWatcher.Log.Warnf("cannot scale down controller %s, error=%s", controllerDeployment.Name, err.Error())
 	}
-	// delete mutation webhook configuration
-	mutationWebhook := deployments.GetKubeArmorControllerMutationAdmissionConfiguration(common.Namespace, caCert.Bytes())
+
+	mutationWebhook := deployments.GetKubeArmorControllerMutationAdmissionConfiguration(common.Namespace, caPEM.Bytes())
 	mutationWebhook = addOwnership(mutationWebhook).(*v1.MutatingWebhookConfiguration)
-	if err := clusterWatcher.Client.AdmissionregistrationV1().MutatingWebhookConfigurations().Delete(context.Background(), mutationWebhook.Name, metav1.DeleteOptions{}); err != nil {
+	if err := clusterWatcher.Client.AdmissionregistrationV1().MutatingWebhookConfigurations().Delete(
+		context.Background(), mutationWebhook.Name, metav1.DeleteOptions{}); err != nil {
 		clusterWatcher.Log.Warnf("cannot delete mutation webhook %s, error=%s", mutationWebhook.Name, err.Error())
 	}
+
 	// == ROTATE ==
-	// update controller tls secret
-	controllerSecret := deployments.GetKubeArmorControllerTLSSecret(common.Namespace, caCert.String(), tlsCrt.String(), tlsKey.String())
+	controllerSecret := deployments.GetKubeArmorControllerTLSSecret(
+		common.Namespace,
+		caPEM.String(),
+		caKeyPEM.String(),
+		tlsCrt.String(),
+		tlsKey.String(),
+	)
 	controllerSecret = addOwnership(controllerSecret).(*corev1.Secret)
-	if _, err := clusterWatcher.Client.CoreV1().Secrets(common.Namespace).Update(context.Background(), controllerSecret, metav1.UpdateOptions{}); err != nil {
+	if _, err := clusterWatcher.Client.CoreV1().Secrets(common.Namespace).Update(
+		context.Background(), controllerSecret, metav1.UpdateOptions{}); err != nil {
 		clusterWatcher.Log.Warnf("cannot update controller tls secret %s, error=%s", controllerSecret.Name, err.Error())
 	}
+
 	// == ROLLOUT ==
-	// create mutation webhook configuration
-	if _, err := clusterWatcher.Client.AdmissionregistrationV1().MutatingWebhookConfigurations().Create(context.Background(), mutationWebhook, metav1.CreateOptions{}); err != nil {
+	if _, err := clusterWatcher.Client.AdmissionregistrationV1().MutatingWebhookConfigurations().Create(
+		context.Background(), mutationWebhook, metav1.CreateOptions{}); err != nil {
 		clusterWatcher.Log.Warnf("Cannot create mutation webhook %s, error=%s", mutationWebhook.Name, err.Error())
 	}
-	// scale up controller deployment to previous settings
+
 	controllerDeployment.Spec.Replicas = replicas
-	if _, err := clusterWatcher.Client.AppsV1().Deployments(common.Namespace).Update(context.Background(), controllerDeployment, metav1.UpdateOptions{}); err != nil {
-		clusterWatcher.Log.Warnf("cannot scale down controller %s, error=%s", controllerDeployment.Name, err.Error())
+	if _, err := clusterWatcher.Client.AppsV1().Deployments(common.Namespace).Update(
+		context.Background(), controllerDeployment, metav1.UpdateOptions{}); err != nil {
+		clusterWatcher.Log.Warnf("cannot scale up controller %s, error=%s", controllerDeployment.Name, err.Error())
 	}
+
 	clusterWatcher.Log.Info("Tls rotation completed")
 }


### PR DESCRIPTION
**Purpose of PR?**:
Fixes the TODO in `RotateTlsCerts()` to persist the CA certificate in the k8s secret during TLS rotation.

Previously, `RotateTlsCerts()` called `common.GeneratePki()` on every rotation which generated a brand new CA each time. This meant any component that had already trusted the old CA would reject the new leaf cert, silently breaking trust on every rotation cycle.

This PR:
- Adds `ca.key` storage to the controller TLS secret alongside the existing `ca.crt`
- Adds `GeneratePkiWithExistingCA()` in `tls.go` which reuses an existing CA to sign a fresh leaf cert
- Updates `RotateTlsCerts()` to read the existing CA from the secret and reuse it, only falling back to generating a fresh CA if none is found

**Does this PR introduce a breaking change?**
No. The secret gains one additional field (`ca.key`). Existing deployments will generate a fresh CA on the first rotation after this change and persist it from that point forward.

**If the changes in this PR are manually verified, list down the scenarios covered:**
- Fresh install with no existing secret: falls back to `GeneratePki()`, generates new CA, stores `ca.crt` and `ca.key` in secret
- TLS rotation with existing secret containing `ca.crt` and `ca.key`: reuses existing CA, only regenerates leaf cert
- TLS rotation with existing secret missing `ca.key` (pre-fix secret): falls back to `GeneratePki()` gracefully

**Additional information for reviewer?**:
This resolves the `// TODO: Keep CA certificate in k8s secret` comment in `RotateTlsCerts()` in `pkg/KubeArmorOperator/internal/controller/resources.go`. No issue was filed for this TODO - it was identified directly in the code.

**Checklist:**
- [x] Bug fix. Fixes #
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] PR Title follows the convention of `<type>(<scope>): <subject>`
- [ ] Commit has unit tests
- [ ] Commit has integration tests