### PR TITLE
ci: upgrade checkout action to v4

### DIFF
--- a/.github/workflows/ci-latest-release.yml
+++ b/.github/workflows/ci-latest-release.yml
@@ -35,7 +35,7 @@ jobs:
       kubearmor: ${{ steps.filter.outputs.kubearmor}}
       controller: ${{ steps.filter.outputs.controller }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: dorny/paths-filter@v2
       id: filter
       with:
@@ -54,7 +54,7 @@ jobs:
       id-token: write
     timeout-minutes: 150
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: true
 
@@ -169,7 +169,7 @@ jobs:
       id-token: write
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: main
 
@@ -242,7 +242,7 @@ jobs:
       id-token: write
     timeout-minutes: 150    
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Install regctl
         run: |

--- a/.github/workflows/ci-marketplace-release.yml
+++ b/.github/workflows/ci-marketplace-release.yml
@@ -14,7 +14,7 @@ jobs:
   certify-images-on-redhat:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: install latest preflight
         run: |
@@ -61,7 +61,7 @@ jobs:
   publish-images-to-ecr:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v6
@@ -94,7 +94,7 @@ jobs:
   publish-images-to-ocir:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: login to ocir registry
         run: |
@@ -121,7 +121,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: ["publish-images-to-ecr"]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: azure/setup-helm@v3
 
       - name: Configure AWS credentials
@@ -177,7 +177,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: ["publish-images-to-ocir"]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: azure/setup-helm@v3
 
       - name: Login to OCI Helm
@@ -228,7 +228,7 @@ jobs:
     permissions:
       issues: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Create marketplace release issue
         run: |
           RELEASE=`cat STABLE-RELEASE`

--- a/.github/workflows/ci-merge-coverage.yaml
+++ b/.github/workflows/ci-merge-coverage.yaml
@@ -44,7 +44,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: true
           

--- a/.github/workflows/ci-multiubuntu-push.yml
+++ b/.github/workflows/ci-multiubuntu-push.yml
@@ -19,7 +19,7 @@ jobs:
       id-token: write
     timeout-minutes: 90
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2

--- a/.github/workflows/ci-network-tests.yml
+++ b/.github/workflows/ci-network-tests.yml
@@ -40,7 +40,7 @@ jobs:
           - os: bpflsm
             runtime: crio
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: true
 

--- a/.github/workflows/ci-operator-release.yaml
+++ b/.github/workflows/ci-operator-release.yaml
@@ -35,7 +35,7 @@ jobs:
       id-token: write
     timeout-minutes: 90
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: actions/setup-go@v5
         with:
@@ -124,7 +124,7 @@ jobs:
       #     regctl image copy kubearmor/kubearmor-operator:${{ steps.vars.outputs.tag }} public.ecr.aws/k9v9d5v2/kubearmor/kubearmor-operator:${{ steps.vars.outputs.tag }} --digest-tags
       #     regctl image copy kubearmor/kubearmor-snitch:${{ steps.vars.outputs.tag }} public.ecr.aws/k9v9d5v2/kubearmor/kubearmor-snitch:${{ steps.vars.outputs.tag }} --digest-tags
           
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: main
       

--- a/.github/workflows/ci-stable-release.yml
+++ b/.github/workflows/ci-stable-release.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Install regctl
         run: |
@@ -61,7 +61,7 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Update Chart.yaml
         id: update

--- a/.github/workflows/ci-systemd-release.yml
+++ b/.github/workflows/ci-systemd-release.yml
@@ -53,7 +53,7 @@ jobs:
               core.setOutput('release_tag', version);
             }
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: true
           fetch-depth: 0

--- a/.github/workflows/ci-test-controllers.yml
+++ b/.github/workflows/ci-test-controllers.yml
@@ -23,7 +23,7 @@ jobs:
         os: [oracle-vm-16cpu-64gb-x86-64]
         runtime: ["containerd"]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: true
 

--- a/.github/workflows/ci-test-ginkgo.yml
+++ b/.github/workflows/ci-test-ginkgo.yml
@@ -37,7 +37,7 @@ jobs:
         os: [oracle-vm-16cpu-64gb-x86-64]
         runtime: ["containerd", "crio"]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: true
 

--- a/.github/workflows/ci-test-go.yml
+++ b/.github/workflows/ci-test-go.yml
@@ -25,7 +25,7 @@ jobs:
   go-fmt:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: actions/setup-go@v5
         with:
@@ -38,7 +38,7 @@ jobs:
   go-lint:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: actions/setup-go@v5
         with:
@@ -52,7 +52,7 @@ jobs:
   go-lint-tests:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: actions/setup-go@v5
         with:
@@ -66,7 +66,7 @@ jobs:
   go-sec:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: actions/setup-go@v5
         with:
@@ -79,7 +79,7 @@ jobs:
   go-vuln:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: actions/setup-go@v5
         with:
@@ -92,7 +92,7 @@ jobs:
   go-test:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: actions/setup-go@v5
         with:
@@ -105,7 +105,7 @@ jobs:
   license:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Check License Header
         uses: apache/skywalking-eyes@ed436a5593c63a25f394ea29da61b0ac3731a9fe

--- a/.github/workflows/ci-test-helm-charts.yml
+++ b/.github/workflows/ci-test-helm-charts.yml
@@ -20,7 +20,7 @@ jobs:
     name: Helm Chart Tests / ubuntu 22.04
     runs-on: "ubuntu-22.04"
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: true
 

--- a/.github/workflows/ci-test-operator.yaml
+++ b/.github/workflows/ci-test-operator.yaml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: actions/setup-go@v5
         with:

--- a/.github/workflows/ci-test-systemd.yml
+++ b/.github/workflows/ci-test-systemd.yml
@@ -24,7 +24,7 @@ jobs:
     name: Test KubeArmor in Systemd Mode
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: true
 

--- a/.github/workflows/ci-test-ubi-image.yml
+++ b/.github/workflows/ci-test-ubi-image.yml
@@ -38,7 +38,7 @@ jobs:
         runtime: ["crio"]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: true
 

--- a/.github/workflows/ci-trivy-scan.yaml
+++ b/.github/workflows/ci-trivy-scan.yaml
@@ -28,7 +28,7 @@ jobs:
     timeout-minutes: 150
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: true
 


### PR DESCRIPTION
## Summary
- upgrade workflow uses of actions/checkout from v3 to v4
- keep the change limited to workflow action version updates

## Testing
- parsed all workflow YAML files locally
- verified no actions/checkout@v3 references remain under .github/workflows