### PR TITLE
feat(build): switch to cosign attest-blob to generate in-toto attestations for Signed-Releases 10/10 [LFX-PreTask]

### DIFF
--- a/.github/workflows/ci-systemd-release.yml
+++ b/.github/workflows/ci-systemd-release.yml
@@ -115,6 +115,27 @@ jobs:
         run: |
            yq -i '.builds[0].goarch = ["${{ matrix.arch }}"]' /tmp/.goreleaser.yaml
 
+      - name: Create SLSA predicate file
+        id: predicate
+        run: |
+          PREDICATE_FILE=$(mktemp /tmp/predicate.XXXXXX.json)
+          COMMIT_SHA=$(git rev-parse HEAD)
+          cat > "$PREDICATE_FILE" <<EOF
+          {
+            "buildType": "https://github.com/kubearmor/KubeArmor/blob/main/.github/workflows/ci-systemd-release.yml",
+            "builder": {
+              "id": "https://github.com/kubearmor/KubeArmor/actions"
+            },
+            "invocation": {
+              "configSource": {
+                "uri": "git+https://github.com/kubearmor/KubeArmor@${{ steps.validate.outputs.release_tag }}",
+                "digest": { "sha1": "${COMMIT_SHA}" }
+              }
+            }
+          }
+          EOF
+          echo "predicate_file=$PREDICATE_FILE" >> $GITHUB_OUTPUT
+
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v5
         with:
@@ -126,6 +147,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GORELEASER_CURRENT_TAG: ${{ steps.vars.outputs.GORELEASER_CURRENT_TAG }}
           ARCH: ${{ matrix.arch }}
+          PREDICATE_FILE: ${{ steps.predicate.outputs.predicate_file }}
 
       - name: Setup ORAS
         uses: oras-project/setup-oras@v1
@@ -136,3 +158,66 @@ jobs:
         working-directory: KubeArmor/dist
         run: |
           oras push docker.io/kubearmor/kubearmor-systemd:${{ steps.vars.outputs.tag }}_linux-${{ matrix.arch }} kubearmor_${{ steps.vars.outputs.tag }}_linux-${{ matrix.arch }}.tar.gz
