### PR TITLE
fix(bpf): use BPF_CORE_READ for ns.inum to fix verifier stack boundary error on kernel 6.18+

### DIFF
--- a/KubeArmor/BPF/shared.h
+++ b/KubeArmor/BPF/shared.h
@@ -439,12 +439,12 @@ static __always_inline long strtol(const char *buf, size_t buf_len, long *res)
 
 static __always_inline u32 get_task_pid_ns_id(struct task_struct *task)
 {
-  return BPF_CORE_READ(task, nsproxy, pid_ns_for_children, ns).inum;
+  return BPF_CORE_READ(task, nsproxy, pid_ns_for_children, ns.inum);
 }
 
 static __always_inline u32 get_task_mnt_ns_id(struct task_struct *task)
 {
-  return BPF_CORE_READ(task, nsproxy, mnt_ns, ns).inum;
+  return BPF_CORE_READ(task, nsproxy, mnt_ns, ns.inum);
 }
 
 static __always_inline u32 get_task_pid_vnr(struct task_struct *task)


### PR DESCRIPTION
**Purpose of PR?**:

On kernel 6.18 (Talos 1.12.6), the BPF LSM enforcer fails to load with a verifier error: `invalid read from stack R7 off=0 size=4`. `get_task_pid_ns_id` and `get_task_mnt_ns_id` in `shared.h` used `BPF_CORE_READ(..., ns).inum` which reads the entire `ns_common` struct (24 bytes) onto the stack at `fp-24`, then accesses `.inum` at offset +24 from that base, landing at `fp+0` - past the stack frame boundary. Kernel 6.18 is stricter about this than earlier kernels, causing the verifier to reject the program and the enforcer to fail to initialize, leaving no active LSMs. Fix moves `.inum` inside the `BPF_CORE_READ` macro so it is read as a scalar directly from kernel memory instead of staging `ns_common` on the stack first.

Fixes #2544 

**Does this PR introduce a breaking change?**

No

**If the changes in this PR are manually verified, list down the scenarios covered:**:

Verified by reproducing the verifier error on Talos 1.12.6 (kernel 6.18.18-talos) with kubearmor 1.6.16 and confirming the error matches the stack boundary analysis. Unable to recompile BPF objects locally to test binary, but the root cause is confirmed directly from the verifier output.

**Additional information for reviewer?** :

The commented-out cgroup_ns line in `get_outer_key` has the same pattern `BPF_CORE_READ(t, nsproxy, cgroup_ns, ns).inum` and will hit the same verifier error if uncommented. Should be fixed preemptively.


**Checklist:**
- [x] Bug fix. Fixes #2544 
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Commit has unit tests
- [ ] Commit has integration tests