### PR TITLE
fix(operator): respect globalNodeSelector in Snitch job deployment (#2469)

### DIFF
--- a/pkg/KubeArmorOperator/internal/controller/cluster.go
+++ b/pkg/KubeArmorOperator/internal/controller/cluster.go
@@ -259,7 +259,7 @@ func (clusterWatcher *ClusterWatcher) WatchNodes() {
 			if node, ok := obj.(*corev1.Node); ok {
 				runtime := node.Status.NodeInfo.ContainerRuntimeVersion
 				runtime = strings.Split(runtime, ":")[0]
-				if val, ok := node.Labels[common.OsLabel]; ok && val == "linux" {
+				if val, ok := node.Labels[common.OsLabel]; ok && val == "linux" && nodeMatchesGlobalNodeSelector(node.Labels) {
 					log.Infof("Installing snitch on node %s", node.Name)
 					snitchJob, err := clusterWatcher.Client.BatchV1().Jobs(common.Namespace).Create(context.Background(), deploySnitch(node.Name, runtime), v1.CreateOptions{})
 					if err != nil {
@@ -283,7 +283,7 @@ func (clusterWatcher *ClusterWatcher) WatchNodes() {
 						runtime := node.Status.NodeInfo.ContainerRuntimeVersion
 						runtime = strings.Split(runtime, ":")[0]
 						clusterWatcher.Log.Infof("Node might have been restarted, redeploying snitch ")
-						if val, ok := node.Labels[common.OsLabel]; ok && val == "linux" {
+						if val, ok := node.Labels[common.OsLabel]; ok && val == "linux" && nodeMatchesGlobalNodeSelector(node.Labels) {
 							log.Infof("Installing snitch on node %s", node.Name)
 							snitchJob, err := clusterWatcher.Client.BatchV1().Jobs(common.Namespace).Create(context.Background(), deploySnitch(node.Name, runtime), v1.CreateOptions{})
 							if err != nil {
@@ -1011,6 +1011,21 @@ func AddOrUpdateEnv(dst *[]corev1.EnvVar, src []corev1.EnvVar) {
 			return e.Name == val
 		})
 	}
+}
+
+// nodeMatchesGlobalNodeSelector returns true if the node's labels satisfy all
+// entries in common.GlobalNodeSelectors (ignoring entries marked for deletion
+// with value "-").
+func nodeMatchesGlobalNodeSelector(nodeLabels map[string]string) bool {
+	for k, v := range common.GlobalNodeSelectors {
+		if v == "-" {
+			continue
+		}
+		if nodeLabels[k] != v {
+			return false
+		}
+	}
+	return true
 }
 
 func RemoveDeletedEntriesForNodeSelector(ns map[string]string) {

--- a/pkg/KubeArmorOperator/internal/controller/cluster_test.go
+++ b/pkg/KubeArmorOperator/internal/controller/cluster_test.go
@@ -184,3 +184,99 @@ func TestAddorUpdateNodeSelector(t *testing.T) {
 		})
 	})
 }
+
+func TestNodeMatchesGlobalNodeSelector(t *testing.T) {
+	tests := []struct {
+		name                string
+		nodeLabels          map[string]string
+		globalSelectors     map[string]string
+		expected            bool
+	}{
+		{
+			name:            "empty global selectors matches any node",
+			nodeLabels:      map[string]string{"key1": "value1"},
+			globalSelectors: map[string]string{},
+			expected:        true,
+		},
+		{
+			name:            "single matching label",
+			nodeLabels:      map[string]string{"env": "prod"},
+			globalSelectors: map[string]string{"env": "prod"},
+			expected:        true,
+		},
+		{
+			name:            "single non-matching label",
+			nodeLabels:      map[string]string{"env": "dev"},
+			globalSelectors: map[string]string{"env": "prod"},
+			expected:        false,
+		},
+		{
+			name:            "multiple matching labels",
+			nodeLabels:      map[string]string{"env": "prod", "zone": "us-east"},
+			globalSelectors: map[string]string{"env": "prod", "zone": "us-east"},
+			expected:        true,
+		},
+		{
+			name:            "missing key in node labels",
+			nodeLabels:      map[string]string{"env": "prod"},
+			globalSelectors: map[string]string{"env": "prod", "zone": "us-east"},
+			expected:        false,
+		},
+		{
+			name:            "extra node labels should not affect",
+			nodeLabels:      map[string]string{"env": "prod", "zone": "us-east", "extra": "x"},
+			globalSelectors: map[string]string{"env": "prod"},
+			expected:        true,
+		},
+		{
+			name:            "ignore deletion marker",
+			nodeLabels:      map[string]string{"env": "prod", "zone": "us-east"},
+			globalSelectors: map[string]string{"env": "prod", "zone": "-"},
+			expected:        true,
+		},
+		{
+			name:            "all deletion markers",
+			nodeLabels:      map[string]string{"env": "prod"},
+			globalSelectors: map[string]string{"env": "-", "zone": "-"},
+			expected:        true,
+		},
+		{
+			name:            "empty node labels with constraints",
+			nodeLabels:      map[string]string{},
+			globalSelectors: map[string]string{"env": "prod"},
+			expected:        false,
+		},
+		{
+			name:            "both empty",
+			nodeLabels:      map[string]string{},
+			globalSelectors: map[string]string{},
+			expected:        true,
+		},
+		{
+			name:            "case sensitive key mismatch",
+			nodeLabels:      map[string]string{"ENV": "prod"},
+			globalSelectors: map[string]string{"env": "prod"},
+			expected:        false,
+		},
+		{
+			name:            "case sensitive value mismatch",
+			nodeLabels:      map[string]string{"env": "Prod"},
+			globalSelectors: map[string]string{"env": "prod"},
+			expected:        false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			original := common.GlobalNodeSelectors
+			defer func() {
+				common.GlobalNodeSelectors = original
+			}()
+
+			common.GlobalNodeSelectors = tt.globalSelectors
+
+			result := nodeMatchesGlobalNodeSelector(tt.nodeLabels)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}


### PR DESCRIPTION
**Purpose of PR?**:

Fixes #2469

The Snitch job was previously deployed on all `kubernetes.io/os=linux` nodes without considering `globalNodeSelector`. This caused inconsistent behavior compared to other components (DaemonSet, Relay, Controller), which already respect `globalNodeSelector`.

This PR ensures that Snitch jobs are only deployed on nodes that satisfy both:
- `kubernetes.io/os=linux`
- `common.GlobalNodeSelectors`


**What changed?**

- Added `nodeMatchesGlobalNodeSelector` helper to validate node labels against `common.GlobalNodeSelectors`
  - Ignores entries marked for deletion (`"-"`)
- Updated `WatchNodes()` logic to include global node selector filtering before deploying/redeploying Snitch jobs
- Added unit tests for `nodeMatchesGlobalNodeSelector` covering:
  - matching and non-matching labels
  - missing keys
  - deletion markers (`"-"`)
  - empty selectors
  - case sensitivity


**Does this PR introduce a breaking change?**

No. This change aligns Snitch job behavior with existing components and improves consistency.


**Testing**

- Unit tests added in `cluster_test.go`
- Verified that:
  - Snitch is deployed only on nodes matching both OS and global selector
  - Existing behavior remains unchanged when `globalNodeSelector` is empty


**Additional information for reviewer**

This change brings Snitch job scheduling behavior in line with other operator components that already respect `globalNodeSelector`.

**Checklist:**
- [x] Bug fix. Fixes #2469
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [x] Commit has unit tests
- [ ] Commit has integration tests

<!--

The PR title message must follow convention:
`<type>(<scope>): <subject>`.

Where: <br />
- `type` is to define what type of PR is this.
  Most common types are:
    - `feat`      - for new features, not a new feature for build script
    - `fix`       - for bug fixes or improvements, not a fix for build script
    - `chore`     - changes not related to production code
    - `docs`      - changes related to documentation
    - `style`     - formatting, missing semi colons, linting fix etc; no significant production code changes
    - `test`      - adding missing tests, refactoring tests; no production code change
    - `refactor`  - refactoring production code, eg. renaming a variable or function name, there should not be any significant production code changes

- `scope` is a single word that best describes where the changes fit.
    - feature(`monitor`,`enforcer`)
    - test(`tests`, `bdd`)
    - chore(`build`)
- `subject` is a single line brief description of the changes made in the pull request.

-->