### PR TITLE
chore: remove global from helm values

### DIFF
--- a/.github/actions/marketplace/action.yml
+++ b/.github/actions/marketplace/action.yml
@@ -35,15 +35,15 @@ runs:
     - name: Generate Helm Chart
       shell: bash
       run: |
-        yq -i '.global.kubearmor.repo = "${{inputs.registry}}" |
-              .global.kubearmor.images.kubearmor.tag = "${{ inputs.version }}" |
-              .global.kubearmor.images.kubearmorInit.tag = "${{ inputs.version }}" |
-              .global.kubearmor.images.kubearmorController.tag = "${{ inputs.version }}" |
-              .global.kubearmor.images.kubearmorSnitch.tag = "${{ inputs.version }}" |
-              .gloabal.kubearmor.images.kubearmorOperator.tag = "${{ inputs.version }}" |
-              .global.kubearmor.images.kubearmorRelay.tag = "${{ inputs.relay_version }}" |
-              .global.autoDeploy = true |
-              .global.imagePinning = true' ${{ inputs.helm_chart_path }}/values.yaml
+        yq -i '.kubearmor.repo = "${{inputs.registry}}" |
+              .kubearmor.images.kubearmor.tag = "${{ inputs.version }}" |
+              .kubearmor.images.kubearmorInit.tag = "${{ inputs.version }}" |
+              .kubearmor.images.kubearmorController.tag = "${{ inputs.version }}" |
+              .kubearmor.images.kubearmorSnitch.tag = "${{ inputs.version }}" |
+              .kubearmor.images.kubearmorOperator.tag = "${{ inputs.version }}" |
+              .kubearmor.images.kubearmorRelay.tag = "${{ inputs.relay_version }}" |
+              .autoDeploy = true |
+              .imagePinning = true' ${{ inputs.helm_chart_path }}/values.yaml
         yq -i '.name = "${{ inputs.helm_chart_name }}" |
               .version = "${{ inputs.version }}"' ${{ inputs.helm_chart_path }}/Chart.yaml
 

--- a/contribution/testing_operator_controller_guide.md
+++ b/contribution/testing_operator_controller_guide.md
@@ -27,7 +27,7 @@ You can skip this if kubearmor images (core and init) are already built!
 
 4. Create Operator from local images
 ```text
-~/KubeArmor$ helm upgrade --install kubearmor-operator ./deployments/helm/KubeArmorOperator -n kubearmor --create-namespace --set global.kubearmorOperator.image.tag=latest,global.kubearmorOperator.imagePullPolicy=Never
+~/KubeArmor$ helm upgrade --install kubearmor-operator ./deployments/helm/KubeArmorOperator -n kubearmor --create-namespace --set kubearmorOperator.image.tag=latest,kubearmorOperator.imagePullPolicy=Never
 ```
 
 5. Create Controller, Relay Service and other services from local images

--- a/deployments/helm/KubeArmorOperator/templates/deployment.yaml
+++ b/deployments/helm/KubeArmorOperator/templates/deployment.yaml
@@ -29,9 +29,9 @@ spec:
       imagePullSecrets:
       {{- toYaml .Values.kubearmorOperator.image.imagePullSecrets | nindent 8 }}
 
-      {{- else if .Values.global.registry.secretName }}
+      {{- else if .Values.registry.secretName }}
       imagePullSecrets:
-        - name: {{ .Values.global.registry.secretName }}
+        - name: {{ .Values.registry.secretName }}
       {{- end }}
       {{- if .Values.kubearmorOperator.tolerations }}
       tolerations: 
@@ -52,8 +52,8 @@ spec:
         - name: KUBEARMOR_OCI_HOOKS
           value: "yes"
         {{- end }}
-        {{- if .Values.global.imagePinning -}}
-          {{- include "pinnedImages" .Values.global.kubearmor | trim | nindent 8 }}
+        {{- if .Values.imagePinning -}}
+          {{- include "pinnedImages" .Values.kubearmor | trim | nindent 8 }}
         {{- end }}
         {{- if .Values.kubearmorOperator.env -}}
           {{- .Values.kubearmorOperator.env | toYaml | nindent 8 }}
@@ -69,8 +69,8 @@ spec:
         {{- if .Values.kubearmorOperator.image.imagePullSecrets }}
         - --image-pull-secrets={{ .Values.kubearmorOperator.image.imagePullSecrets | toJson }}
 
-        {{- else if .Values.global.registry.secretName }}
-        - --image-pull-secrets={{ list (dict "name" .Values.global.registry.secretName) | toJson }}
+        {{- else if .Values.registry.secretName }}
+        - --image-pull-secrets={{ list (dict "name" .Values.registry.secretName) | toJson }}
         {{- end }}
         {{- if .Values.kubearmorOperator.args -}}
           {{- toYaml .Values.kubearmorOperator.args | trim | nindent 8 }}

--- a/deployments/helm/KubeArmorOperator/templates/helpers.tpl
+++ b/deployments/helm/KubeArmorOperator/templates/helpers.tpl
@@ -12,8 +12,8 @@
 {{- end }}
 
 {{- define "operatorImage" }}
-{{- if .Values.global.imagePinning }}
-{{- printf "%s/%s:%s" .Values.global.kubearmor.repo .Values.global.kubearmor.images.kubearmorOperator.image .Values.global.kubearmor.images.kubearmorOperator.tag }}
+{{- if .Values.imagePinning }}
+{{- printf "%s/%s:%s" .Values.kubearmor.repo .Values.kubearmor.images.kubearmorOperator.image .Values.kubearmor.images.kubearmorOperator.tag }}
 {{- else if eq .Values.kubearmorOperator.image.tag "" }}
 {{- printf "%s:%s" .Values.kubearmorOperator.image.repository .Chart.Version }}
 {{- else }}

