### PR TITLE
test(state): add unit tests for stateagent and data modules (#2130)

### DIFF
--- a/KubeArmor/state/data_test.go
+++ b/KubeArmor/state/data_test.go
@@ -1,0 +1,236 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Authors of KubeArmor
+
+package state
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	tp "github.com/kubearmor/KubeArmor/KubeArmor/types"
+)
+
+// ── PushContainerEvent ────────────────────────────────────────────────────────
+
+func TestPushContainerEvent_EmptyID_NoOp(t *testing.T) {
+	sa := newTestStateAgent()
+	sa.PushContainerEvent(tp.Container{NamespaceName: "ns"}, EventAdded)
+	if len(sa.KubeArmorNamespaces) != 0 {
+		t.Error("namespace should not be created for empty container ID")
+	}
+}
+
+func TestPushContainerEvent_Add_CreatesNamespace(t *testing.T) {
+	sa := newTestStateAgent()
+	sa.PushContainerEvent(testContainer("c1", "container1", "ns1"), EventAdded)
+
+	ns, ok := sa.KubeArmorNamespaces["ns1"]
+	if !ok {
+		t.Fatal("namespace ns1 should have been created")
+	}
+	if ns.ContainerCount != 1 {
+		t.Errorf("expected ContainerCount=1, got %d", ns.ContainerCount)
+	}
+	if ns.KubearmorFilePosture != "audit" {
+		t.Errorf("expected default file posture 'audit', got %s", ns.KubearmorFilePosture)
+	}
+}
+
+func TestPushContainerEvent_Add_IncrementsExistingNamespace(t *testing.T) {
+	sa := newTestStateAgent()
+	sa.PushContainerEvent(testContainer("c1", "c1", "ns1"), EventAdded)
+	sa.PushContainerEvent(testContainer("c2", "c2", "ns1"), EventAdded)
+
+	ns := sa.KubeArmorNamespaces["ns1"]
+	if ns.ContainerCount != 2 {
+		t.Errorf("expected ContainerCount=2, got %d", ns.ContainerCount)
+	}
+}
+
+func TestPushContainerEvent_Delete_DecrementsCount(t *testing.T) {
+	sa := newTestStateAgent()
+	sa.PushContainerEvent(testContainer("c1", "c1", "ns1"), EventAdded)
+	sa.PushContainerEvent(testContainer("c2", "c2", "ns1"), EventAdded)
+	sa.PushContainerEvent(testContainer("c1", "c1", "ns1"), EventDeleted)
+
+	ns, ok := sa.KubeArmorNamespaces["ns1"]
+	if !ok {
+		t.Fatal("namespace ns1 should still exist")
+	}
+	if ns.ContainerCount != 1 {
+		t.Errorf("expected ContainerCount=1, got %d", ns.ContainerCount)
+	}
+}
+
+func TestPushContainerEvent_Delete_RemovesNamespaceWhenEmpty(t *testing.T) {
+	sa := newTestStateAgent()
+	sa.PushContainerEvent(testContainer("c1", "c1", "ns1"), EventAdded)
+	sa.PushContainerEvent(testContainer("c1", "c1", "ns1"), EventDeleted)
+
+	if _, ok := sa.KubeArmorNamespaces["ns1"]; ok {
+		t.Error("namespace ns1 should be removed when container count reaches 0")
+	}
+}
+
+func TestPushContainerEvent_Delete_UnknownNamespace_NoOp(t *testing.T) {
+	sa := newTestStateAgent()
+	// deleting from a namespace that was never added must not panic
+	sa.PushContainerEvent(testContainer("c1", "c1", "ghost"), EventDeleted)
+}
+
+func TestPushContainerEvent_NilChans_NoSend(t *testing.T) {
+	sa := newTestStateAgent()
+	sa.StateEventChans = nil
+	// namespace bookkeeping should complete without panicking
+	sa.PushContainerEvent(testContainer("c1", "c1", "ns1"), EventAdded)
+}
+
+func TestPushContainerEvent_SendsToRegisteredChan(t *testing.T) {
+	sa := newTestStateAgent()
+	uid, ch := sa.addStateEventChan()
+	defer sa.removeStateEventChan(uid)
+
+	// Pre-seed the namespace so PushContainerEvent doesn't also emit a namespace
+	// event that would appear before the container event in the channel.
+	sa.KubeArmorNamespaces["ns1"] = tp.Namespace{Name: "ns1", ContainerCount: 1}
+
+	sa.PushContainerEvent(testContainer("c1", "mycontainer", "ns1"), EventAdded)
+
+	select {
+	case evt := <-ch:
+		if evt.Kind != KindContainer {
+			t.Errorf("expected kind=%s, got %s", KindContainer, evt.Kind)
+		}
+		if evt.Type != EventAdded {
+			t.Errorf("expected type=%s, got %s", EventAdded, evt.Type)
+		}
+		if evt.Name != "mycontainer" {
+			t.Errorf("expected name=mycontainer, got %s", evt.Name)
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("timeout waiting for container event on channel")
+	}
+}
+
+func TestPushContainerEvent_FullBuffer_DropsGracefully(t *testing.T) {
+	sa := newTestStateAgent()
+	uid, _ := sa.addStateEventChan()
+	defer sa.removeStateEventChan(uid)
+
+	// Fill the buffer (stateEventBufferSize = 25) then push one more.
+	for i := 0; i < stateEventBufferSize; i++ {
+		sa.PushContainerEvent(testContainer("c1", "c1", "ns1"), EventAdded)
+	}
+	sa.PushContainerEvent(testContainer("c2", "c2", "ns2"), EventAdded)
+}
+
+// ── PushNodeEvent ─────────────────────────────────────────────────────────────
+
+func TestPushNodeEvent_EmptyName_NoOp(t *testing.T) {
+	sa := newTestStateAgent()
+	uid, ch := sa.addStateEventChan()
+	defer sa.removeStateEventChan(uid)
+
+	sa.PushNodeEvent(tp.Node{}, EventAdded)
+
+	select {
+	case <-ch:
+		t.Error("no event should be sent for empty node name")
+	case <-time.After(100 * time.Millisecond):
+		// correct: nothing was sent
+	}
+}
+
+func TestPushNodeEvent_NilChans_NoSend(t *testing.T) {
+	sa := newTestStateAgent()
+	sa.StateEventChans = nil
+	// must not panic
+	sa.PushNodeEvent(tp.Node{NodeName: "n1"}, EventAdded)
+}
+
+func TestPushNodeEvent_SendsToRegisteredChan(t *testing.T) {
+	sa := newTestStateAgent()
+	uid, ch := sa.addStateEventChan()
+	defer sa.removeStateEventChan(uid)
+
+	sa.PushNodeEvent(tp.Node{NodeName: "worker-1"}, EventAdded)
+
+	select {
+	case evt := <-ch:
+		if evt.Kind != KindNode {
+			t.Errorf("expected kind=%s, got %s", KindNode, evt.Kind)
+		}
+		if evt.Name != "worker-1" {
+			t.Errorf("expected name=worker-1, got %s", evt.Name)
+		}
+		var decoded tp.Node
+		if err := json.Unmarshal(evt.Object, &decoded); err != nil {
+			t.Fatalf("failed to unmarshal node: %v", err)
+		}
+		if decoded.NodeName != "worker-1" {
+			t.Errorf("decoded node name mismatch: %s", decoded.NodeName)
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("timeout waiting for node event")
+	}
+}
+
+func TestPushNodeEvent_FullBuffer_DropsGracefully(t *testing.T) {
+	sa := newTestStateAgent()
+	uid, _ := sa.addStateEventChan()
+	defer sa.removeStateEventChan(uid)
+
+	for i := 0; i < stateEventBufferSize; i++ {
+		sa.PushNodeEvent(tp.Node{NodeName: "n1"}, EventAdded)
+	}
+	// extra push hits the default (drop) branch
+	sa.PushNodeEvent(tp.Node{NodeName: "n1"}, EventAdded)
+}
+
+// ── PushNamespaceEvent ────────────────────────────────────────────────────────
+
+func TestPushNamespaceEvent_NilChans_NoSend(t *testing.T) {
+	sa := newTestStateAgent()
+	sa.StateEventChans = nil
+	// must not panic
+	sa.PushNamespaceEvent(tp.Namespace{Name: "ns1"}, EventAdded)
+}
+
+func TestPushNamespaceEvent_SendsToRegisteredChan(t *testing.T) {
+	sa := newTestStateAgent()
+	uid, ch := sa.addStateEventChan()
+	defer sa.removeStateEventChan(uid)
+
+	sa.PushNamespaceEvent(tp.Namespace{Name: "my-ns", KubearmorFilePosture: "block"}, EventAdded)
+
+	select {
+	case evt := <-ch:
+		if evt.Kind != KindNamespace {
+			t.Errorf("expected kind=%s, got %s", KindNamespace, evt.Kind)
+		}
+		if evt.Name != "my-ns" {
+			t.Errorf("expected name=my-ns, got %s", evt.Name)
+		}
+		var decoded tp.Namespace
+		if err := json.Unmarshal(evt.Object, &decoded); err != nil {
+			t.Fatalf("unmarshal error: %v", err)
+		}
+		if decoded.KubearmorFilePosture != "block" {
+			t.Errorf("expected file posture 'block', got %s", decoded.KubearmorFilePosture)
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("timeout waiting for namespace event")
+	}
+}
+
+func TestPushNamespaceEvent_FullBuffer_DropsGracefully(t *testing.T) {
+	sa := newTestStateAgent()
+	uid, _ := sa.addStateEventChan()
+	defer sa.removeStateEventChan(uid)
+
+	for i := 0; i < stateEventBufferSize; i++ {
+		sa.PushNamespaceEvent(tp.Namespace{Name: "ns1"}, EventAdded)
+	}
+	sa.PushNamespaceEvent(tp.Namespace{Name: "ns1"}, EventAdded)
+}

--- a/KubeArmor/state/stateAgent_test.go
+++ b/KubeArmor/state/stateAgent_test.go
@@ -1,0 +1,400 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Authors of KubeArmor
+
+package state
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+	"testing"
+	"time"
+
+	tp "github.com/kubearmor/KubeArmor/KubeArmor/types"
+	pb "github.com/kubearmor/KubeArmor/protobuf"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/protobuf/types/known/emptypb"
+)
+
+// ── gRPC mock helpers ────────────────────────────────────────────────────────
+
+// baseServerStream satisfies grpc.ServerStream with no-op stubs.
+type baseServerStream struct {
+	ctx context.Context
+}
+
+func (b *baseServerStream) SetHeader(metadata.MD) error  { return nil }
+func (b *baseServerStream) SendHeader(metadata.MD) error { return nil }
+func (b *baseServerStream) SetTrailer(metadata.MD)       {}
+func (b *baseServerStream) Context() context.Context     { return b.ctx }
+func (b *baseServerStream) SendMsg(interface{}) error    { return nil }
+func (b *baseServerStream) RecvMsg(interface{}) error    { return nil }
+
+// mockWatchStateServer records StateEvents sent through WatchState.
+type mockWatchStateServer struct {
+	grpc.ServerStream
+	base   *baseServerStream
+	mu     sync.Mutex
+	events []*pb.StateEvent
+	sendFn func(*pb.StateEvent) error // optional override
+}
+
+func newMockWatchServer(ctx context.Context) *mockWatchStateServer {
+	b := &baseServerStream{ctx: ctx}
+	return &mockWatchStateServer{ServerStream: b, base: b}
+}
+
+func (m *mockWatchStateServer) Send(e *pb.StateEvent) error {
+	if m.sendFn != nil {
+		return m.sendFn(e)
+	}
+	m.mu.Lock()
+	m.events = append(m.events, e)
+	m.mu.Unlock()
+	return nil
+}
+
+func (m *mockWatchStateServer) Context() context.Context { return m.base.ctx }
+
+func (m *mockWatchStateServer) received() []*pb.StateEvent {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	cp := make([]*pb.StateEvent, len(m.events))
+	copy(cp, m.events)
+	return cp
+}
+
+// mockGetStateServer records StateEvents batches sent through GetState.
+type mockGetStateServer struct {
+	grpc.ServerStream
+	base   *baseServerStream
+	mu     sync.Mutex
+	calls  []*pb.StateEvents
+	sendFn func(*pb.StateEvents) error
+}
+
+func newMockGetServer(ctx context.Context) *mockGetStateServer {
+	b := &baseServerStream{ctx: ctx}
+	return &mockGetStateServer{ServerStream: b, base: b}
+}
+
+func (m *mockGetStateServer) Send(e *pb.StateEvents) error {
+	if m.sendFn != nil {
+		return m.sendFn(e)
+	}
+	m.mu.Lock()
+	m.calls = append(m.calls, e)
+	m.mu.Unlock()
+	return nil
+}
+
+func (m *mockGetStateServer) Context() context.Context { return m.base.ctx }
+
+// ── shared fixtures (used by both test files) ─────────────────────────────────
+
+func newTestStateAgent() *StateAgent {
+	node := &tp.Node{NodeName: "test-node"}
+	nodeLock := &sync.RWMutex{}
+	containers := map[string]tp.Container{}
+	containersLock := &sync.RWMutex{}
+	return NewStateAgent(node, nodeLock, containers, containersLock)
+}
+
+func testContainer(id, name, ns string) tp.Container {
+	return tp.Container{
+		ContainerID:   id,
+		ContainerName: name,
+		NamespaceName: ns,
+	}
+}
+
+// ── NewStateAgent ─────────────────────────────────────────────────────────────
+
+func TestNewStateAgent_FieldsInitialized(t *testing.T) {
+	sa := newTestStateAgent()
+
+	if !sa.Running {
+		t.Error("expected Running=true")
+	}
+	if sa.StateEventChans == nil {
+		t.Error("StateEventChans must not be nil")
+	}
+	if sa.StateEventChansLock == nil {
+		t.Error("StateEventChansLock must not be nil")
+	}
+	if sa.Node == nil || sa.Node.NodeName != "test-node" {
+		t.Error("Node not set correctly")
+	}
+	if sa.Containers == nil {
+		t.Error("Containers must not be nil")
+	}
+	if sa.KubeArmorNamespaces == nil {
+		t.Error("KubeArmorNamespaces must not be nil")
+	}
+}
+
+// ── addStateEventChan / removeStateEventChan ──────────────────────────────────
+
+func TestAddStateEventChan_ReturnsUIDAndChan(t *testing.T) {
+	sa := newTestStateAgent()
+	uid, ch := sa.addStateEventChan()
+
+	if uid == "" {
+		t.Error("expected non-empty UID")
+	}
+	if ch == nil {
+		t.Error("expected non-nil channel")
+	}
+	if _, ok := sa.StateEventChans[uid]; !ok {
+		t.Errorf("UID %s not found in StateEventChans", uid)
+	}
+}
+
+func TestAddStateEventChan_MultipleCalls_UniqueUIDs(t *testing.T) {
+	sa := newTestStateAgent()
+	uid1, _ := sa.addStateEventChan()
+	uid2, _ := sa.addStateEventChan()
+
+	if uid1 == uid2 {
+		t.Error("expected unique UIDs for each call")
+	}
+	if len(sa.StateEventChans) != 2 {
+		t.Errorf("expected 2 channels, got %d", len(sa.StateEventChans))
+	}
+}
+
+func TestRemoveStateEventChan_DeletesEntry(t *testing.T) {
+	sa := newTestStateAgent()
+	uid, _ := sa.addStateEventChan()
+	sa.removeStateEventChan(uid)
+
+	if _, ok := sa.StateEventChans[uid]; ok {
+		t.Errorf("expected UID %s to be removed", uid)
+	}
+}
+
+// ── DestroyStateAgent ─────────────────────────────────────────────────────────
+
+func TestDestroyStateAgent_SetsRunningFalse(t *testing.T) {
+	sa := newTestStateAgent()
+	done := make(chan error, 1)
+	go func() { done <- sa.DestroyStateAgent() }()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("DestroyStateAgent did not complete in time")
+	}
+
+	if sa.Running {
+		t.Error("expected Running=false after Destroy")
+	}
+}
+
+// ── WatchState ────────────────────────────────────────────────────────────────
+
+func TestWatchState_ContextCancel_ReturnsNil(t *testing.T) {
+	sa := newTestStateAgent()
+	ctx, cancel := context.WithCancel(context.Background())
+	srv := newMockWatchServer(ctx)
+
+	done := make(chan error, 1)
+	go func() { done <- sa.WatchState(&emptypb.Empty{}, srv) }()
+
+	time.Sleep(20 * time.Millisecond)
+	cancel()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Errorf("expected nil error on context cancel, got %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("WatchState did not return after context cancellation")
+	}
+}
+
+func TestWatchState_DeliverEvent_ThenCancel(t *testing.T) {
+	sa := newTestStateAgent()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	srv := newMockWatchServer(ctx)
+
+	done := make(chan error, 1)
+	go func() { done <- sa.WatchState(&emptypb.Empty{}, srv) }()
+
+	// Wait until WatchState has registered its channel.
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		sa.StateEventChansLock.RLock()
+		n := len(sa.StateEventChans)
+		sa.StateEventChansLock.RUnlock()
+		if n > 0 {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	sa.PushNodeEvent(tp.Node{NodeName: "worker-1"}, EventAdded)
+
+	// Wait for the event to reach the mock server.
+	deadline = time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		if len(srv.received()) > 0 {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	cancel()
+	<-done
+
+	events := srv.received()
+	if len(events) == 0 {
+		t.Fatal("expected at least one event delivered via WatchState")
+	}
+	if events[0].Kind != KindNode {
+		t.Errorf("expected KindNode, got %s", events[0].Kind)
+	}
+}
+
+func TestWatchState_StopsWhenRunningFalse(t *testing.T) {
+	sa := newTestStateAgent()
+	srv := newMockWatchServer(context.Background())
+
+	done := make(chan error, 1)
+	go func() { done <- sa.WatchState(&emptypb.Empty{}, srv) }()
+
+	time.Sleep(20 * time.Millisecond)
+	sa.Running = false
+
+	// Push a dummy event so the select fires and the loop condition is re-evaluated.
+	sa.StateEventChansLock.RLock()
+	for _, ch := range sa.StateEventChans {
+		ch <- &pb.StateEvent{Kind: KindNode, Type: EventAdded, Name: "dummy"}
+	}
+	sa.StateEventChansLock.RUnlock()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("WatchState did not stop after Running=false")
+	}
+}
+
+// ── GetState ──────────────────────────────────────────────────────────────────
+
+func TestGetState_SendsNodeAndContainers(t *testing.T) {
+	sa := newTestStateAgent()
+	sa.Containers["abc123"] = tp.Container{
+		ContainerID:   "abc123",
+		ContainerName: "web",
+		NamespaceName: "production",
+	}
+	sa.KubeArmorNamespaces["production"] = tp.Namespace{Name: "production", ContainerCount: 1}
+
+	srv := newMockGetServer(context.Background())
+	if err := sa.GetState(&emptypb.Empty{}, srv); err != nil {
+		t.Fatalf("unexpected error from GetState: %v", err)
+	}
+
+	srv.mu.Lock()
+	defer srv.mu.Unlock()
+
+	if len(srv.calls) == 0 {
+		t.Fatal("expected at least one Send call from GetState")
+	}
+	kinds := countKinds(srv.calls[0].StateEvents)
+	if kinds[KindNode] != 1 {
+		t.Errorf("expected 1 node event, got %d", kinds[KindNode])
+	}
+	if kinds[KindContainer] != 1 {
+		t.Errorf("expected 1 container event, got %d", kinds[KindContainer])
+	}
+	if kinds[KindNamespace] != 1 {
+		t.Errorf("expected 1 namespace event, got %d", kinds[KindNamespace])
+	}
+}
+
+func TestGetState_EmptyContainers_OnlyNodeSent(t *testing.T) {
+	sa := newTestStateAgent()
+	srv := newMockGetServer(context.Background())
+
+	if err := sa.GetState(&emptypb.Empty{}, srv); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	srv.mu.Lock()
+	defer srv.mu.Unlock()
+
+	if len(srv.calls) == 0 {
+		t.Fatal("expected a Send call")
+	}
+	events := srv.calls[0].StateEvents
+	if len(events) != 1 || events[0].Kind != KindNode {
+		t.Errorf("expected exactly 1 node event, got %v", events)
+	}
+}
+
+func TestGetState_NodeDataMarshaled(t *testing.T) {
+	sa := newTestStateAgent()
+	srv := newMockGetServer(context.Background())
+
+	if err := sa.GetState(&emptypb.Empty{}, srv); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	srv.mu.Lock()
+	defer srv.mu.Unlock()
+
+	nodeEvt := srv.calls[0].StateEvents[0]
+	var node tp.Node
+	if err := json.Unmarshal(nodeEvt.Object, &node); err != nil {
+		t.Fatalf("failed to unmarshal node: %v", err)
+	}
+	if node.NodeName != "test-node" {
+		t.Errorf("expected NodeName=test-node, got %s", node.NodeName)
+	}
+}
+
+func TestGetState_MultipleContainersAndNamespaces(t *testing.T) {
+	sa := newTestStateAgent()
+	sa.Containers["c1"] = tp.Container{ContainerID: "c1", ContainerName: "alpha", NamespaceName: "ns-a"}
+	sa.Containers["c2"] = tp.Container{ContainerID: "c2", ContainerName: "beta", NamespaceName: "ns-b"}
+	sa.KubeArmorNamespaces["ns-a"] = tp.Namespace{Name: "ns-a", ContainerCount: 1}
+	sa.KubeArmorNamespaces["ns-b"] = tp.Namespace{Name: "ns-b", ContainerCount: 1}
+
+	srv := newMockGetServer(context.Background())
+	if err := sa.GetState(&emptypb.Empty{}, srv); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	srv.mu.Lock()
+	defer srv.mu.Unlock()
+
+	kinds := countKinds(srv.calls[0].StateEvents)
+	if kinds[KindNode] != 1 {
+		t.Errorf("expected 1 node event, got %d", kinds[KindNode])
+	}
+	if kinds[KindContainer] != 2 {
+		t.Errorf("expected 2 container events, got %d", kinds[KindContainer])
+	}
+	if kinds[KindNamespace] != 2 {
+		t.Errorf("expected 2 namespace events, got %d", kinds[KindNamespace])
+	}
+}
+
+// countKinds tallies event kinds from a slice of StateEvents.
+func countKinds(events []*pb.StateEvent) map[string]int {
+	m := map[string]int{}
+	for _, e := range events {
+		m[e.Kind]++
+	}
+	return m
+}


### PR DESCRIPTION
Refers (#2130) and (#2570)

**Purpose of PR?**:
This PR adds comprehensive unit test coverage for the `state` package, focusing on `data.go` and `stateAgent.go`.

**Test Coverage Impact**

- Coverage increased by ~88.1% for the `state` package
- Total tests added: 27

<img width="1766" height="279" alt="image" src="https://github.com/user-attachments/assets/d365880f-a232-42ca-9a31-b7a8c65d8f89" />

**Does this PR introduce a breaking change?**
No. This PR only adds test coverage.

**If the changes in this PR are manually verified, list down the scenarios covered:**:
### data.go
- PushContainerEvent:
  - empty ID guard
  - namespace creation
  - count increment/decrement
  - namespace deletion when empty
  - unknown namespace no-op
  - nil channel safety
  - event delivery
  - buffer overflow handling

- PushNodeEvent:
  - empty name guard
  - nil channel safety
  - JSON event verification
  - buffer overflow handling

- PushNamespaceEvent:
  - nil channel safety
  - JSON event verification
  - buffer overflow handling
  
  
### stateAgent.go
- NewStateAgent, DestroyStateAgent
- addStateEventChan, removeStateEventChan

#### WatchState
- context cancellation
- event delivery
- stop when `Running=false`

#### GetState
- node, container, namespace retrieval
- empty state handling
- JSON marshaling verification
- multiple entities handling


**Additional information for reviewer?** :
This PR is part of the Unit Test Coverage Audit (#2130)
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [ ] Bug fix. Fixes #<issue number>
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [x] Commit has unit tests
- [ ] Commit has integration tests

<!--

The PR title message must follow convention:
`<type>(<scope>): <subject>`.

Where: <br />
- `type` is to define what type of PR is this.
  Most common types are:
    - `feat`      - for new features, not a new feature for build script
    - `fix`       - for bug fixes or improvements, not a fix for build script
    - `chore`     - changes not related to production code
    - `docs`      - changes related to documentation
    - `style`     - formatting, missing semi colons, linting fix etc; no significant production code changes
    - `test`      - adding missing tests, refactoring tests; no production code change
    - `refactor`  - refactoring production code, eg. renaming a variable or function name, there should not be any significant production code changes

- `scope` is a single word that best describes where the changes fit.
    - feature(`monitor`,`enforcer`)
    - test(`tests`, `bdd`)
    - chore(`build`)
- `subject` is a single line brief description of the changes made in the pull request.

-->