### PR TITLE
chore(monitor): change iov check for RHEL and newer kernels in system monitor

### DIFF
--- a/KubeArmor/BPF/Makefile
+++ b/KubeArmor/BPF/Makefile
@@ -29,16 +29,14 @@ ifeq (,$(wildcard $(LIBBPF)/src/libbpf.a))
 	$(Q)make -C $(LIBBPF)/src
 endif
 
-# below we use long chain of commands, clang | opt | llvm-dis | llc,
-# to generate final object file. 'clang' compiles the source into IR
-# with native target, e.g., x64, arm64, etc. 'opt' does bpf CORE IR builtin
-# processing (llvm12) and IR optimizations. 'llvm-dis' converts
-# 'opt' output to IR, and finally 'llc' generates bpf byte code.
-# Ref https://elixir.bootlin.com/linux/v5.19.5/source/samples/bpf/Makefile#L439
+# Modern single-step BPF compilation pipeline.
+# 'clang -target bpf' compiles directly to BPF bytecode with CO-RE
+# relocation support. This replaces the legacy multi-stage pipeline
+# (clang | opt | llvm-dis | llc) 
 
 system_monitor.bpf.o: $(SYSMONITOR) $(VMLINUX_H)
 	@echo "Compiling eBPF bytecode: $(GREEN)$@$(NC) ..."
-	$(Q)$(CL) $(KF) -Xclang -disable-llvm-passes -c $< -o - | opt -O2 -mtriple=bpf-pc-linux | llvm-dis | llc -march=bpf -mcpu=probe -filetype=obj -o $@
+	$(Q)$(CL) $(KF) -c $< -o $@
 
 .PHONY: clean
 clean:

--- a/KubeArmor/BPF/Makefile.vars
+++ b/KubeArmor/BPF/Makefile.vars
@@ -63,8 +63,7 @@ endif
 
 ifeq ($(BTF_SUPPORTED),1)
 	INC_F = -I $(VMLINUX) \
-			-DBTF_SUPPORTED \
-			-DBPF_NO_PRESERVE_ACCESS_INDEX
+			-DBTF_SUPPORTED
 else
 	# copied from kernel's samples/bpf/Makefile
 	INC_F = -I$(KRNDIR)/arch/$(LINUX_ARCH)/include -I$(KRNDIR)/arch/$(LINUX_ARCH)/include/generated  \
@@ -116,7 +115,8 @@ KF = $(INC_F) -I$(LIBBPF)/src \
 	 -fno-jump-tables \
 	 -fno-unwind-tables \
 	 -fno-asynchronous-unwind-tables \
-	 -xc -O2 -g -emit-llvm
+	 -target bpf \
+	 -xc -O2 -g
 
 SYSMONITOR = $(CURDIR)/system_monitor.c
 

--- a/KubeArmor/BPF/kernel_helpers.h
+++ b/KubeArmor/BPF/kernel_helpers.h
@@ -148,4 +148,15 @@ static __always_inline void get_outer_key(struct outer_key *pokey,
     }
 }
 
+// Shadow struct for new kernel (>= 6.4)
+// Only define when CO-RE builtins are available (requires modern clang with BPF CO-RE support)
+#if defined(BTF_SUPPORTED) && __has_builtin(__builtin_preserve_field_info)
+struct iov_iter___new {
+  union {
+    const struct iovec *__iov;
+    const struct iovec *iov;
+  };
+} __attribute__((preserve_access_index));
+#endif
+
 #endif // _KERNEL_HELPERS_H

--- a/KubeArmor/BPF/kernel_helpers.h
+++ b/KubeArmor/BPF/kernel_helpers.h
@@ -64,6 +64,30 @@ struct mount
 
 #endif    
 
+#if defined(BTF_SUPPORTED) && __has_builtin(__builtin_preserve_field_info)
+
+// Shadow struct for iov_iter field rename (iov -> __iov in kernel >= 6.4)
+struct iov_iter___new {
+  union {
+    const struct iovec *__iov;
+    const struct iovec *iov;
+  };
+} __attribute__((preserve_access_index));
+
+// Shadow struct for old task_struct (kernel < 4.19) where pids[] was used
+// instead of thread_pid. CO-RE maps task_struct___old -> task_struct at load
+// time and resolves the pids field from the target kernel's BTF.
+struct pid_link___old {
+    struct hlist_node node;
+    struct pid *pid;
+} __attribute__((preserve_access_index));
+
+struct task_struct___old {
+    struct pid_link___old pids[4];
+} __attribute__((preserve_access_index));
+
+#endif
+
 // == Kernel Helpers == //
 
 static __always_inline u32 get_pid_ns_id(struct nsproxy *ns)
