### PR TITLE
fix: guard InitContainers[0] access to prevent panic on BTF-enabled nodes

### DIFF
--- a/pkg/KubeArmorOperator/internal/controller/cluster.go
+++ b/pkg/KubeArmorOperator/internal/controller/cluster.go
@@ -601,11 +601,13 @@ func (clusterWatcher *ClusterWatcher) UpdateKubeArmorImages(images []string) err
 					}
 
 					// update with global env
-					AddOrUpdateEnv(&ds.Spec.Template.Spec.InitContainers[0].Env, common.GlobalEnv)
-					// add/override with kubearmor-init specific env
-					if len(common.KubeArmorInitEnv) > 0 {
-						defer RemoveDeletedEntriesForEnv(&common.KubeArmorInitEnv)
-						AddOrUpdateEnv(&ds.Spec.Template.Spec.InitContainers[0].Env, common.KubeArmorInitEnv)
+					if len(ds.Spec.Template.Spec.InitContainers) != 0 {
+						AddOrUpdateEnv(&ds.Spec.Template.Spec.InitContainers[0].Env, common.GlobalEnv)
+						// add/override with kubearmor-init specific env
+						if len(common.KubeArmorInitEnv) > 0 {
+							defer RemoveDeletedEntriesForEnv(&common.KubeArmorInitEnv)
+							AddOrUpdateEnv(&ds.Spec.Template.Spec.InitContainers[0].Env, common.KubeArmorInitEnv)
+						}
 					}
 
 					NRIVolume, NRIVolumeMount := common.GenerateNRIvol(ds.Spec.Selector.MatchLabels["kubearmor.io/nri-socket"])
@@ -871,13 +873,17 @@ func (clusterWatcher *ClusterWatcher) UpdateKubearmorSeccomp(cfg *opv1.KubeArmor
 						Type:             corev1.SeccompProfileTypeLocalhost,
 						LocalhostProfile: &common.SeccompProfile,
 					}
-					ds.Spec.Template.Spec.InitContainers[0].SecurityContext.SeccompProfile = &corev1.SeccompProfile{
-						Type:             corev1.SeccompProfileTypeLocalhost,
-						LocalhostProfile: &common.SeccompInitProfile,
+					if len(ds.Spec.Template.Spec.InitContainers) > 0 {
+						ds.Spec.Template.Spec.InitContainers[0].SecurityContext.SeccompProfile = &corev1.SeccompProfile{
+							Type:             corev1.SeccompProfileTypeLocalhost,
+							LocalhostProfile: &common.SeccompInitProfile,
+						}
 					}
 				} else if !cfg.Spec.SeccompEnabled && ds.Spec.Template.Spec.Containers[0].SecurityContext.SeccompProfile != nil {
 					ds.Spec.Template.Spec.Containers[0].SecurityContext.SeccompProfile = nil
-					ds.Spec.Template.Spec.InitContainers[0].SecurityContext.SeccompProfile = nil
+					if len(ds.Spec.Template.Spec.InitContainers) > 0 {
+						ds.Spec.Template.Spec.InitContainers[0].SecurityContext.SeccompProfile = nil
+					}
 				}
 
 				_, err = clusterWatcher.Client.AppsV1().DaemonSets(common.Namespace).Update(context.Background(), &ds, v1.UpdateOptions{})

--- a/pkg/KubeArmorOperator/internal/controller/resources.go
+++ b/pkg/KubeArmorOperator/internal/controller/resources.go
@@ -131,8 +131,10 @@ func generateDaemonset(name, enforcer, runtime, socket, nriSocket, btfPresent, a
 
 	AddOrUpdateEnv(&daemonset.Spec.Template.Spec.Containers[0].Env, common.GlobalEnv)
 	AddOrUpdateEnv(&daemonset.Spec.Template.Spec.Containers[0].Env, common.KubeArmorEnv)
-	AddOrUpdateEnv(&daemonset.Spec.Template.Spec.InitContainers[0].Env, common.GlobalEnv)
-	AddOrUpdateEnv(&daemonset.Spec.Template.Spec.InitContainers[0].Env, common.KubeArmorInitEnv)
+	if len(daemonset.Spec.Template.Spec.InitContainers) > 0 {
+		AddOrUpdateEnv(&daemonset.Spec.Template.Spec.InitContainers[0].Env, common.GlobalEnv)
+		AddOrUpdateEnv(&daemonset.Spec.Template.Spec.InitContainers[0].Env, common.KubeArmorInitEnv)
+	}
 
 	// TODO: handle passing annotateResource flag to kubearmor
 	// ideally this configuration should be part of kubearmoconfig to avoid hardcoding version checks
@@ -196,8 +198,10 @@ func generateDaemonset(name, enforcer, runtime, socket, nriSocket, btfPresent, a
 	}
 	daemonset.Spec.Template.Spec.Containers[0].Args = append(daemonset.Spec.Template.Spec.Containers[0].Args, ociArgs...)
 	daemonset.Spec.Template.Spec.Containers[0].Args = append(daemonset.Spec.Template.Spec.Containers[0].Args, LsmFlagString)
-	daemonset.Spec.Template.Spec.InitContainers[0].Image = common.GetApplicationImage(common.KubeArmorInitName)
-	daemonset.Spec.Template.Spec.InitContainers[0].ImagePullPolicy = corev1.PullPolicy(common.KubeArmorInitImagePullPolicy)
+	if len(daemonset.Spec.Template.Spec.InitContainers) > 0 {
+		daemonset.Spec.Template.Spec.InitContainers[0].Image = common.GetApplicationImage(common.KubeArmorInitName)
+		daemonset.Spec.Template.Spec.InitContainers[0].ImagePullPolicy = corev1.PullPolicy(common.KubeArmorInitImagePullPolicy)
+	}
 
 	daemonset = addOwnership(daemonset).(*appsv1.DaemonSet)
 	fmt.Printf("generated daemonset: %v", daemonset)


### PR DESCRIPTION
Fixes #2536

## Problem

`generateDaemonset` in `resources.go` empties `InitContainers` when BTF is present and `initDeploy` is false:

```go
if btfPresent != "no" && !initDeploy {
    daemonset.Spec.Template.Spec.InitContainers = []corev1.Container{}
}
```

But later code unconditionally accesses `InitContainers[0]` in multiple places:
- `resources.go`: env updates (lines 134-135) and image updates (lines 199-200)
- `cluster.go`: env updates outside the existing `len() != 0` guard (line 604) and seccomp profile updates (lines 874, 880)

This causes an index out of range panic on any BTF-enabled node (common on modern kernels).

## Fix

Wrap all unconditional `InitContainers[0]` accesses with `len(InitContainers) > 0` guards, consistent with existing guards already present elsewhere in the same files.

## Files Changed
- `pkg/KubeArmorOperator/internal/controller/resources.go`
- `pkg/KubeArmorOperator/internal/controller/cluster.go`