### PR TITLE
fix(core): skip removed containers during pod updates

### DIFF
--- a/KubeArmor/core/kubeUpdate.go
+++ b/KubeArmor/core/kubeUpdate.go
@@ -379,17 +379,17 @@ func (dm *KubeArmorDaemon) UpdateEndPointWithPod(action string, pod tp.K8sPod) {
 
 	} else if action == updateEvent {
 		newEndPoint := tp.EndPoint{}
-		endpoints := []tp.EndPoint{}
+		endPointExists := false
 
 		dm.EndPointsLock.RLock()
 		for _, endPoint := range dm.EndPoints {
 			if pod.Metadata["namespaceName"] == endPoint.NamespaceName && pod.Metadata["podName"] == endPoint.EndPointName {
-				endpoints = append(endpoints, endPoint)
+				endPointExists = true
 				break
 			}
 		}
 		dm.EndPointsLock.RUnlock()
-		if len(endpoints) == 0 {
+		if !endPointExists {
 			// No endpoints were added as containers ID have been just added
 			// Same logic as ADDED
 			dm.UpdateEndPointWithPod(addEvent, pod)
@@ -447,11 +447,18 @@ func (dm *KubeArmorDaemon) UpdateEndPointWithPod(action string, pod tp.K8sPod) {
 			}
 
 			containersAppArmorProfiles := map[string]string{}
+			activeContainers := make([]string, 0, len(newEndPoint.Containers))
 
 			dm.ContainersLock.Lock()
 			// update containers and apparmors
 			for _, containerID := range newEndPoint.Containers {
-				container := dm.Containers[containerID]
+				container, ok := dm.Containers[containerID]
+				if !ok {
+					// Skip terminated containers that were already removed by the runtime handler.
+					continue
+				}
+
+				activeContainers = append(activeContainers, containerID)
 				container.NamespaceName = newEndPoint.NamespaceName
 				container.EndPointName = newEndPoint.EndPointName
 				if (container.Owner == tp.PodOwner{}) && (len(dm.OwnerInfo) > 0) {
@@ -493,6 +500,7 @@ func (dm *KubeArmorDaemon) UpdateEndPointWithPod(action string, pod tp.K8sPod) {
 				dm.HandleUnknownNamespaceNsMap(&container)
 			}
 			dm.ContainersLock.Unlock()
+			newEndPoint.Containers = activeContainers
 
 			dm.DefaultPosturesLock.Lock()
 			if val, ok := dm.DefaultPostures[newEndPoint.NamespaceName]; ok {
@@ -510,38 +518,38 @@ func (dm *KubeArmorDaemon) UpdateEndPointWithPod(action string, pod tp.K8sPod) {
 			// get security policies according to the updated identities
 			newEndPoint.SecurityPolicies = dm.GetSecurityPolicies(newEndPoint)
 
-			newendpoints := []tp.EndPoint{}
-			for k, v := range pod.Containers {
+			updatedEndpoints := make([]tp.EndPoint, 0, len(newEndPoint.Containers))
+			for _, containerID := range newEndPoint.Containers {
 				endpoint := newEndPoint
 				endpoint.Containers = []string{}
 				endpoint.AppArmorProfiles = []string{}
 				endpoint.SecurityPolicies = []tp.SecurityPolicy{}
-				endpoint.AppArmorProfiles = append(endpoint.AppArmorProfiles, containersAppArmorProfiles[k])
-				endpoint.Containers = append(endpoint.Containers, k)
-				endpoint.ContainerName = v
+				endpoint.AppArmorProfiles = append(endpoint.AppArmorProfiles, containersAppArmorProfiles[containerID])
+				endpoint.Containers = append(endpoint.Containers, containerID)
+				endpoint.ContainerName = pod.Containers[containerID]
 
 				for _, secPolicy := range newEndPoint.SecurityPolicies {
-					if len(secPolicy.Spec.Selector.Containers) == 0 || kl.ContainsElement(secPolicy.Spec.Selector.Containers, v) {
+					if len(secPolicy.Spec.Selector.Containers) == 0 || kl.ContainsElement(secPolicy.Spec.Selector.Containers, endpoint.ContainerName) {
 						endpoint.SecurityPolicies = append(endpoint.SecurityPolicies, secPolicy)
 					}
 				}
 
-				endpoints = append(newendpoints, endpoint)
+				updatedEndpoints = append(updatedEndpoints, endpoint)
 			}
 
 			dm.EndPointsLock.Lock()
 
-			for nidx := 0; nidx < len(endpoints); nidx++ {
+			for nidx := 0; nidx < len(updatedEndpoints); nidx++ {
 				for idx := 0; idx < len(dm.EndPoints); idx++ {
-					if pod.Metadata["namespaceName"] == dm.EndPoints[idx].NamespaceName && pod.Metadata["podName"] == dm.EndPoints[idx].EndPointName && endpoints[nidx].ContainerName == dm.EndPoints[idx].ContainerName {
-						dm.EndPoints[idx] = endpoints[nidx]
+					if pod.Metadata["namespaceName"] == dm.EndPoints[idx].NamespaceName && pod.Metadata["podName"] == dm.EndPoints[idx].EndPointName && updatedEndpoints[nidx].ContainerName == dm.EndPoints[idx].ContainerName {
+						dm.EndPoints[idx] = updatedEndpoints[nidx]
 						break
 					}
 				}
 			}
 
 			dm.EndPointsLock.Unlock()
-			for _, endpoint := range endpoints {
+			for _, endpoint := range updatedEndpoints {
 				if cfg.GlobalCfg.Policy {
 					// update security policies
 					dm.Logger.UpdateSecurityPolicies(action, endpoint)
@@ -583,6 +591,10 @@ func (dm *KubeArmorDaemon) UpdateEndPointWithPod(action string, pod tp.K8sPod) {
 
 // HandleUnknownNamespaceNsMap Function
 func (dm *KubeArmorDaemon) HandleUnknownNamespaceNsMap(container *tp.Container) {
+	if dm.SystemMonitor == nil || !cfg.GlobalCfg.Policy {
+		return
+	}
+
 	dm.SystemMonitor.AddContainerIDToNsMap(container.ContainerID, container.NamespaceName, container.PidNS, container.MntNS)
 	dm.SystemMonitor.NsMapLock.Lock()
 	if val, ok := dm.SystemMonitor.NamespacePidsMap["Unknown"]; ok {

--- a/KubeArmor/core/kubeUpdate_test.go
+++ b/KubeArmor/core/kubeUpdate_test.go
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Authors of KubeArmor
+
+package core
+
+import (
+	"reflect"
+	"testing"
+
+	cfg "github.com/kubearmor/KubeArmor/KubeArmor/config"
+	tp "github.com/kubearmor/KubeArmor/KubeArmor/types"
+)
+
+func TestUpdateEndPointWithPodAddCreatesPlaceholderContainers(t *testing.T) {
+	dm := NewKubeArmorDaemon()
+	pod := newTestK8sPod(
+		map[string]string{"cid-1": "ubuntu-1-container"},
+		map[string]string{"cid-1": "kubearmor/ubuntu-w-utils:0.1"},
+	)
+
+	previousPolicy := cfg.GlobalCfg.Policy
+	cfg.GlobalCfg.Policy = false
+	t.Cleanup(func() {
+		cfg.GlobalCfg.Policy = previousPolicy
+	})
+
+	dm.UpdateEndPointWithPod(addEvent, pod)
+
+	container, ok := dm.Containers["cid-1"]
+	if !ok {
+		t.Fatalf("expected placeholder container to be added")
+	}
+
+	if container.NamespaceName != "syscalls" {
+		t.Fatalf("expected namespace %q, got %q", "syscalls", container.NamespaceName)
+	}
+
+	if container.EndPointName != "ubuntu-1-deployment" {
+		t.Fatalf("expected endpoint %q, got %q", "ubuntu-1-deployment", container.EndPointName)
+	}
+
+	if container.ContainerName != "ubuntu-1-container" {
+		t.Fatalf("expected container name %q, got %q", "ubuntu-1-container", container.ContainerName)
+	}
+}
+
+func TestUpdateEndPointWithPodSkipsRemovedContainersOnPodUpdate(t *testing.T) {
+	dm := NewKubeArmorDaemon()
+	dm.Containers["tracked"] = tp.Container{
+		NamespaceName:            "syscalls",
+		EndPointName:             "ubuntu-1-deployment",
+		ContainerName:            "ubuntu-1-container",
+		AppArmorProfile:          "kubearmor-syscalls-ubuntu-1-deployment-ubuntu-1-container",
+		PolicyEnabled:            tp.KubeArmorPolicyEnabled,
+		FileVisibilityEnabled:    true,
+		ProcessVisibilityEnabled: true,
+		NetworkVisibilityEnabled: true,
+	}
+	dm.EndPoints = append(dm.EndPoints, tp.EndPoint{
+		NamespaceName: "syscalls",
+		EndPointName:  "ubuntu-1-deployment",
+		ContainerName: "ubuntu-1-container",
+		Containers:    []string{"tracked"},
+	})
+
+	pod := newTestK8sPod(
+		map[string]string{
+			"tracked": "ubuntu-1-container",
+			"stale":   "ubuntu-1-container",
+		},
+		map[string]string{
+			"tracked": "kubearmor/ubuntu-w-utils:0.1",
+			"stale":   "kubearmor/ubuntu-w-utils:0.1",
+		},
+	)
+
+	previousPolicy := cfg.GlobalCfg.Policy
+	cfg.GlobalCfg.Policy = false
+	t.Cleanup(func() {
+		cfg.GlobalCfg.Policy = previousPolicy
+	})
+
+	dm.UpdateEndPointWithPod(updateEvent, pod)
+
+	if _, ok := dm.Containers["stale"]; ok {
+		t.Fatalf("expected removed container not to be recreated")
+	}
+
+	container, ok := dm.Containers["tracked"]
+	if !ok {
+		t.Fatalf("expected tracked container to remain present")
+	}
+
+	if container.ContainerImage != "kubearmor/ubuntu-w-utils:0.1" {
+		t.Fatalf("expected updated image, got %q", container.ContainerImage)
+	}
+
+	expectedContainers := []string{"tracked"}
+	if !reflect.DeepEqual(dm.EndPoints[0].Containers, expectedContainers) {
+		t.Fatalf("expected endpoint containers %v, got %v", expectedContainers, dm.EndPoints[0].Containers)
+	}
+}
+
+func newTestK8sPod(containers, images map[string]string) tp.K8sPod {
+	return tp.K8sPod{
+		Metadata: map[string]string{
+			"namespaceName": "syscalls",
+			"podName":       "ubuntu-1-deployment",
+		},
+		Annotations: map[string]string{
+			"kubearmor-policy":     "enabled",
+			"kubearmor-visibility": "process,file,network",
+		},
+		Labels: map[string]string{
+			"container": "ubuntu-1",
+		},
+		Containers:                 containers,
+		ContainerImages:            images,
+		PrivilegedContainers:       map[string]struct{}{},
+		PrivilegedAppArmorProfiles: map[string]struct{}{},
+	}
+}


### PR DESCRIPTION
**Purpose of PR?**:

Skip Kubernetes pod-update entries whose containers were already removed by the runtime handler so they are not recreated in `dm.Containers` during terminating pod events.

Fixes #1349

**Does this PR introduce a breaking change?**

No.

**If the changes in this PR are manually verified, list down the scenarios covered:**:

- `go test ./core -run "TestUpdateEndPointWithPod(AddCreatesPlaceholderContainers|SkipsRemovedContainersOnPodUpdate)$" -count=1`
- `go test ./core -count=1`

**Additional information for reviewer?** :
This keeps the existing add-event placeholder flow intact, but skips stale runtime-removed containers during pod update reconciliation and adds focused regression coverage for both paths.

**Checklist:**
- [x] Bug fix. Fixes #1349
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [x] Commit has unit tests
- [ ] Commit has integration tests
