### PR TITLE
ci: enable cosign signed-releases baseline for Scorecard (LFX Pre-task)

### DIFF
--- a/.github/workflows/ci-systemd-release.yml
+++ b/.github/workflows/ci-systemd-release.yml
@@ -127,7 +127,7 @@ jobs:
           GORELEASER_CURRENT_TAG: ${{ steps.vars.outputs.GORELEASER_CURRENT_TAG }}
           ARCH: ${{ matrix.arch }}
 
-      # --- NEW SIGNING & UPLOAD BLOCKS ---
+      # --- UPDATED BUNDLE SIGNING & UPLOAD BLOCKS ---
       - name: Sign Release Artifacts with Cosign
         working-directory: KubeArmor/dist
         run: |
@@ -136,10 +136,7 @@ jobs:
           # Edge Case check: Ensure Goreleaser actually created the file
           if [ -f "$FILE" ]; then
             echo "Artifact found. Signing $FILE..."
-            cosign sign-blob --yes \
-              --output-certificate ${FILE}.cert \
-              --output-signature ${FILE}.sig \
-              ${FILE}
+            cosign sign-blob --yes --bundle ${FILE}.bundle ${FILE}
           else
             echo "Error: Expected artifact $FILE was not found in KubeArmor/dist."
             exit 1
@@ -153,14 +150,14 @@ jobs:
         run: |
           FILE="kubearmor_${{ steps.vars.outputs.tag }}_linux-${{ matrix.arch }}.tar.gz"
           
-          if [ -f "${FILE}.sig" ] && [ -f "${FILE}.cert" ]; then
-            echo "Uploading signatures to GitHub Release: ${RELEASE_TAG}"
-            gh release upload ${RELEASE_TAG} ${FILE}.sig ${FILE}.cert
+          if [ -f "${FILE}.bundle" ]; then
+            echo "Uploading signature bundle to GitHub Release: ${RELEASE_TAG}"
+            gh release upload ${RELEASE_TAG} ${FILE}.bundle
           else
-            echo "Error: Signature files missing. Upload failed."
+            echo "Error: Signature bundle missing. Upload failed."
             exit 1
           fi
-      # --- END OF NEW SIGNING BLOCKS ---
+      # --- END OF UPDATED SIGNING BLOCKS ---
 
       - name: Setup ORAS
         uses: oras-project/setup-oras@v1

--- a/.github/workflows/ci-systemd-release.yml
+++ b/.github/workflows/ci-systemd-release.yml
@@ -127,6 +127,41 @@ jobs:
           GORELEASER_CURRENT_TAG: ${{ steps.vars.outputs.GORELEASER_CURRENT_TAG }}
           ARCH: ${{ matrix.arch }}
 
+      # --- NEW SIGNING & UPLOAD BLOCKS ---
+      - name: Sign Release Artifacts with Cosign
+        working-directory: KubeArmor/dist
+        run: |
+          FILE="kubearmor_${{ steps.vars.outputs.tag }}_linux-${{ matrix.arch }}.tar.gz"
+          
+          # Edge Case check: Ensure Goreleaser actually created the file
+          if [ -f "$FILE" ]; then
+            echo "Artifact found. Signing $FILE..."
+            cosign sign-blob --yes \
+              --output-certificate ${FILE}.cert \
+              --output-signature ${FILE}.sig \
+              ${FILE}
+          else
+            echo "Error: Expected artifact $FILE was not found in KubeArmor/dist."
+            exit 1
+          fi
+
+      - name: Upload Signatures to GitHub Release
+        working-directory: KubeArmor/dist
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ steps.vars.outputs.GORELEASER_CURRENT_TAG }}
+        run: |
+          FILE="kubearmor_${{ steps.vars.outputs.tag }}_linux-${{ matrix.arch }}.tar.gz"
+          
+          if [ -f "${FILE}.sig" ] && [ -f "${FILE}.cert" ]; then
+            echo "Uploading signatures to GitHub Release: ${RELEASE_TAG}"
+            gh release upload ${RELEASE_TAG} ${FILE}.sig ${FILE}.cert
+          else
+            echo "Error: Signature files missing. Upload failed."
+            exit 1
+          fi
+      # --- END OF NEW SIGNING BLOCKS ---
+
       - name: Setup ORAS
         uses: oras-project/setup-oras@v1
         with:


### PR DESCRIPTION
**Purpose of PR?**:
This PR implements the required Cosign keyless signing for release artifacts in `ci-systemd-release.yml`, fulfilling the pre-task baseline requirement for the "Supply Chain Security with SLSA L3" project. It resolves the 0/10 `Signed-Releases` Scorecard check by generating and attaching `.sig` and `.cert` files to the GitHub release.

Fixes #1164

**Does this PR introduce a breaking change?**
No.

**If the changes in this PR are manually verified, list down the scenarios covered:**
- Verified `id-token: write` permissions are correctly mapped for OIDC keyless signing.
- Verified `cosign sign-blob` is executed safely after the `.tar.gz` artifact is generated, including file existence checks.
- Verified `gh release upload` correctly targets the validated tag variables (`$GORELEASER_CURRENT_TAG`) to attach signatures to the release assets.

**Additional information for reviewer?** :
This PR establishes the baseline `Signed-Releases` Scorecard compliance via standard Cosign signing. The subsequent generation of non-falsifiable SLSA provenance via `slsa-github-generator` is deferred to the primary internship scope to maintain a clear, isolated baseline.


**Checklist:**
- [ ] Bug fix. Fixes #<issue number>
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Commit has unit tests
- [ ] Commit has integration tests