@@ -97,7 +121,16 @@ static __always_inline u32 get_task_pid_vnr(struct task_struct *task)
 {
     struct pid *pid = NULL;
 
-#if (defined(KBUILD_MODNAME) && LINUX_VERSION_CODE < KERNEL_VERSION(4, 19, 0) && !defined(RHEL_RELEASE_GT_8_0) && !defined(BTF_SUPPORTED))
+#if defined(BTF_SUPPORTED) && __has_builtin(__builtin_preserve_field_info)
+    // CO-RE: detect thread_pid vs pids[] at load time
+    if (bpf_core_field_exists(task->thread_pid)) {
+        pid = READ_KERN(task->thread_pid);
+    } else {
+        // Kernel < 4.19: task_struct had pids[PIDTYPE_PID].pid
+        struct task_struct___old *old_task = (void *)task;
+        bpf_core_read(&pid, sizeof(pid), &old_task->pids[0].pid);
+    }
+#elif (defined(KBUILD_MODNAME) && LINUX_VERSION_CODE < KERNEL_VERSION(4, 19, 0) && !defined(RHEL_RELEASE_GT_8_0) && !defined(BTF_SUPPORTED))
     pid = READ_KERN(task->pids[PIDTYPE_PID].pid);
 #else
     pid = READ_KERN(task->thread_pid);
@@ -147,16 +180,5 @@ static __always_inline void get_outer_key(struct outer_key *pokey,
         pokey->mnt_ns = 0;
     }
 }
-
-// Shadow struct for new kernel (>= 6.4)
-// Only define when CO-RE builtins are available (requires modern clang with BPF CO-RE support)
-#if defined(BTF_SUPPORTED) && __has_builtin(__builtin_preserve_field_info)
-struct iov_iter___new {
-  union {
-    const struct iovec *__iov;
-    const struct iovec *iov;
-  };
-} __attribute__((preserve_access_index));
-#endif
 
 #endif // _KERNEL_HELPERS_H

--- a/KubeArmor/BPF/system_monitor.c
+++ b/KubeArmor/BPF/system_monitor.c
@@ -2445,7 +2445,11 @@ int kretprobe__inet_csk_accept(struct pt_regs *ctx)
     // Code from https://github.com/iovisor/bcc/blob/master/tools/tcpaccept.py with adaptations
     u16 protocol = 1;
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 6, 0)
+#if defined(BTF_SUPPORTED) && __has_builtin(__builtin_preserve_field_info)
+    // CO-RE: BPF_CORE_READ_BITFIELD_PROBED handles both the pre-5.6
+    // bitfield layout and post-5.6 standalone u16 transparently
+    protocol = BPF_CORE_READ_BITFIELD_PROBED(newsk, sk_protocol);
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(5, 6, 0)
     protocol = READ_KERN(newsk->sk_protocol);
 #else
     int gso_max_segs_offset = offsetof(struct sock, sk_gso_max_segs);
@@ -2580,37 +2584,44 @@ int kprobe__udp_sendmsg(struct pt_regs *ctx)
     if (len > 512) // MAX_DNS_SIZE
         return 0;
 
-    sys_context_t context = {};
-    args_t args = {};
-    u64 types = 0;
-    init_context(&context);
-    context.argnum = 3;
-    // Presuming the success event
-    context.retval = 0;
-    context.event_id = _UDP_SENDMSG;
-
-    if (context.retval >= 0 && drop_syscall(_DNS_PROBE))
-    {
-        return 0;
-    }
-
-    if (context.retval < 0 && !get_kubearmor_config(_ENFORCER_BPFLSM) && get_kubearmor_config(_ALERT_THROTTLING) && should_drop_alerts_per_container(&context, ctx, types, &args))
-    {
-        return 0;
-    }
-
+    // Use per-cpu buffer for sys_context_t to avoid exceeding
+    // BPF stack size limit of 512 bytes (same pattern as kretprobe__tcp_connect)
     set_buffer_offset(DNS_BUF_TYPE, sizeof(sys_context_t));
     bufs_t *bufs_p = get_buffer(DNS_BUF_TYPE);
     if (bufs_p == NULL)
         return 0;
-    save_context_to_buffer(bufs_p, (void *)&context);
 