+
+      - name: Combine attestations into multiple.intoto.jsonl
+        working-directory: KubeArmor/dist
+        run: |
+          shopt -s nullglob
+          bundles=( *.sigstore.json )
+          missing_or_invalid=0
+
+          > multiple.intoto.jsonl
+          if [ ${#bundles[@]} -eq 0 ]; then
+            echo "ERROR: no *.sigstore.json bundles found" >&2
+            exit 1
+          fi
+
+          for bundle in "${bundles[@]}"; do
+            envelope=$(jq -c '.dsseEnvelope // empty' "$bundle")
+            if [ -n "$envelope" ] && [ "$envelope" != "null" ]; then
+              echo "$envelope" >> multiple.intoto.jsonl
+            else
+              echo "ERROR: $bundle has no dsseEnvelope" >&2
+              missing_or_invalid=1
+            fi
+          done
+
+          if [ "$missing_or_invalid" -ne 0 ] || [ ! -s multiple.intoto.jsonl ]; then
+            echo "ERROR: failed to assemble required attestations into multiple.intoto.jsonl" >&2
+            exit 1
+          fi
+
+          cp multiple.intoto.jsonl multiple-linux-${{ matrix.arch }}.intoto.jsonl
+          echo "multiple-linux-${{ matrix.arch }}.intoto.jsonl contents:"
+          cat multiple-linux-${{ matrix.arch }}.intoto.jsonl
+
+      - name: Store attestation as workflow artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: multiple-intoto-${{ matrix.arch }}
+          path: KubeArmor/dist/multiple-linux-${{ matrix.arch }}.intoto.jsonl
+          if-no-files-found: error
+  
+  upload-provenance:
+    runs-on: ubuntu-22.04
+    needs: goreleaser
+    if: github.repository == 'kubearmor/kubearmor'
+    permissions:
+      contents: write
+    steps:
+      - name: Download attestation artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: multiple-intoto-*
+          path: release-provenance
+          merge-multiple: true
+
+      - name: Upload attestations to GitHub Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          RELEASE_TAG="${{ github.event_name == 'workflow_dispatch' && github.event.inputs.tag || github.ref_name }}"
+          gh release upload "${RELEASE_TAG}" \
+            release-provenance/*.intoto.jsonl \
+            --repo ${{ github.repository }} \
+            --clobber

--- a/KubeArmor/.goreleaser.yaml
+++ b/KubeArmor/.goreleaser.yaml
@@ -28,9 +28,11 @@ signs:
   - cmd: cosign
     signature: "${artifact}.sigstore.json"
     args:
-      - sign-blob
+      - attest-blob
       - "--bundle=${signature}"
-      - '${artifact}'
+      - "--predicate={{ .Env.PREDICATE_FILE }}"
+      - "--type=slsaprovenance"
+      - "${artifact}"
       - --yes
     artifacts: all
     output: true


### PR DESCRIPTION
**Purpose of PR?**:
Fixes the OpenSSF Scorecard Signed-Releases check being capped at 8/10. The existing release pipeline used `cosign sign-blob` which produces Sigstore bundles containing a `messageSignature` payload. Scorecard can detect these signatures but cannot verify provenance claims from a plain blob signature, so the check cannot exceed 8/10.

This PR switches to `cosign attest-blob` with `--type=slsaprovenance`, which produces a DSSE envelope containing an in-toto statement inside each `.sigstore.json` bundle. A post-release step then extracts those envelopes and combines them into a `multiple.intoto.jsonl-linux-{arch}` file uploaded to the GitHub Release. Scorecard scans all `*.intoto.jsonl` release assets to award 10/10 on the Signed-Releases check.

Changes:
- `KubeArmor/.goreleaser.yaml`: replaced `sign-blob` with `attest-blob`, added `--predicate` and `--type=slsaprovenance` args
- `.github/workflows/ci-systemd-release.yml`: added SLSA predicate file generation step before GoReleaser runs, passed `PREDICATE_FILE` env var to GoReleaser, added step to combine DSSE envelopes into `multiple.intoto.jsonl-linux-{arch}` and upload it to the GitHub Release

Fixes #2566

**Does this PR introduce a breaking change?**
No. The `.sigstore.json` bundle files are still produced per artifact as before. The only addition is that each bundle now contains a `dsseEnvelope` instead of a `messageSignature`, and a new `multiple.intoto.jsonl-linux-{arch}` asset is uploaded to each release.

**If the changes in this PR are manually verified, list down the scenarios covered:**
- Confirmed current release v1.7.0 bundles contain `messageSignature` with no `dsseEnvelope` key, which is the root cause of the 8/10 cap
 
<img width="1532" height="106" alt="Screenshot from 2026-05-14 22-21-22" src="https://github.com/user-attachments/assets/d3991148-f301-4365-b89f-3946fca67af7" />

- Confirmed Scorecard Signed-Releases check scores 8/10 on the current main branch 

<img width="1540" height="549" alt="Screenshot from 2026-05-14 22-25-59" src="https://github.com/user-attachments/assets/e450f684-a2b3-4bd1-acee-6da9280a5a0a" />
 
- Verified locally that `cosign attest-blob` produces a bundle with dsseEnvelope` instead of `messageSignature` 

<img width="1600" height="683" alt="Screenshot from 2026-05-15 09-37-06" src="https://github.com/user-attachments/assets/955fab16-1a92-42eb-9655-c0f3e92a12b0" />

- Verified `multiple.intoto.jsonl` is valid JSONL with one envelope per line

To verify after merge on the next release:
```
cosign verify-blob-attestation 
--bundle kubearmor_<version>linux-amd64.tar.gz.sigstore.json 
--type slsaprovenance 
--certificate-identity-regexp "https://github.com/kubearmor/KubeArmor" 
--certificate-oidc-issuer https://token.actions.githubusercontent.com/ 
kubearmor<version>_linux-amd64.tar.gzcosign verify-blob-attestation 
--bundle kubearmor_<version>linux-amd64.tar.gz.sigstore.json 
--type slsaprovenance 
--certificate-identity-regexp "https://github.com/kubearmor/KubeArmor" 
--certificate-oidc-issuer https://token.actions.githubusercontent.com/ 
kubearmor<version>_linux-amd64.tar.gz
```

**Additional information for reviewer?**
This PR is the pre-task for the LFX mentorship project on SLSA L3 compliance and OpenSSF Scorecard improvement for KubeArmor. The Signed-Releases check is the first targeted item. The full term will cover SLSA L3 provenance via slsa-github-generator, Fuzzing via OSS-Fuzz, SAST via CodeQL, and Pinned-Dependencies.

**Checklist:**
- [ ] Bug fix. Fixes #<issue number>
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] PR Title follows the convention of `<type>(<scope>): <subject>`
- [ ] Commit has unit tests
- [ ] Commit has integration tests