### PR TITLE
test(tests): add network default-deny posture assertions in block posture suite

### DIFF
--- a/tests/k8s_env/blockposture/block_test.go
+++ b/tests/k8s_env/blockposture/block_test.go
@@ -4,6 +4,7 @@
 package blockposture
 
 import (
+	"strings"
 	"time"
 
 	"github.com/kubearmor/KubeArmor/tests/util"
@@ -13,25 +14,27 @@ import (
 )
 
 var _ = BeforeSuite(func() {
-	// deploy nginx app
 	err := K8sApply([]string{"res/nginx-posture-deployment.yaml"})
 	Expect(err).To(BeNil())
-	//annotate block posture on namespace level
+
 	_, err = Kubectl("annotate ns nginx-posture kubearmor-network-posture=block --overwrite")
 	Expect(err).To(BeNil())
 
 	_, err = Kubectl("annotate ns nginx-posture kubearmor-file-posture=block --overwrite")
 	Expect(err).To(BeNil())
 
-	//give some time for the deployment to be up before applying whitelisting policies
+	// Restart the deployment so the mutating webhook reliably injects the annotation,
+	// overcoming any race condition during the initial namespace/deployment creation.
+	_, err = Kubectl("rollout restart deployment nginx-posture-deployment -n nginx-posture")
+	Expect(err).To(BeNil())
+
 	time.Sleep(60 * time.Second)
-	// delete all KSPs
+
 	err = DeleteAllKsp()
 	Expect(err).To(BeNil())
 })
 
 var _ = AfterSuite(func() {
-	// delete nginx app
 	err := K8sDelete([]string{"res/nginx-posture-deployment.yaml"})
 	Expect(err).To(BeNil())
 })
@@ -41,6 +44,34 @@ func getNginxPod(name string, ant string) string {
 	Expect(err).To(BeNil())
 	Expect(len(pods)).To(Equal(1))
 	return pods[0]
+}
+
+func probeNetworkBinary(pod, ns string) (bin string, args []string) {
+	candidates := []struct {
+		binary string
+		args   []string
+	}{
+		{
+			"curl",
+			[]string{"sh", "-c", "curl -s --connect-timeout 5 -m 5 1.1.1.1"},
+		},
+		{
+			"wget",
+			[]string{"sh", "-c", "wget -q -T 5 -t 1 -O /dev/null http://1.1.1.1"},
+		},
+		{
+			"nc",
+			[]string{"sh", "-c", "nc -z -w 5 1.1.1.1 80"},
+		},
+	}
+
+	for _, c := range candidates {
+		out, _, err := K8sExecInPodWithContainer(pod, ns, "", []string{"sh", "-c", "which " + c.binary})
+		if err == nil && len(strings.TrimSpace(out)) > 0 {
+			return c.binary, c.args
+		}
+	}
+	return "", nil
 }
 
 var _ = Describe("Posture", func() {
@@ -55,7 +86,6 @@ var _ = Describe("Posture", func() {
 		KarmorLogStop()
 		err := DeleteAllKsp()
 		Expect(err).To(BeNil())
-		// wait for policy deletion
 		time.Sleep(5 * time.Second)
 	})
 
@@ -63,14 +93,12 @@ var _ = Describe("Posture", func() {
 		It("can whitelist certain files accessed by a package while blocking all other sensitive content", func() {
 			err := util.AnnotateNS("nginx-posture", "kubearmor-file-posture", "block")
 			Expect(err).To(BeNil())
-			// Apply policy
+
 			err = K8sApplyFile("res/ksp-nginx-allow-file.yaml")
 			Expect(err).To(BeNil())
 
-			// wait for policy creation, added due to flaky behaviour
 			time.Sleep(10 * time.Second)
 
-			// Start Kubearmor Logs
 			err = KarmorLogStart("policy", "nginx-posture", "File", ng)
 			Expect(err).To(BeNil())
 
@@ -83,7 +111,7 @@ var _ = Describe("Posture", func() {
 				ng, "nginx-posture", []string{"sh", "-c", "cat /usr/share/nginx/html/index.html"},
 				MatchRegexp("<!DOCTYPE html>((?:.*\r?\n?)*)</html>"), true,
 			)
-			// check policy violation alert
+
 			_, alerts, err := KarmorGetLogs(10*time.Second, 1)
 			Expect(err).To(BeNil())
 			Expect(len(alerts)).To(BeNumerically(">=", 1))
@@ -92,4 +120,84 @@ var _ = Describe("Posture", func() {
 		})
 	})
 
+	Describe("Network Posture", func() {
+
+		It("should block egress traffic and emit a DefaultPosture Network alert when file Allow policy is active", func() {
+			_, err := Kubectl("annotate ns nginx-posture kubearmor-network-posture=block --overwrite")
+			Expect(err).To(BeNil())
+
+			err = K8sApplyFile("res/ksp-nginx-allow-file.yaml")
+			Expect(err).To(BeNil())
+			time.Sleep(10 * time.Second)
+
+			netBin, netArgs := probeNetworkBinary(ng, "nginx-posture")
+			if netBin == "" {
+				Skip("No network binary (curl/wget/nc) found in pod " + ng)
+			}
+
+			err = KarmorLogStart("policy", "nginx-posture", "Network", ng)
+			Expect(err).To(BeNil())
+
+			AssertCommand(
+				ng, "nginx-posture", netArgs,
+				MatchRegexp(`(?i)(permission denied|failed to connect|connection timed out|network unreachable|operation not permitted|exit status [1-9])`),
+				true,
+			)
+
+			_, alerts, err := KarmorGetLogs(15*time.Second, 1)
+			Expect(err).To(BeNil())
+			Expect(len(alerts)).To(BeNumerically(">=", 1), "CRITICAL: No Network alert received. Binary used: %s", netBin)
+			Expect(alerts[0].PolicyName).To(Equal("DefaultPosture"))
+			Expect(alerts[0].Action).To(Equal("Block"))
+			Expect(alerts[0].Operation).To(Equal("Network"))
+		})
+
+		It("should NOT emit a Network alert when performing an allowed file operation", func() {
+			_, err := Kubectl("annotate ns nginx-posture kubearmor-network-posture=block --overwrite")
+			Expect(err).To(BeNil())
+
+			err = K8sApplyFile("res/ksp-nginx-allow-file.yaml")
+			Expect(err).To(BeNil())
+			time.Sleep(10 * time.Second)
+
+			err = KarmorLogStart("policy", "nginx-posture", "Network", ng)
+			Expect(err).To(BeNil())
+
+			AssertCommand(
+				ng, "nginx-posture",
+				[]string{"sh", "-c", "cat /usr/share/nginx/html/index.html"},
+				MatchRegexp("<!DOCTYPE html>((?:.*\r?\n?)*)</html>"),
+				false,
+			)
+
+			_, alerts, err := KarmorGetLogs(3*time.Second, 1)
+			Expect(err).To(BeNil())
+			Expect(len(alerts)).To(Equal(0))
+		})
+
+		It("should allow egress after kubearmor-network-posture annotation is removed", func() {
+			_, err := Kubectl("annotate ns nginx-posture kubearmor-network-posture=block --overwrite")
+			Expect(err).To(BeNil())
+
+			DeferCleanup(func() {
+				_, _ = Kubectl("annotate ns nginx-posture kubearmor-network-posture=block --overwrite")
+			})
+
+			netBin, netArgs := probeNetworkBinary(ng, "nginx-posture")
+			if netBin == "" {
+				Skip("No network binary found in pod " + ng)
+			}
+
+			_, err = Kubectl("annotate ns nginx-posture kubearmor-network-posture-")
+			Expect(err).To(BeNil())
+
+			time.Sleep(5 * time.Second)
+
+			AssertCommand(
+				ng, "nginx-posture", netArgs,
+				Not(MatchRegexp(`(?i)(permission denied|operation not permitted)`)),
+				false,
+			)
+		})
+	})
 })


### PR DESCRIPTION
### Purpose of PR

Closes the network default-deny posture assertion gap in the block posture integration test suite.

Close : #2578 

### Does this PR introduce a breaking change?

No.

### If the changes in this PR were manually verified, list the scenarios covered:

* Verified that network egress is blocked and a `DefaultPosture` network alert is emitted when `kubearmor-network-posture=block` is set and no network `Allow` rule exists
* Verified that no unexpected network alerts are generated during allowed file operations (negative test case)
* Verified that egress connectivity is restored after removing the `kubearmor-network-posture=block` annotation
* Tested on a Kind cluster with the AppArmor enforcer enabled

### Additional information for reviewers

This PR continues the block posture test improvements.

Changes included:

* Added a reusable `probeNetworkBinary()` helper to gracefully handle minimal/distroless container images
* Increased alert timeout to 15s to reduce CI flakiness under heavy load

### Checklist

* [x] Bug fix / Test improvement
* [ ] New feature
* [ ] Breaking change
* [ ] Documentation update required
* [x] PR title follows the convention: `<type>(<scope>): <subject>`
* [ ] Unit tests
* [x] Integration tests