-    // get socket info
-    struct sock_common conn = READ_KERN(sk->__sk_common);
-    // udp_sendmsg operates on AF_INET socket
+    sys_context_t *context = (sys_context_t *)bufs_p->buf;
+    if (context == NULL)
+        return 0;
+
+    __builtin_memset(context, 0, sizeof(sys_context_t));
+
+    args_t args = {};
+    u64 types = 0;
+    init_context(context);
+    context->argnum = 3;
+    // Presuming the success event
+    context->retval = 0;
+    context->event_id = _UDP_SENDMSG;
+
+    if (context->retval >= 0 && drop_syscall(_DNS_PROBE))
+    {
+        return 0;
+    }
+
+    if (context->retval < 0 && !get_kubearmor_config(_ENFORCER_BPFLSM) && get_kubearmor_config(_ALERT_THROTTLING) && should_drop_alerts_per_container(context, ctx, types, &args))
+    {
+        return 0;
+    }
+
+    save_context_to_buffer(bufs_p, (void *)context);
+
+    // Read only required fields from sock_common instead of copying
+    // the entire struct (~136 bytes) to stay within stack limits
     struct sockaddr_in sockv4;
-    sockv4.sin_family = conn.skc_family;
-    sockv4.sin_addr.s_addr = conn.skc_daddr;
+    bpf_probe_read(&sockv4.sin_family, sizeof(sockv4.sin_family), &sk->__sk_common.skc_family);
+    bpf_probe_read(&sockv4.sin_addr.s_addr, sizeof(sockv4.sin_addr.s_addr), &sk->__sk_common.skc_daddr);
     sockv4.sin_port = dport;
 
     // save socket, domain-name(QNAME) and query-type (QTYPE) as args

--- a/KubeArmor/BPF/system_monitor.c
+++ b/KubeArmor/BPF/system_monitor.c
@@ -2554,7 +2554,23 @@ int kprobe__udp_sendmsg(struct pt_regs *ctx)
     dport = ntohs(dport);
     if (dport != 53)
         return 0;
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 3, 13) || RHEL9_BUILD_GTE_400
+
+#if defined(BTF_SUPPORTED) && __has_builtin(__builtin_preserve_field_info)
+    void *iov_ptr = NULL;
+    // Handle __iov / iov field rename across kernel versions using CO-RE
+    struct iov_iter___new *iter = (void *)&msg->msg_iter;
+    if (bpf_core_field_exists(iter->__iov))
+    {
+      bpf_core_read(&iov_ptr, sizeof(iov_ptr), &iter->__iov);
+    }
+    else
+    {
+      bpf_core_read(&iov_ptr, sizeof(iov_ptr), &iter->iov);
+    }
+    if (iov_ptr) {
+      bpf_probe_read_kernel(&iov, sizeof(iov), iov_ptr);
+    }
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(6, 3, 13) || RHEL9_BUILD_GTE_400
     bpf_probe_read(&iov, sizeof(iov), &msg->msg_iter.__iov);
 #else
     bpf_probe_read(&iov, sizeof(iov), &msg->msg_iter.iov);


### PR DESCRIPTION
**Purpose of PR?**:
Add shadow struct for compatibility btwn RHEL and mainstream kernel. Referenced from [enforcer.bpf.c
](https://github.com/kubearmor/KubeArmor/blob/4817c389113b84e4fb4b54d0bfca0808ce09536c/KubeArmor/BPF/enforcer.bpf.c?plain=1#L985)

Fixes #

**Does this PR introduce a breaking change?**

**If the changes in this PR are manually verified, list down the scenarios covered:**:

**Additional information for reviewer?** :
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [x] Bug fix. Fixes #<issue number>
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Commit has unit tests
- [ ] Commit has integration tests

<!--

The PR title message must follow convention:
`<type>(<scope>): <subject>`.

Where: <br />
- `type` is to define what type of PR is this.
  Most common types are:
    - `feat`      - for new features, not a new feature for build script
    - `fix`       - for bug fixes or improvements, not a fix for build script
    - `chore`     - changes not related to production code
    - `docs`      - changes related to documentation
    - `style`     - formatting, missing semi colons, linting fix etc; no significant production code changes
    - `test`      - adding missing tests, refactoring tests; no production code change
    - `refactor`  - refactoring production code, eg. renaming a variable or function name, there should not be any significant production code changes

- `scope` is a single word that best describes where the changes fit.
    - feature(`monitor`,`enforcer`)
    - test(`tests`, `bdd`)
    - chore(`build`)
- `subject` is a single line brief description of the changes made in the pull request.

-->