### PR TITLE
feat: Allow system monitor to be disabled for BPFLSM-only mode

### DIFF
--- a/KubeArmor/config/config.go
+++ b/KubeArmor/config/config.go
@@ -79,6 +79,8 @@ type KubearmorConfig struct {
 	MatchArgs bool // enable argument rules for policy
 
 	NetworkPolicyEnforcer bool // enable network policy enforcement
+
+	EnableMonitor bool // Enable/Disable eBPF system monitor
 }
 
 // GlobalCfg Global configuration for Kubearmor
@@ -136,6 +138,7 @@ const (
 	ConfigUSBDeviceHandler               string = "enableUSBDeviceHandler"
 	ConfigArgMatching                    string = "matchArgs"
 	ConfigNetworkPolicyEnforcer          string = "enableNetworkPolicyEnforcer"
+	ConfigEnableMonitor                  string = "enableMonitor"
 )
 
 func readCmdLineParams() {
@@ -210,6 +213,8 @@ func readCmdLineParams() {
 	matchArgs := flag.Bool(ConfigArgMatching, true, "enabling Argument matching")
 
 	networkPolicyEnforcer := flag.Bool(ConfigNetworkPolicyEnforcer, true, "Enable network policy enforcement")
+
+	enableMonitor := flag.Bool(ConfigEnableMonitor, true, "Enable/Disable eBPF system monitor")
 
 	flags := []string{}
 	flag.VisitAll(func(f *flag.Flag) {
@@ -292,6 +297,8 @@ func readCmdLineParams() {
 	viper.SetDefault(ConfigArgMatching, *matchArgs)
 
 	viper.SetDefault(ConfigNetworkPolicyEnforcer, *networkPolicyEnforcer)
+
+	viper.SetDefault(ConfigEnableMonitor, *enableMonitor)
 }
 
 // LoadConfig Load configuration
@@ -387,6 +394,8 @@ func LoadConfig() error {
 	GlobalCfg.SELinuxProfileDir = viper.GetString(ConfigSELinuxProfileDir)
 
 	GlobalCfg.NetworkPolicyEnforcer = viper.GetBool(ConfigNetworkPolicyEnforcer)
+
+	GlobalCfg.EnableMonitor = viper.GetBool(ConfigEnableMonitor)
 
 	LoadDynamicConfig()
 

--- a/KubeArmor/core/kubeArmor.go
+++ b/KubeArmor/core/kubeArmor.go
@@ -301,6 +301,11 @@ func (dm *KubeArmorDaemon) CloseLogger() error {
 
 // InitSystemMonitor Function
 func (dm *KubeArmorDaemon) InitSystemMonitor() error {
+	if !cfg.GlobalCfg.EnableMonitor {
+		dm.Logger.Print("System monitor disabled (enableMonitor=false) — syscall tracing will not run; BPFLSM enforcer alerts only")
+		return nil
+	}
+
 	dm.SystemMonitor = mon.NewSystemMonitor(&dm.Node, &dm.NodeLock, dm.Logger, &dm.Containers, &dm.ContainersLock, &dm.ActiveHostPidMap, &dm.ActivePidMapLock, &dm.MonitorLock)
 	if dm.SystemMonitor == nil {
 		return fmt.Errorf("failed to create new system monitor")
@@ -317,6 +322,10 @@ func (dm *KubeArmorDaemon) InitSystemMonitor() error {
 func (dm *KubeArmorDaemon) MonitorSystemEvents() {
 	dm.WgDaemon.Add(1)
 	defer dm.WgDaemon.Done()
+
+	if dm.SystemMonitor == nil {
+		return
+	}
 
 	if cfg.GlobalCfg.Policy || cfg.GlobalCfg.HostPolicy {
 		go dm.SystemMonitor.TraceSyscall()
@@ -693,7 +702,14 @@ func KubeArmor() {
 		if cfg.GlobalCfg.LsmOrder[0] == "" || cfg.GlobalCfg.LsmOrder[0] == "none" {
 			dm.Logger.Printf("Disabled KubeArmor Enforcer: No LSM specified")
 		} else {
-			if err := dm.InitRuntimeEnforcer(dm.SystemMonitor.PinPath); err != nil {
+			pinPath := ""
+			if dm.SystemMonitor != nil {
+				pinPath = dm.SystemMonitor.PinPath
+			} else {
+				pinPath = kl.GetMapRoot()
+			}
+
+			if err := dm.InitRuntimeEnforcer(pinPath); err != nil {
 				dm.Logger.Printf("Disabled KubeArmor Enforcer: %s", err.Error())
 			} else {
 				dm.Logger.Print("Initialized KubeArmor Enforcer")
@@ -709,10 +725,14 @@ func KubeArmor() {
 		}
 
 		// initialize presets
-		if err := dm.InitPresets(dm.Logger, dm.SystemMonitor); err != nil {
-			dm.Logger.Printf("Disabled Presets: %s", err.Error())
+		if dm.SystemMonitor != nil {
+			if err := dm.InitPresets(dm.Logger, dm.SystemMonitor); err != nil {
+				dm.Logger.Printf("Disabled Presets: %s", err.Error())
+			} else {
+				dm.Logger.Print("Initialized Presets")
+			}
 		} else {
-			dm.Logger.Print("Initialized Presets")
+			dm.Logger.Print("Skipped Presets initialization as system monitor is disabled")
 		}
 	}
 

--- a/KubeArmor/core/kubeUpdate.go
+++ b/KubeArmor/core/kubeUpdate.go
@@ -583,6 +583,9 @@ func (dm *KubeArmorDaemon) UpdateEndPointWithPod(action string, pod tp.K8sPod) {
 
 // HandleUnknownNamespaceNsMap Function
 func (dm *KubeArmorDaemon) HandleUnknownNamespaceNsMap(container *tp.Container) {
+	if dm.SystemMonitor == nil {
+		return
+	}
 	dm.SystemMonitor.AddContainerIDToNsMap(container.ContainerID, container.NamespaceName, container.PidNS, container.MntNS)
 	dm.SystemMonitor.NsMapLock.Lock()
 	if val, ok := dm.SystemMonitor.NamespacePidsMap["Unknown"]; ok {
@@ -680,9 +683,11 @@ func (dm *KubeArmorDaemon) handlePodEvent(event string, obj *corev1.Pod) {
 	for k, v := range pod.Labels {
 		labels = append(labels, k+"="+v)
 	}
-	dm.SystemMonitor.PodLabelsMapLock.Lock()
-	dm.SystemMonitor.PodLabelsMap[pod.Metadata["podName"]] = strings.Join(labels, ",")
-	dm.SystemMonitor.PodLabelsMapLock.Unlock()
+	if dm.SystemMonitor != nil {
+		dm.SystemMonitor.PodLabelsMapLock.Lock()
+		dm.SystemMonitor.PodLabelsMap[pod.Metadata["podName"]] = strings.Join(labels, ",")
+		dm.SystemMonitor.PodLabelsMapLock.Unlock()
+	}
 
 	pod.Containers = map[string]string{}
 	pod.ContainerImages = map[string]string{}
@@ -952,7 +957,9 @@ func (dm *KubeArmorDaemon) handlePodEvent(event string, obj *corev1.Pod) {
 			if k8spod.Metadata["namespaceName"] == pod.Metadata["namespaceName"] && k8spod.Metadata["podName"] == pod.Metadata["podName"] {
 				dm.K8sPods = append(dm.K8sPods[:idx], dm.K8sPods[idx+1:]...)
 				delete(dm.OwnerInfo, pod.Metadata["podName"])
-				delete(dm.SystemMonitor.PodLabelsMap, pod.Metadata["podName"])
+				if dm.SystemMonitor != nil {
+					delete(dm.SystemMonitor.PodLabelsMap, pod.Metadata["podName"])
+				}
 				break
 			}
 		}
@@ -3007,6 +3014,9 @@ func (dm *KubeArmorDaemon) validateVisibility(scope string, visibility string) b
 
 // UpdateVisibility Function
 func (dm *KubeArmorDaemon) UpdateVisibility(action string, namespace string, visibility tp.Visibility) {
+	if dm.SystemMonitor == nil {
+		return
+	}
 	dm.SystemMonitor.BpfMapLock.Lock()
 	defer dm.SystemMonitor.BpfMapLock.Unlock()
 

--- a/KubeArmor/core/unorchestratedUpdates.go
+++ b/KubeArmor/core/unorchestratedUpdates.go
@@ -84,13 +84,17 @@ func (dm *KubeArmorDaemon) WatchConfigChanges() {
 		}
 
 		// Update throttling configs
-		dm.SystemMonitor.UpdateThrottlingConfig()
+		if dm.SystemMonitor != nil {
+			dm.SystemMonitor.UpdateThrottlingConfig()
+		}
 
 		// Update USB Device Handler
 		dm.UpdateUSBDeviceHandler(cfg.GlobalCfg.USBDeviceHandler)
 
 		// Update the default posture and visibility for the unorchestrated containers
-		dm.SystemMonitor.UpdateVisibility()
+		if dm.SystemMonitor != nil {
+			dm.SystemMonitor.UpdateVisibility()
+		}
 		dm.UpdateHostSecurityPolicies()
 	})
 	viper.WatchConfig()

--- a/deployments/helm/KubeArmor/templates/daemonset.yaml
+++ b/deployments/helm/KubeArmor/templates/daemonset.yaml
@@ -32,6 +32,7 @@ spec:
         - {{ printf "--tlsCertPath=%s" .Values.kubearmor.tls.tlsCertPath | quote }}
         - {{ printf "--tlsCertProvider=%s" .Values.kubearmor.tls.tlsCertProvider | quote }}
         {{- end }}
+        - {{ printf "--enableMonitor=%t" .Values.kubearmorConfigMap.enableMonitor | quote }}
 
         {{- with .Values.kubearmor.args }}
         {{- toYaml . | nindent 8 }}

--- a/deployments/helm/KubeArmor/values.yaml
+++ b/deployments/helm/KubeArmor/values.yaml
@@ -6,7 +6,7 @@ environment:
   name: generic
 
 tls:
-  enabled: false  
+  enabled: false
 
 kubearmorRelay:
   # to enable/disable kubearmor-relay
@@ -40,31 +40,30 @@ kubearmorRelay:
     tlsCertProvider: external
     certSecretName: kubearmor-relay-server-certs
     certVolumeMount:
-    - mountPath: /var/lib/kubearmor/tls
-      name: kubearmor-relay-certs-secrets
-      readOnly: true
+      - mountPath: /var/lib/kubearmor/tls
+        name: kubearmor-relay-certs-secrets
+        readOnly: true
     certVolume:
-    - name: kubearmor-relay-certs-secrets
-      projected:
-        defaultMode: 0444
-        sources:
-        - secret:
-            name: kubearmor-relay-server-certs
-            items:
-            - key: tls.crt
-              path: server.crt
-            - key: tls.key
-              path: server.key
-            - key: ca.crt
-              path: ca.crt
-        - secret:
-            name: kubearmor-client-certs
-            items:
-            - key: tls.crt
-              path: client.crt
-            - key: tls.key
-              path: client.key  
-
+      - name: kubearmor-relay-certs-secrets
+        projected:
+          defaultMode: 0444
+          sources:
+            - secret:
+                name: kubearmor-relay-server-certs
+                items:
+                  - key: tls.crt
+                    path: server.crt
+                  - key: tls.key
+                    path: server.key
+                  - key: ca.crt
+                    path: ca.crt
+            - secret:
+                name: kubearmor-client-certs
+                items:
+                  - key: tls.crt
+                    path: client.crt
+                  - key: tls.key
+                    path: client.key
 
 kubearmorInit:
   image:
@@ -99,7 +98,7 @@ kubearmorController:
     tag: latest
     # Optional, but if there are a lot of image pulls required, Docker might be rate-limited. So, it's good to add pull secrets for production.
     imagePullSecrets: ""
-  tolerations: ""  
+  tolerations: ""
   mutation:
     # kubearmor-controller failure policy
     failurePolicy: Ignore
@@ -120,6 +119,7 @@ kubearmorConfigMap:
   maxAlertPerSec: 10
   throttleSec: 30
   matchArgs: true
+  enableMonitor: true
 
 #volume mounts and volumes
 kubearmor:
@@ -144,61 +144,61 @@ kubearmor:
     caSecretName: kubearmor-ca
     clientCertSecretName: kubearmor-client-certs
     kubearmorCACertVolumeMount:
-    - mountPath: /var/lib/kubearmor/tls
-      name: kubearmor-ca-secret
-      readOnly: true
+      - mountPath: /var/lib/kubearmor/tls
+        name: kubearmor-ca-secret
+        readOnly: true
     kubearmorCACertVolume:
-    - name: kubearmor-ca-secret
-      projected:
-        defaultMode: 0444
-        sources:
-        - secret:
-            name: kubearmor-ca
-            items:
-            - key: tls.crt
-              path: ca.crt
-            - key: tls.key
-              path: ca.key
+      - name: kubearmor-ca-secret
+        projected:
+          defaultMode: 0444
+          sources:
+            - secret:
+                name: kubearmor-ca
+                items:
+                  - key: tls.crt
+                    path: ca.crt
+                  - key: tls.key
+                    path: ca.key
 
   capabilities:
     add:
-    - SETUID
-    - SETGID
-    - SETPCAP
-    - SYS_ADMIN
-    - SYS_PTRACE
-    - MAC_ADMIN
-    - SYS_RESOURCE
-    - IPC_LOCK
-    - CAP_DAC_OVERRIDE
-    - CAP_DAC_READ_SEARCH
+      - SETUID
+      - SETGID
+      - SETPCAP
+      - SYS_ADMIN
+      - SYS_PTRACE
+      - MAC_ADMIN
+      - SYS_RESOURCE
+      - IPC_LOCK
+      - CAP_DAC_OVERRIDE
+      - CAP_DAC_READ_SEARCH
     drop:
-    - ALL
+      - ALL
 
   commonMounts:
-  - mountPath: /opt/kubearmor/BPF
-    name: bpf
+    - mountPath: /opt/kubearmor/BPF
+      name: bpf
 
   commonVolumes:
-  - emptyDir: {}
-    name: bpf
+    - emptyDir: {}
+      name: bpf
 
   initMounts:
-  - mountPath: /opt/kubearmor/BPF
-    name: bpf
-  - mountPath: /lib/modules
-    name: lib-modules-path
-    readOnly: true
-  - mountPath: /sys/kernel/security
-    name: sys-kernel-security-path
-  - mountPath: /sys/kernel/debug
-    name: sys-kernel-debug-path
-  - mountPath: /media/root/etc/os-release
-    name: os-release-path
-    readOnly: true
-  - mountPath: /usr/src
-    name: usr-src-path
-    readOnly: true
+    - mountPath: /opt/kubearmor/BPF
+      name: bpf
+    - mountPath: /lib/modules
+      name: lib-modules-path
+      readOnly: true
+    - mountPath: /sys/kernel/security
+      name: sys-kernel-security-path
+    - mountPath: /sys/kernel/debug
+      name: sys-kernel-debug-path
+    - mountPath: /media/root/etc/os-release
+      name: os-release-path
+      readOnly: true
+    - mountPath: /usr/src
+      name: usr-src-path
+      readOnly: true
 
   volumeMountsGeneric:
     - mountPath: /usr/src

--- a/pkg/KubeArmorOperator/api/operator.kubearmor.com/v1/kubearmorconfig_types.go
+++ b/pkg/KubeArmorOperator/api/operator.kubearmor.com/v1/kubearmorconfig_types.go
@@ -130,6 +130,8 @@ type KubeArmorConfigSpec struct {
 	DropResourceFromProcessLogs bool `json:"dropResourceFromProcessLogs,omitempty"`
 
 	MatchArgs bool `json:"matchArgs,omitempty"`
+
+	EnableMonitor bool `json:"enableMonitor,omitempty"`
 }
 
 // KubeArmorConfigStatus defines the observed state of KubeArmorConfig

--- a/pkg/KubeArmorOperator/internal/controller/cluster.go
+++ b/pkg/KubeArmorOperator/internal/controller/cluster.go
@@ -467,6 +467,7 @@ func (clusterWatcher *ClusterWatcher) WatchConfigCrd() {
 						common.OperatorConfigCrd = cfg
 						clusterWatcher.Log.Info("kubearmorconfig CR created")
 						UpdateTlsData(&cfg.Spec)
+						UpdateEnableMonitor(&cfg.Spec)
 						UpdateConfigMapData(&cfg.Spec)
 						UpdateImages(&cfg.Spec)
 						UpdatedKubearmorRelayEnv(&cfg.Spec)
@@ -497,10 +498,11 @@ func (clusterWatcher *ClusterWatcher) WatchConfigCrd() {
 						relayEnvUpdated := UpdatedKubearmorRelayEnv(&cfg.Spec)
 						seccompEnabledUpdated := UpdatedSeccomp(&cfg.Spec)
 						tlsUpdated := UpdateTlsData(&cfg.Spec)
+						enableMonitorUpdated := UpdateEnableMonitor(&cfg.Spec)
 						UpdateRecommendedPolicyConfig(&cfg.Spec)
 
 						// return if only status has been updated
-						if !tlsUpdated && !relayEnvUpdated && !configChanged && cfg.Status != oldObj.(*opv1.KubeArmorConfig).Status && len(imageUpdated) < 1 && !controllerPortUpdated {
+						if !tlsUpdated && !relayEnvUpdated && !configChanged && cfg.Status != oldObj.(*opv1.KubeArmorConfig).Status && len(imageUpdated) < 1 && !controllerPortUpdated && !enableMonitorUpdated {
 							return
 						}
 						if tlsUpdated {
@@ -1673,5 +1675,18 @@ func UpdateTlsData(config *opv1.KubeArmorConfigSpec) bool {
 		common.ExtraDnsNames = config.Tls.RelayExtraIpAddresses
 	}
 
+	return updated
+}
+
+// UpdateEnableMonitor updates the EnableMonitor flag from KubeArmorConfig spec
+func UpdateEnableMonitor(config *opv1.KubeArmorConfigSpec) bool {
+	updated := false
+	// EnableMonitor defaults to true if not explicitly set in spec
+	enableMonitor := true
+	if config.EnableMonitor != enableMonitor {
+		fmt.Printf("enableMonitor config changed: %v", config.EnableMonitor)
+		enableMonitor = config.EnableMonitor
+		updated = true
+	}
 	return updated
 }


### PR DESCRIPTION
This PR implements feature request #1636 to allow disabling the eBPF syscall 
tracing system monitor when BPFLSM is the active enforcer. This enables 
significant resource savings in production clusters where learning mode is 
not needed.

Fix : #1636 