### PR TITLE
fix(ci): install protoc binary in ci-test-systemd workflow

### DIFF
--- a/.github/workflows/ci-test-systemd.yml
+++ b/.github/workflows/ci-test-systemd.yml
@@ -46,8 +46,11 @@ jobs:
 
       - name: Install protoc
         run: |
+          sudo apt-get update
+          sudo apt-get install -y protobuf-compiler
           go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
           go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
+          echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
     
       - name: Build Systemd Release
         run: make local-release


### PR DESCRIPTION
**Purpose of PR?**:
Fixes #2604 

The `Install protoc` step in `ci-test-systemd.yml` installs only the Go protoc plugins (`protoc-gen-go`, `protoc-gen-go-grpc`) via `go install` but does not install the `protoc` compiler binary itself. When `make local-release` runs and invokes `protobuf/Makefile`, it fails with `protoc: No such file or directory` (exit 127). This fix installs `protobuf-compiler` via apt and adds the Go bin directory to PATH so both `protoc` and the Go plugins are available on the runner.

**Does this PR introduce a breaking change?**
No.

**If the changes in this PR are manually verified, list down the scenarios covered:**
- Confirmed the bug exists on `main` by running `git show origin/main:.github/workflows/ci-test-systemd.yml` and verifying the missing `apt-get install protobuf-compiler`
- Confirmed the failure log shows `protoc: No such file or directory` at the `make -C ../protobuf` step 

<img width="1547" height="186" alt="Screenshot from 2026-05-15 09-59-11" src="https://github.com/user-attachments/assets/9a79fece-577e-4899-8d39-1dc026f91e27" />


**Additional information for reviewer?**
This is a standalone bug fix unrelated to any other open PR. The failure is reproducible on any push to `main` touching `KubeArmor/**`, `tests/**`, or `protobuf/**`.

**Checklist:**
- [x] Bug fix. Fixes #<issue number>
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] PR Title follows the convention of `<type>(<scope>): <subject>`
- [ ] Commit has unit tests
- [ ] Commit has integration tests