--- a/deployments/helm/KubeArmorOperator/templates/ka-config.yaml
+++ b/deployments/helm/KubeArmorOperator/templates/ka-config.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.global.autoDeploy }}
+{{- if .Values.autoDeploy }}
 apiVersion: operator.kubearmor.com/v1
 kind: KubeArmorConfig
 metadata:

--- a/deployments/helm/KubeArmorOperator/values.yaml
+++ b/deployments/helm/KubeArmorOperator/values.yaml
@@ -1,35 +1,33 @@
-global:  
-  autoDeploy: false
-  # operator will deploy pinned images for each application
-  imagePinning: false
+autoDeploy: false
+# operator will deploy pinned images for each application
+imagePinning: false
   
-  # To use existing secret updated {registry.secretName} with your secret name.
-  registry: 
-    secretName: ""
+# To use existing secret updated {registry.secretName} with your secret name.
+registry: 
+  secretName: ""
 
-
-  # pinned images
-  kubearmor:
-    repo: kubearmor
-    images:
-      kubearmor:
-        image: kubearmor
-        tag: stable
-      kubearmorInit:
-        image: kubearmor-init
-        tag: stable
-      kubearmorRelay:
-        image: kubearmor-relay-server
-        tag: latest
-      kubearmorController:
-        image: kubearmor-controller
-        tag: latest
-      kubearmorSnitch:
-        image: kubearmor-snitch
-        tag: latest
-      kubearmorOperator:
-        image: kubearmor-operator
-        tag: latest
+# pinned images
+kubearmor:
+  repo: kubearmor
+  images:
+    kubearmor:
+      image: kubearmor
+      tag: stable
+    kubearmorInit:
+      image: kubearmor-init
+      tag: stable
+    kubearmorRelay:
+      image: kubearmor-relay-server
+      tag: latest
+    kubearmorController:
+      image: kubearmor-controller
+      tag: latest
+    kubearmorSnitch:
+      image: kubearmor-snitch
+      tag: latest
+    kubearmorOperator:
+      image: kubearmor-operator
+      tag: latest
 
 # in case if image pinning is disabled
 kubearmorOperator:


### PR DESCRIPTION
**Purpose of PR?**:

Fixes #

**Does this PR introduce a breaking change?**

**If the changes in this PR are manually verified, list down the scenarios covered:**:
1. Installed operator
```
❯ helm install kubearmor-operator ./deployments/helm/KubeArmorOperator -n kubearmor
NAME: kubearmor-operator
LAST DEPLOYED: Wed Apr 15 23:57:45 2026
NAMESPACE: kubearmor
STATUS: deployed
REVISION: 1
TEST SUITE: None
NOTES:
⚠️  WARNING: Pre-existing pods will not be annotated. Policy enforcement for already existing pods on Apparmor nodes will not work.  
  • To check enforcer present on nodes use:
    ➤ kubectl get nodes -o jsonpath='{range .items[*]}{.metadata.name} {.metadata.labels.kubearmor\.io/enforcer}{"\n"}{end}' 
  • To annotate existing pods use: 
    ➤ helm upgrade --install kubearmor-operator kubearmor/kubearmor-operator -n kubearmor --create-namespace --set annotateExisting=true  
    Our controller will automatically rollout restart deployments during the Helm upgrade to force the admission controller to add annotations.  
  • Alternatively, if you prefer manual control, you can restart your deployments yourself:
    ➤ kubectl rollout restart deployment <deployment> -n <namespace>
ℹ️  Your release is named kubearmor-operator.
💙 Thank you for installing KubeArmor.
```
2. Installed kubearmorConfig
```
❯ k apply -f pkg/KubeArmorOperator/config/samples/sample-config.yml 
kubearmorconfig.operator.kubearmor.com/kubearmorconfig-default created
```
3. Kubearmor pods were running
```
❯ k get po -n kubearmor
NAME                                    READY   STATUS      RESTARTS   AGE
kubearmor-bpf-containerd-2c350-sqzsx    1/1     Running     0          43s
kubearmor-controller-5b5f9c4897-fdkzv   1/1     Running     0          28s
kubearmor-operator-6c45f7b8f-ljv6q      1/1     Running     0          52s
kubearmor-relay-7b78d7db7f-cnknt        1/1     Running     0          41s
kubearmor-snitch-l5vjc-d9nfz            0/1     Completed   0          44s
```

**Additional information for reviewer?** :
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [ ] Bug fix. Fixes #<issue number>
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [X] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Commit has unit tests
- [ ] Commit has integration tests

<!--

The PR title message must follow convention:
`<type>(<scope>): <subject>`.

Where: <br />
- `type` is to define what type of PR is this.
  Most common types are:
    - `feat`      - for new features, not a new feature for build script
    - `fix`       - for bug fixes or improvements, not a fix for build script
    - `chore`     - changes not related to production code
    - `docs`      - changes related to documentation
    - `style`     - formatting, missing semi colons, linting fix etc; no significant production code changes
    - `test`      - adding missing tests, refactoring tests; no production code change
    - `refactor`  - refactoring production code, eg. renaming a variable or function name, there should not be any significant production code changes

- `scope` is a single word that best describes where the changes fit.
    - feature(`monitor`,`enforcer`)
    - test(`tests`, `bdd`)
    - chore(`build`)
- `subject` is a single line brief description of the changes made in the pull request.

-->