### PR TITLE
fix(enforcer): fix bpflsm enforcer verifier issue on talos os

### DIFF
--- a/KubeArmor/BPF/enforcer.bpf.c
+++ b/KubeArmor/BPF/enforcer.bpf.c
@@ -5,6 +5,7 @@
 #include "shared.h"
 #include "syscalls.h"
 #include "arg_matching_helpers.h"
+
 SEC("lsm/bprm_check_security")
 int BPF_PROG(enforce_proc, struct linux_binprm *bprm, int ret)
 {
@@ -57,11 +58,18 @@ int BPF_PROG(enforce_proc, struct linux_binprm *bprm, int ret)
   if (path_offset == NULL)
     return 0;
 
-  void *path_ptr = &path_buf->buf[*path_offset];
+  u32 path_off = 0;
+  if (!valid_buf_and_off(path_buf, path_offset, &path_off))
+      return 0;
+
+  void *path_ptr = &path_buf->buf[path_off];
+  if (!path_ptr)
+      return 0;
+
   bpf_probe_read_str(store->path, MAX_STRING_SIZE, path_ptr);
 
   struct data_t *val = bpf_map_lookup_elem(inner, store);
-  struct data_t *dirval;
+  struct data_t *dirval = NULL;
   bool recursivebuthint = false;
   bool fromSourceCheck = true;
   bool goToDecision = false;
@@ -74,21 +82,29 @@ int BPF_PROG(enforce_proc, struct linux_binprm *bprm, int ret)
   bufs_t *src_buf = get_buf(PATH_BUFFER);
   if (src_buf == NULL)
     fromSourceCheck = false;
-  struct path f_src = BPF_CORE_READ(file_p, f_path);
-  if (!prepend_path(&f_src, src_buf))
-    fromSourceCheck = false;
+  if (fromSourceCheck) {
+    struct path f_src = BPF_CORE_READ(file_p, f_path);
+    if (!prepend_path(&f_src, src_buf))
+      fromSourceCheck = false;
+  }
 
   u32 *src_offset = get_buf_off(PATH_BUFFER);
   if (src_offset == NULL)
     fromSourceCheck = false;
 
-  void *src_ptr;
-  if (src_buf->buf[*src_offset])
-  {
-    src_ptr = &src_buf->buf[*src_offset];
+  void *src_ptr = NULL;
+
+  if (fromSourceCheck) {
+    u32 src_off = 0;
+
+    if (!valid_buf_and_off(src_buf, src_offset, &src_off)) {
+      fromSourceCheck = false;
+    } else {
+      src_ptr = &src_buf->buf[src_off];
+      if (!src_ptr)
+        fromSourceCheck = false;
+    }
   }
-  if (src_ptr == NULL)
-    fromSourceCheck = false;
 
   if (fromSourceCheck)
   {
@@ -113,8 +129,12 @@ int BPF_PROG(enforce_proc, struct linux_binprm *bprm, int ret)
 
         match = false;
 
-        bpf_probe_read_str(pk->path, i + 2, store->path);
+        u32 len = i + 2;
+        if (len > MAX_STRING_SIZE)
+            len = MAX_STRING_SIZE;
+
         // Check Subdir with From Source
+        bpf_probe_read_str(pk->path, len, store->path);
         bpf_probe_read_str(pk->source, MAX_STRING_SIZE, store->source);
         dirval = bpf_map_lookup_elem(inner, pk);
         if (dirval)
@@ -124,16 +144,14 @@ int BPF_PROG(enforce_proc, struct linux_binprm *bprm, int ret)
           {
             match = true;
             if ((dirval->processmask & RULE_RECURSIVE) &&
-                (~dirval->processmask &
-                 RULE_HINT))
+                (~dirval->processmask & RULE_HINT))
             { // true directory match and not a hint suggests
               // there are no possibility of child dir
               val = dirval;
               goToDecision = true; // to please the holy verifier
               break;
             }
-            else if (dirval->processmask &
-                     RULE_RECURSIVE)
+            else if (dirval->processmask & RULE_RECURSIVE) 
             { // It's a directory match but also a
               // hint, it's possible that a
               // subdirectory exists that can also
@@ -161,13 +179,10 @@ int BPF_PROG(enforce_proc, struct linux_binprm *bprm, int ret)
       match = true;
       goto decision;
     }
-    if (match)
-    {
-      if (dirval)
-      { // to please the holy verifier
-        val = dirval;
-        goto decision;
-      }
+    if (match && dirval)
+    { // to please the holy verifier
+      val = dirval;
+      goto decision;
     }
   }
   bpf_map_update_elem(&bufk, &two, z, BPF_ANY);
@@ -182,8 +197,8 @@ int BPF_PROG(enforce_proc, struct linux_binprm *bprm, int ret)
   }
 
   // match exec name
-  struct qstr d_name;
-  d_name = BPF_CORE_READ(f_path.dentry, d_name);
+  struct qstr d_name = BPF_CORE_READ(f_path.dentry, d_name);
+
   bpf_map_update_elem(&bufk, &two, z, BPF_ANY);
   bpf_probe_read_str(pk->path, MAX_STRING_SIZE, d_name.name);
 
@@ -209,7 +224,11 @@ int BPF_PROG(enforce_proc, struct linux_binprm *bprm, int ret)
 
       match = false;
 
-      bpf_probe_read_str(pk->path, i + 2, store->path);
+      u32 len = i + 2;
+      if (len > MAX_STRING_SIZE)
+          len = MAX_STRING_SIZE;
+
+      bpf_probe_read_str(pk->path, len, store->path);
       dirval = bpf_map_lookup_elem(inner, pk);
       if (dirval)
       {
@@ -218,8 +237,7 @@ int BPF_PROG(enforce_proc, struct linux_binprm *bprm, int ret)
         {
           match = true;
           if ((dirval->processmask & RULE_RECURSIVE) &&
-              (~dirval->processmask &
-               RULE_HINT))
+              (~dirval->processmask & RULE_HINT))
           { // true directory match and not a hint suggests
             // there are no possibility of child dir match
             val = dirval;

--- a/KubeArmor/BPF/shared.h
+++ b/KubeArmor/BPF/shared.h
@@ -282,6 +282,19 @@ static __always_inline u32 *get_buf_off(int buf_idx)
   return bpf_map_lookup_elem(&bufs_off, &buf_idx);
 }
 
+static __always_inline bool valid_buf_and_off(bufs_t *buf, u32 *off_ptr, u32 *off)
+{
+    if (!buf || !off_ptr)
+        return false;
+
+    *off = *off_ptr;
+
+    if (*off >= MAX_BUFFER_SIZE)
+        return false;
+
+    return true;
+}
+
 static inline struct mount *real_mount(struct vfsmount *mnt)
 {
   return container_of(mnt, struct mount, mnt);
@@ -439,12 +452,31 @@ static __always_inline long strtol(const char *buf, size_t buf_len, long *res)
 
 static __always_inline u32 get_task_pid_ns_id(struct task_struct *task)
 {
-  return BPF_CORE_READ(task, nsproxy, pid_ns_for_children, ns).inum;
+  struct pid_namespace *pid_ns;
+  u32 inum = 0;
+
+  pid_ns = BPF_CORE_READ(task, nsproxy, pid_ns_for_children);
+
+  if (!pid_ns)
+      return 0;
+
+  bpf_core_read(&inum, sizeof(inum), &pid_ns->ns.inum);
+
+  return inum;
 }
 
 static __always_inline u32 get_task_mnt_ns_id(struct task_struct *task)
 {
-  return BPF_CORE_READ(task, nsproxy, mnt_ns, ns).inum;
+    struct mnt_namespace *mnt_ns;
+    u32 inum = 0;
+
+    mnt_ns = BPF_CORE_READ(task, nsproxy, mnt_ns);
+    if (!mnt_ns)
+        return 0;
+
+    bpf_core_read(&inum, sizeof(inum), &mnt_ns->ns.inum);
+
+    return inum;
 }
 
 static __always_inline u32 get_task_pid_vnr(struct task_struct *task)


### PR DESCRIPTION
**Purpose of PR?**:
bpf-lsm enforcer was failing to load on talos os due to verifier issue, this PR fixes that issue.

```
Talos (v1.13.0)   6.18.24-talos (amd64)
```

<img width="2890" height="1742" alt="Screenshot 2026-05-06 at 2 59 05 PM" src="https://github.com/user-attachments/assets/946c918b-fa17-4ee3-b991-35bd4a79c59a" />


**Does this PR introduce a breaking change?**
No
**If the changes in this PR are manually verified, list down the scenarios covered:**:

tested on k8s cluster with talos os nodes.

```
2026-05-06 08:21:15.886231      ESC[34mINFOESC[0m       Node Name: talos-fua-gef
2026-05-06 08:21:15.886339      ESC[34mINFOESC[0m       Node IP: 192.168.100.106
2026-05-06 08:21:15.886364      ESC[34mINFOESC[0m       Node ID: talos-fua-gef
2026-05-06 08:21:15.886418      ESC[34mINFOESC[0m       Node Annotations: map[flannel.alpha.coreos.com/backend-data:{"VNI":1,"VtepMAC":"e2:8c:68:1a:92:e4"} flannel.alpha.coreos.com/backend-type:vxlan flannel.alpha.coreos.com/kube-subnet-manager:true flannel.alpha.coreos.com/public-ip:192.168.100.106 kubearmor-policy:enabled kubearmor-visibility:none node.alpha.kubernetes.io/ttl:0 talos.dev/owned-labels:["node-role.kubernetes.io/control-plane","node.kubernetes.io/exclude-from-external-load-balancers"] talos.dev/owned-taints:["node-role.kubernetes.io/control-plane"] volumes.kubernetes.io/controller-managed-attach-detach:true]
2026-05-06 08:21:15.886443      ESC[34mINFOESC[0m       OS Image: Talos (v1.13.0)
2026-05-06 08:21:15.886469      ESC[34mINFOESC[0m       Kernel Version: 6.18.24-talos
2026-05-06 08:21:15.886492      ESC[34mINFOESC[0m       Kubelet Version: v1.36.0
2026-05-06 08:21:15.886524      ESC[34mINFOESC[0m       Container Runtime: containerd://2.2.3
2026-05-06 08:21:15.896160      ESC[34mINFOESC[0m       Initialized KubeArmor Logger
2026-05-06 08:21:15.900766      ESC[34mINFOESC[0m       Mounting BPF Filesystem at /sys/fs/bpf
2026-05-06 08:21:15.905534      ESC[34mINFOESC[0m       Initializing eBPF system monitor
2026-05-06 08:21:15.924640      ESC[34mINFOESC[0m       Successfully added visibility map with key={PidNS:0 MntNS:0} to the kernel
2026-05-06 08:21:15.940577      ESC[34mINFOESC[0m       Successfully added visibility map with key={PidNS:12648430 MntNS:12648430} to the kernel
2026-05-06 08:21:15.940898      ESC[34mINFOESC[0m       Alert Throttling configured {alertThrottling:true, maxAlertPerSec:10, throttleSec:30}
2026-05-06 08:21:15.940942      ESC[34mINFOESC[0m       Argument matching configured {matchArgs:true}
2026-05-06 08:21:15.940960      ESC[34mINFOESC[0m       eBPF system monitor object file path: /opt/kubearmor/BPF/system_monitor.bpf.o
2026-05-06 08:21:18.256485      ESC[34mINFOESC[0m       Initialized the eBPF system monitor
2026-05-06 08:21:18.375704      ESC[33mWARNESC[0m       error:[syscalls sys_exit_openat]: neither debugfs nor tracefs are mounted
2026-05-06 08:21:18.375758      ESC[33mWARNESC[0m       error:[syscalls sys_enter_setns]: neither debugfs nor tracefs are mounted
2026-05-06 08:21:18.375766      ESC[33mWARNESC[0m       error:[syscalls sys_exit_setns]: neither debugfs nor tracefs are mounted
2026-05-06 08:21:18.375772      ESC[33mWARNESC[0m       error:[sched sched_process_fork]: neither debugfs nor tracefs are mounted
2026-05-06 08:21:18.430498      ESC[34mINFOESC[0m       Initialized KubeArmor Monitor
2026-05-06 08:21:18.430583      ESC[34mINFOESC[0m       Started to monitor system events
2026-05-06 08:21:18.433315      ESC[34mINFOESC[0m       Supported LSMs: lockdown,capability,yama,selinux,bpf,landlock
2026-05-06 08:21:25.814068      ESC[34mINFOESC[0m       Initialized BPF-LSM Enforcer
2026-05-06 08:21:25.814140      ESC[34mINFOESC[0m       Initialized KubeArmor Enforcer
2026-05-06 08:21:25.814149      ESC[34mINFOESC[0m       Started to protect containers
2026-05-06 08:21:25.814317      ESC[34mINFOESC[0m       Starting TraceEvents from BPF LSM Enforcer
2026-05-06 08:21:25.849621      ESC[34mINFOESC[0m       Starting TraceEvents from AnonMapExec Presets
2026-05-06 08:21:25.894155      ESC[34mINFOESC[0m       Starting TraceEvents from FilelessExec Presets
```

**Additional information for reviewer?** :
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [x] Bug fix.
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Commit has unit tests
- [ ] Commit has integration tests

<!--

The PR title message must follow convention:
`<type>(<scope>): <subject>`.

Where: <br />
- `type` is to define what type of PR is this.
  Most common types are:
    - `feat`      - for new features, not a new feature for build script
    - `fix`       - for bug fixes or improvements, not a fix for build script
    - `chore`     - changes not related to production code
    - `docs`      - changes related to documentation
    - `style`     - formatting, missing semi colons, linting fix etc; no significant production code changes
    - `test`      - adding missing tests, refactoring tests; no production code change
    - `refactor`  - refactoring production code, eg. renaming a variable or function name, there should not be any significant production code changes

- `scope` is a single word that best describes where the changes fit.
    - feature(`monitor`,`enforcer`)
    - test(`tests`, `bdd`)
    - chore(`build`)
- `subject` is a single line brief description of the changes made in the pull request.

-->