### PR TITLE
fix(core): normalize Kubernetes container names

### DIFF
--- a/KubeArmor/core/container_name.go
+++ b/KubeArmor/core/container_name.go
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Authors of KubeArmor
+
+package core
+
+import "strings"
+
+const kubernetesContainerNameLabel = "io.kubernetes.container.name"
+
+// resolveContainerName returns the Kubernetes container name when the runtime
+// exposes it, otherwise it falls back to the runtime-derived name.
+func resolveContainerName(runtimeName string, labels map[string]string) string {
+	if labels != nil {
+		if containerName, ok := labels[kubernetesContainerNameLabel]; ok && containerName != "" {
+			return containerName
+		}
+	}
+
+	return strings.TrimPrefix(runtimeName, "/")
+}

--- a/KubeArmor/core/container_name_test.go
+++ b/KubeArmor/core/container_name_test.go
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Authors of KubeArmor
+
+package core
+
+import "testing"
+
+func TestResolveContainerName(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		runtime string
+		labels  map[string]string
+		want    string
+	}{
+		{
+			name:    "uses kubernetes container label when present",
+			runtime: "/k8s_POD_backend-67f6d7c4b7-5x9df_default_12345_0",
+			labels: map[string]string{
+				kubernetesContainerNameLabel: "backend",
+			},
+			want: "backend",
+		},
+		{
+			name:    "falls back to trimmed runtime name",
+			runtime: "/k8s_POD_backend-67f6d7c4b7-5x9df_default_12345_0",
+			want:    "k8s_POD_backend-67f6d7c4b7-5x9df_default_12345_0",
+		},
+		{
+			name:    "keeps runtime name when it has no leading slash",
+			runtime: "containerd://abcd1234",
+			want:    "containerd://abcd1234",
+		},
+		{
+			name:    "ignores empty kubernetes container label",
+			runtime: "/container-123",
+			labels: map[string]string{
+				kubernetesContainerNameLabel: "",
+			},
+			want: "container-123",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := resolveContainerName(tt.runtime, tt.labels)
+			if got != tt.want {
+				t.Fatalf("resolveContainerName() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/KubeArmor/core/containerdHandler.go
+++ b/KubeArmor/core/containerdHandler.go
@@ -182,7 +182,7 @@ func (ch *ContainerdHandler) GetContainerInfo(ctx context.Context, containerID, 
 	// == container base == //
 
 	container.ContainerID = res.ID
-	container.ContainerName = res.ID
+	container.ContainerName = resolveContainerName(res.ID, res.Labels)
 	container.NamespaceName = "Unknown"
 	container.EndPointName = "Unknown"
 

--- a/KubeArmor/core/dockerHandler.go
+++ b/KubeArmor/core/dockerHandler.go
@@ -109,7 +109,7 @@ func (dh *DockerHandler) GetContainerInfo(containerID, nodeID string, OwnerInfo 
 	// == container base == //
 
 	container.ContainerID = inspect.ID
-	container.ContainerName = strings.TrimLeft(inspect.Name, "/")
+	container.ContainerName = resolveContainerName(inspect.Name, inspect.Config.Labels)
 
 	container.NamespaceName = "Unknown"
 	container.EndPointName = "Unknown"


### PR DESCRIPTION
**Purpose of PR?**:

Normalize runtime-derived container names for Kubernetes-managed containers by preferring the `io.kubernetes.container.name` label when available, with a runtime-name fallback.

Fixes #1305

**Does this PR introduce a breaking change?**

No.

**If the changes in this PR are manually verified, list down the scenarios covered:**:

- `go test ./core -run TestResolveContainerName -count=1`
- `go test ./core -count=1`

**Additional information for reviewer?** :
This is limited to `KubeArmor/core/` runtime name normalization and the focused unit tests in that package.

**Checklist:**
- [x] Bug fix. Fixes #1305
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [x] Commit has unit tests
- [ ] Commit has integration tests
