### PR TITLE
fix(operator): return error on non-200 metadata response and fix log format verbs

### DIFF
--- a/pkg/KubeArmorOperator/internal/controller/resources.go
+++ b/pkg/KubeArmorOperator/internal/controller/resources.go
@@ -686,7 +686,7 @@ func (clusterWatcher *ClusterWatcher) fetchClusterNameFromGKE(providerHostname, 
 	// Check for a successful response
 	if resp.StatusCode != http.StatusOK {
 		clusterWatcher.Log.Warnf("failed to fetch from metadata, status code: %d", resp.StatusCode)
-		return "", err
+		return "", fmt.Errorf("unexpected status code: %d", resp.StatusCode)
 	}
 
 	// Read the response body
@@ -719,7 +719,7 @@ func (clusterWatcher *ClusterWatcher) fetchClusterNameFromAWS(providerHostname, 
 	if resp.StatusCode == http.StatusOK {
 		token, err = io.ReadAll(resp.Body)
 		if err != nil {
-			clusterWatcher.Log.Warnf("failed to read token: %d", err)
+			clusterWatcher.Log.Warnf("failed to read token: %s", err.Error())
 			return "", err
 		}
 	}
@@ -743,12 +743,12 @@ func (clusterWatcher *ClusterWatcher) fetchClusterNameFromAWS(providerHostname, 
 
 	if resp.StatusCode != http.StatusOK {
 		clusterWatcher.Log.Warnf("failed to fetch from metadata, status code: %d", resp.StatusCode)
-		return "", err
+		return "", fmt.Errorf("unexpected status code: %d", resp.StatusCode)
 	}
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		clusterWatcher.Log.Warnf("failed to read metadata: %d", err)
+		clusterWatcher.Log.Warnf("failed to read metadata: %s", err.Error())
 		return "", err
 	}
 

--- a/pkg/KubeArmorOperator/internal/controller/resources.go
+++ b/pkg/KubeArmorOperator/internal/controller/resources.go
@@ -759,7 +759,7 @@ func (clusterWatcher *ClusterWatcher) fetchClusterNameFromAWS(providerHostname, 
 		return match[1], nil
 	}
 
-	return "", err
+	return "", fmt.Errorf("cluster name not found in EKS metadata response")
 }
 
 func (clusterWatcher *ClusterWatcher) GetClusterName(providerHostname, providerEndpoint string) string {

--- a/pkg/KubeArmorOperator/internal/controller/resources.go
+++ b/pkg/KubeArmorOperator/internal/controller/resources.go
@@ -775,7 +775,7 @@ func (clusterWatcher *ClusterWatcher) fetchClusterNameFromAWS(providerHostname, 
 		return match[1], nil
 	}
 
-	return "", err
+	return "", fmt.Errorf("cluster name not found in EKS metadata response")
 }
 
 func (clusterWatcher *ClusterWatcher) GetClusterName(providerHostname, providerEndpoint string) string {

--- a/pkg/KubeArmorOperator/internal/controller/resources.go
+++ b/pkg/KubeArmorOperator/internal/controller/resources.go
@@ -702,7 +702,7 @@ func (clusterWatcher *ClusterWatcher) fetchClusterNameFromGKE(providerHostname, 
 	// Check for a successful response
 	if resp.StatusCode != http.StatusOK {
 		clusterWatcher.Log.Warnf("failed to fetch from metadata, status code: %d", resp.StatusCode)
-		return "", err
+		return "", fmt.Errorf("unexpected status code: %d", resp.StatusCode)
 	}
 
 	// Read the response body
@@ -735,7 +735,7 @@ func (clusterWatcher *ClusterWatcher) fetchClusterNameFromAWS(providerHostname, 
 	if resp.StatusCode == http.StatusOK {
 		token, err = io.ReadAll(resp.Body)
 		if err != nil {
-			clusterWatcher.Log.Warnf("failed to read token: %d", err)
+			clusterWatcher.Log.Warnf("failed to read token: %s", err.Error())
 			return "", err
 		}
 	}
@@ -759,12 +759,12 @@ func (clusterWatcher *ClusterWatcher) fetchClusterNameFromAWS(providerHostname, 
 
 	if resp.StatusCode != http.StatusOK {
 		clusterWatcher.Log.Warnf("failed to fetch from metadata, status code: %d", resp.StatusCode)
-		return "", err
+		return "", fmt.Errorf("unexpected status code: %d", resp.StatusCode)
 	}
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		clusterWatcher.Log.Warnf("failed to read metadata: %d", err)
+		clusterWatcher.Log.Warnf("failed to read metadata: %s", err.Error())
 		return "", err
 	}
 


### PR DESCRIPTION
**Purpose of PR?**:
Fixes two bugs in `fetchClusterNameFromGKE` and `fetchClusterNameFromAWS` in `resources.go`:

1. When the metadata server returns a non-200 status code, both functions were returning `("", nil)` because `err` is nil after a successful HTTP round-trip. The caller `GetClusterName` checks `if err != nil` to trigger fallback to `"default"`, so a 404 or 500 from the metadata server would silently return an empty cluster name instead of falling back correctly. Fixed by returning `fmt.Errorf("unexpected status code: %d", resp.StatusCode)`.

2. Two `Warnf` calls were using `%d` (integer format verb) to format `error` values, producing garbled log output like `%!d(*errors.errorString=&{...})`. Fixed to use `%s` with `err.Error()`.


**Does this PR introduce a breaking change?**
No.

**If the changes in this PR are manually verified, list down the scenarios covered:**
- Metadata server returns non-200 status: `GetClusterName` now correctly falls back to `"default"` instead of returning an empty cluster name
- Error log lines in `fetchClusterNameFromAWS` now produce readable output

**Additional information for reviewer?**:
Four lines changed across two functions in `resources.go`. No logic changes outside of error handling.

**Checklist:**
- [x] Bug fix. Fixes #
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] PR Title follows the convention of `<type>(<scope>): <subject>`
- [ ] Commit has unit tests
- [ ] Commit has integration tests