### PR TITLE
feat(ci): add cosign keyless signing for GitHub Release artifacts

### DIFF
--- a/.github/workflows/sign-release-artifacts.yml
+++ b/.github/workflows/sign-release-artifacts.yml
@@ -1,0 +1,108 @@
+# This workflow signs GitHub Release artifacts with cosign keyless signing.
+# Triggered automatically whenever a new release is published.
+# Enables the OpenSSF Scorecard Signed-Releases check to pass.
+
+name: sign-release-artifacts
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to sign (e.g. v1.7.1)"
+        type: string
+        required: true
+
+# Declare default permissions as read only.
+permissions: read-all
+
+jobs:
+  sign:
+    name: Sign release artifacts with cosign
+    runs-on: ubuntu-22.04
+    if: github.repository == 'kubearmor/KubeArmor'
+    permissions:
+      id-token: write   # required for cosign keyless signing via Sigstore OIDC
+      contents: write   # required to upload .sig and .pem files to the release
+
+    steps:
+      - name: Resolve release tag
+        id: tag
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          DISPATCH_TAG: ${{ github.event.inputs.tag }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            echo "tag=$DISPATCH_TAG" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag=$RELEASE_TAG" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3.5.0
+        with:
+          cosign-release: 'v2.2.4'
+
+      - name: Verify cosign installation
+        run: cosign version
+
+      - name: Download release assets
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.tag.outputs.tag }}
+        run: |
+          mkdir -p release-assets
+          cd release-assets
+          gh release download "$TAG" \
+            --repo "${{ github.repository }}" \
+            --pattern '*' \
+            --skip-existing
+          echo "Downloaded assets:"
+          ls -la
+
+      - name: Sign all release artifacts with cosign keyless
+        working-directory: release-assets
+        run: |
+          for f in *; do
+            # Skip already-signed artifacts and certificate files
+            case "$f" in
+              *.sig|*.pem|*.cert) continue ;;
+            esac
+            echo "Signing: $f"
+            cosign sign-blob \
+              --yes \
+              --output-signature "${f}.sig" \
+              --output-certificate "${f}.pem" \
+              "$f"
+          done
+          echo "Generated signatures:"
+          ls -la *.sig *.pem
+
+      - name: Upload signatures and certificates to release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.tag.outputs.tag }}
+        working-directory: release-assets
+        run: |
+          gh release upload "$TAG" \
+            *.sig *.pem \
+            --repo "${{ github.repository }}" \
+            --clobber
+
+      - name: Verification instructions
+        env:
+          TAG: ${{ steps.tag.outputs.tag }}
+        run: |
+          cat <<EOF
+          Release artifacts signed successfully.
+          
+          To verify any signed artifact:
+            cosign verify-blob \\
+              --certificate-identity-regexp 'https://github.com/${{ github.repository }}/.github/workflows/sign-release-artifacts.yml@.*' \\
+              --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \\
+              --signature <artifact>.sig \\
+              --certificate <artifact>.pem \\
+              <artifact>
+          EOF


### PR DESCRIPTION
## Summary

Adds a new GitHub Actions workflow that signs all GitHub Release artifacts using cosign keyless signing. This enables the OpenSSF Scorecard `Signed-Releases` check to pass on future releases.

This PR is submitted as the pre-task for the **LFX Mentorship 2026 Term 2 — KubeArmor: Supply Chain Security with SLSA L3 and OpenSSF Scorecard Hardening** project.

## Current Scorecard baseline

OpenSSF Scorecard reports `Signed-Releases: 0/10` ([[live scorecard](https://scorecard.dev/viewer/?uri=github.com/kubearmor/KubeArmor)](https://scorecard.dev/viewer/?uri=github.com/kubearmor/KubeArmor)):

```
Reason: 0 out of 5 artifacts are signed or have provenance

Warn: release artifact v1.7.1 does not have provenance
Warn: release artifact v1.7.1 not signed
Warn: release artifact v1.7.0 does not have provenance
Warn: release artifact v1.7.0 not signed
Warn: release artifact v1.6.19 does not have provenance
Warn: release artifact v1.6.19 not signed
Warn: release artifact v1.6.18 does not have provenance
Warn: release artifact v1.6.18 not signed
Warn: release artifact v1.6.17 does not have provenance
Warn: release artifact v1.6.17 not signed
```

## Context

The existing `ci-latest-release.yml` workflow already signs **Docker container images** with cosign:

```yaml
- name: Sign the Container Images
  run: |
    cosign sign -r kubearmor/kubearmor@${{ steps.digest.outputs.imagedigest }} --yes
```

However, the **binary release artifacts** uploaded to GitHub Releases (e.g. `kubearmor_1.7.1_amd64_checksums.txt` and 17 other assets on v1.7.1) are not signed. The Scorecard `Signed-Releases` check specifically looks at GitHub Release assets, not container image signatures, which is why the score is currently 0.

## What this PR does

Adds a new dedicated workflow at `.github/workflows/sign-release-artifacts.yml` that:

1. Triggers automatically when a GitHub Release is published (`release: published`)
2. Also supports manual invocation via `workflow_dispatch` for signing existing releases
3. Downloads all release assets using `gh release download`
4. Signs each artifact with `cosign sign-blob` using keyless signing (Sigstore OIDC)
5. Uploads `.sig` and `.pem` files back to the release via `gh release upload`

### Why a separate workflow?

- **Non-invasive**: does not modify the existing release pipeline (`ci-latest-release.yml`, `ci-stable-release.yml`), eliminating risk of breaking current releases
- **Independent**: can be backfilled on existing releases via `workflow_dispatch` without re-running the entire build pipeline
- **Clear separation of concerns**: container image signing remains in the build workflow, release asset signing is its own concern

### Why keyless signing?

- No long-lived keys to manage or rotate
- Identity is cryptographically tied to the GitHub Actions OIDC token from this specific workflow
- Verifiable via Sigstore's public Rekor transparency log
- Aligns with how OpenSSF Scorecard and SLSA L3 expect modern artifact signing

## Verification

After this PR merges and the next release is published, the workflow will automatically sign all release assets. Verification of any signed artifact:

```bash
cosign verify-blob \
  --certificate-identity-regexp 'https://github.com/kubearmor/KubeArmor/.github/workflows/sign-release-artifacts.yml@.*' \
  --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
  --signature <artifact>.sig \
  --certificate <artifact>.pem \
  <artifact>
```

Re-running Scorecard against the repo after the next release should improve `Signed-Releases` from 0 to 8+.

## Backfilling existing releases (optional)

After merge, maintainers can sign the last few releases retroactively by running the workflow manually with a tag input:

```
Actions → sign-release-artifacts → Run workflow → tag: v1.7.1
```

## Permissions

Workflow requests minimal permissions in line with KubeArmor's existing patterns:
- `id-token: write` — required for cosign keyless OIDC signing
- `contents: write` — required to upload `.sig` and `.pem` files to the release
- All other permissions remain `read-all` (default)

## Related

LFX Mentorship 2026 Term 2 — KubeArmor: Supply Chain Security with SLSA L3 and OpenSSF Scorecard Hardening