### PR TITLE
test(KubeArmor): add unit tests for main package

### DIFF
--- a/KubeArmor/main.go
+++ b/KubeArmor/main.go
@@ -20,6 +20,31 @@ func init() {
 	buildinfo.PrintBuildDetails()
 }
 
+func isKubeArmorBpfMap(name string) bool {
+	return strings.HasPrefix(name, "kubearmor")
+}
+
+func cleanupBpfMaps(bpfMapsDir string, removeFn func(string) error) error {
+	entries, err := os.ReadDir(bpfMapsDir)
+	if err != nil {
+		return err
+	}
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		if isKubeArmorBpfMap(entry.Name()) {
+			path := filepath.Join(bpfMapsDir, entry.Name())
+			if err := removeFn(path); err != nil {
+				kg.Errf("Failed to delete BPF map %s: %v", path, err)
+			} else {
+				kg.Warnf("Deleting existing map %s. This indicates previous cleanup failed", path)
+			}
+		}
+	}
+	return nil
+}
+
 func main() {
 	if os.Geteuid() != 0 {
 		if os.Getenv("KUBEARMOR_UBI") == "" {
@@ -31,28 +56,9 @@ func main() {
 
 	bpfMapsDir := "/sys/fs/bpf/"
 
-	entries, err := os.ReadDir(bpfMapsDir)
-	if err != nil {
+	if err := cleanupBpfMaps(bpfMapsDir, kl.RemoveSafe); err != nil {
 		kg.Errf("Failed to read BPF map directory: %v", err)
 		return
-	}
-
-	for _, entry := range entries {
-		if entry.IsDir() {
-			continue
-		}
-		if strings.HasPrefix(entry.Name(), "kubearmor") {
-			/* This should not be triggered in ideal cases,
-			if this is triggered that means there is incomplete cleanup process
-			from the last installation */
-			path := filepath.Join(bpfMapsDir, entry.Name())
-			err := kl.RemoveSafe(path)
-			if err != nil {
-				kg.Errf("Failed to delete BPF map %s: %v", path, err)
-			} else {
-				kg.Warnf("Deleting existing map %s. This indicates previous cleanup failed", path)
-			}
-		}
 	}
 
 	dir, err := filepath.Abs(filepath.Dir(os.Args[0]))

--- a/KubeArmor/main_test.go
+++ b/KubeArmor/main_test.go
@@ -7,6 +7,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strconv"
 	"testing"
 )
@@ -75,4 +76,85 @@ func TestMain(t *testing.T) {
 	t.Log("[INFO] Executed KubeArmor")
 	main()
 	t.Log("[INFO] Terminated KubeArmor")
+}
+
+func TestBpfMapFiltering(t *testing.T) {
+	cases := []struct {
+		filename string
+		want     bool
+	}{
+		{"kubearmor_events", true},
+		{"kubearmor_policy", true},
+		{"cilium_events", false},
+		{"kube", false},
+		{"", false},
+		{"KubeArmor", false},
+	}
+	for _, tc := range cases {
+		got := isKubeArmorBpfMap(tc.filename)
+		if got != tc.want {
+			t.Errorf("isKubeArmorBpfMap(%q) = %v, want %v", tc.filename, got, tc.want)
+		}
+	}
+}
+
+func TestBpfDirCleanupWithTempDir(t *testing.T) {
+	dir := t.TempDir()
+	files := map[string]bool{
+		"kubearmor_events": true,
+		"kubearmor_policy": true,
+		"cilium_events":    false,
+	}
+	for name := range files {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte("x"), 0600); err != nil {
+			t.Fatalf("failed to create fixture file %q: %v", name, err)
+		}
+	}
+	err := cleanupBpfMaps(dir, os.Remove)
+	if err != nil {
+		t.Fatalf("cleanupBpfMaps returned unexpected error: %v", err)
+	}
+	for name, shouldDelete := range files {
+		_, err := os.Stat(filepath.Join(dir, name))
+		if shouldDelete && err == nil {
+			t.Errorf("%s should have been deleted", name)
+		}
+		if !shouldDelete && err != nil {
+			t.Errorf("%s should still exist", name)
+		}
+	}
+}
+
+func TestBpfDirCleanupSkipsDirectories(t *testing.T) {
+	dir := t.TempDir()
+	sub := filepath.Join(dir, "kubearmor_subdir")
+	if err := os.Mkdir(sub, 0755); err != nil {
+		t.Fatalf("failed to create subdir: %v", err)
+	}
+	err := cleanupBpfMaps(dir, os.Remove)
+	if err != nil {
+		t.Fatalf("cleanupBpfMaps returned unexpected error: %v", err)
+	}
+	if _, err := os.Stat(sub); os.IsNotExist(err) {
+		t.Error("subdir was incorrectly removed")
+	}
+}
+
+func TestBpfDirCleanupMissingDir(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.RemoveAll(dir); err != nil {
+		t.Fatalf("failed to remove temp dir: %v", err)
+	}
+	err := cleanupBpfMaps(dir, os.Remove)
+	if err == nil {
+		t.Error("expected error for missing dir")
+	}
+}
+
+func TestNonRootWithoutUBI(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("must run as non-root")
+	}
+	t.Setenv("KUBEARMOR_UBI", "")
+	main()
 }


### PR DESCRIPTION
**Purpose of PR?**:
Increase unit test coverage for the main package from 16.7% to 51.5%.

Fixes #

**Does this PR introduce a breaking change?**
No

**If the changes in this PR are manually verified, list down the scenarios covered:**
- Non-root execution without KUBEARMOR_UBI set returns early correctly
- BPF map filename filtering correctly identifies kubearmor-prefixed files via isKubeArmorBpfMap helper
- BPF cleanup loop deletes kubearmor-prefixed files and preserves others
- BPF cleanup loop skips subdirectories even with kubearmor prefix
- BPF cleanup returns error on missing directory
- filepath.Abs on the executable path returns a valid absolute path
- os.Chdir to a valid directory succeeds without error

**Additional information for reviewer?**
- Extracted BPF map predicate into isKubeArmorBpfMap and cleanup logic into cleanupBpfMaps to make production code directly testable
- cfg.LoadConfig() and core.KubeArmor() are not covered as they require a full KubeArmor environment with root and a mounted BPF filesystem. Those are left for integration tests.

**Screenshots**
<img width="1513" height="160" alt="Screenshot from 2026-04-22 11-09-22" src="https://github.com/user-attachments/assets/b4e14cb0-25c2-424b-9b8a-14af589b34fb" />


**Checklist:**
- [ ] Bug fix. Fixes #<issue number>
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] PR Title follows the convention of `<type>(<scope>): <subject>`
- [x] Commit has unit tests
- [ ] Commit has integration tests