### PR TITLE
fix(bpflsm): prevent panic on nil map dereference in UpdateContainerR…

### DIFF
--- a/KubeArmor/enforcer/bpflsm/rulesHandling.go
+++ b/KubeArmor/enforcer/bpflsm/rulesHandling.go
@@ -383,6 +383,11 @@ func (be *BPFEnforcer) UpdateContainerRules(id string, securityPolicies []tp.Sec
 		return
 	}
 
+	if be.ContainerMap[id].Map == nil {
+		be.Logger.Errf("Inner map for container %s is nil, aborting rule update", id)
+		return
+	}
+
 	// Check for differences in Fresh Rules Set and Existing Ruleset
 	be.resolveConflictsProcessRules(newrules.ProcessRuleList, be.ContainerMap[id].Rules.ProcessRuleList, be.ContainerMap[id].Map, id, be.ContainerMap[id].Rules.ArgumentsList)
 	be.resolveConflicts(newrules.FileWhiteListPosture, be.ContainerMap[id].Rules.FileWhiteListPosture, newrules.FileRuleList, be.ContainerMap[id].Rules.FileRuleList, be.ContainerMap[id].Map)

--- a/KubeArmor/enforcer/bpflsm/rulesHandling_test.go
+++ b/KubeArmor/enforcer/bpflsm/rulesHandling_test.go
@@ -1,0 +1,72 @@
+package bpflsm
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/kubearmor/KubeArmor/KubeArmor/feeder"
+	tp "github.com/kubearmor/KubeArmor/KubeArmor/types"
+)
+
+func TestUpdateContainerRulesNilMap(t *testing.T) {
+	// Initialize a dummy Feeder logger
+	node := tp.Node{}
+	nodeLock := new(sync.RWMutex)
+	logger := feeder.NewFeeder(&node, &nodeLock)
+
+	// Initialize the enforcer with only the necessary fields
+	be := &BPFEnforcer{
+		Logger:           logger,
+		ContainerMap:     make(map[string]ContainerKV),
+		ContainerMapLock: new(sync.RWMutex),
+	}
+
+	containerID := "test-container-id"
+	
+	// Add container to the map but purposefully do NOT initialize its InnerMap
+	// This simulates a scenario where CreateContainerInnerMap fails due to eBPF limits
+	var rules RuleList
+	rules.Init()
+	be.ContainerMap[containerID] = ContainerKV{
+		Key:   NsKey{PidNS: 1234, MntNS: 5678},
+		Map:   nil, // explicitly nil map
+		Rules: rules,
+	}
+
+	// Create a dummy policy that triggers map creation/updates
+	policies := []tp.SecurityPolicy{
+		{
+			Spec: tp.SecuritySpec{
+				Process: tp.ProcessType{
+					MatchPaths: []tp.ProcessPathType{
+						{
+							Path:   "/bin/bash",
+							Action: "Block",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	defaultPosture := tp.DefaultPosture{
+		FileAction:         "Audit",
+		NetworkAction:      "Audit",
+		CapabilitiesAction: "Audit",
+	}
+
+	// Run UpdateContainerRules and catch any panics
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("UpdateContainerRules panicked when inner map was nil: %v", r)
+		}
+	}()
+
+	// This function call should safely abort without a panic due to the nil map check
+	be.UpdateContainerRules(containerID, policies, defaultPosture)
+
+	// Verify that the map is still nil and the enforcer didn't crash
+	if be.ContainerMap[containerID].Map != nil {
+		t.Errorf("Expected ContainerMap.Map to remain nil")
+	}
+}


### PR DESCRIPTION
**Purpose of PR?**:
Fix a critical nil pointer dereference in `UpdateContainerRules` that could crash the KubeArmor daemon when eBPF map creation fails due to resource limits.

Fixes #2540 

**Does this PR introduce a breaking change?**
No

**If the changes in this PR are manually verified, list down the scenarios covered:**:
- eBPF inner map creation failure due to memory limits (e.g., RLIMIT_MEMLOCK)
- Ensured no panic occurs when map is nil
- Verified daemon continues running without entering CrashLoopBackOff
- Confirmed other containers remain unaffected and enforcement continues
- Validated safe early exit during policy reconciliation

**Additional information for reviewer?** :
- Adds a defensive nil check before performing map operations
- Includes unit test `TestUpdateContainerRulesNilMap` to prevent regression
- Improves system resilience under resource exhaustion scenarios

**Checklist:**
- [x] Bug fix. Fixes #<issue number>
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [x] Commit has unit tests
- [ ] Commit has integration tests