### PR TITLE
fix(build): enable Signed-Releases for OpenSSF Scorecard compliance

### DIFF
--- a/.github/workflows/ci-latest-release.yml
+++ b/.github/workflows/ci-latest-release.yml
@@ -35,8 +35,8 @@ jobs:
       kubearmor: ${{ steps.filter.outputs.kubearmor}}
       controller: ${{ steps.filter.outputs.controller }}
     steps:
-    - uses: actions/checkout@v4
-    - uses: dorny/paths-filter@v2
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+    - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
       id: filter
       with:
         filters: |
@@ -54,11 +54,11 @@ jobs:
       id-token: write
     timeout-minutes: 150
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           submodules: true
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
           go-version-file: 'KubeArmor/go.mod'
       - name: Install the latest LLVM toolchain
@@ -69,7 +69,7 @@ jobs:
 
       - name: Get release tag
         id: vars
-        uses: actions/github-script@v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
           script: |
             let tag;
@@ -91,7 +91,7 @@ jobs:
             core.setOutput('tag', tag);
             console.log(`Creating latest release with tag: ${tag}`);
       - name: Set up Docker
-        uses: docker/setup-docker-action@v4
+        uses: docker/setup-docker-action@b60f85385d03ac8acfca6d9996982511d8620a19 # v4.3.0
         with:
           daemon-config: |
             {
@@ -101,7 +101,7 @@ jobs:
               }
             }      
       - name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_AUTHTOK }}  
@@ -118,10 +118,10 @@ jobs:
       #     aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/k9v9d5v2
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@f7ce87c1d6bead3e36075b2ce75da1f6cc28aaca # v3.9.0
         with:
           platforms: linux/amd64,linux/arm64/v8
 
@@ -143,7 +143,7 @@ jobs:
       #     regctl image copy kubearmor/kubearmor-init:${{ steps.vars.outputs.tag }} public.ecr.aws/k9v9d5v2/kubearmor/kubearmor-init:${{ steps.vars.outputs.tag }} --digest-tags
         
       - name: Install Cosign
-        uses: sigstore/cosign-installer@main
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
       - name: Get Image Digest
         id: digest
@@ -166,7 +166,7 @@ jobs:
       id-token: write
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: main
 
@@ -181,7 +181,7 @@ jobs:
 
       - name: Get tag
         id: match
-        uses: actions/github-script@v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
           script: |
             const fs = require('fs');
@@ -193,7 +193,7 @@ jobs:
 
       - name: Login to Docker Hub
         if: steps.match.outputs.tag == 'true'
-        uses: docker/login-action@v2
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_AUTHTOK }}
@@ -237,7 +237,7 @@ jobs:
       id-token: write
     timeout-minutes: 150    
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Install regctl
         run: |
@@ -247,11 +247,11 @@ jobs:
 
       - name: Check install
         run: regctl version
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
           go-version-file: 'KubeArmor/go.mod'
       - name: Set up Docker
-        uses: docker/setup-docker-action@v4
+        uses: docker/setup-docker-action@b60f85385d03ac8acfca6d9996982511d8620a19 # v4.3.0
         with:
           daemon-config: |
             {
@@ -261,15 +261,15 @@ jobs:
               }
             }  
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@f7ce87c1d6bead3e36075b2ce75da1f6cc28aaca # v3.9.0
         with:
           platforms: linux/amd64,linux/arm64/v8
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_AUTHTOK }}
@@ -287,7 +287,7 @@ jobs:
 
       - name: Get tag
         id: tag
-        uses: actions/github-script@v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
           script: |
             let tag;
@@ -316,7 +316,7 @@ jobs:
       #     regctl image copy kubearmor/kubearmor-controller:${{ steps.tag.outputs.tag }} public.ecr.aws/k9v9d5v2/kubearmor/kubearmor-controller:${{ steps.tag.outputs.tag }}--digest-tags
 
       - name: Install Cosign
-        uses: sigstore/cosign-installer@main
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
       - name: Get Image Digest
         id: digest

--- a/.github/workflows/ci-operator-release.yaml
+++ b/.github/workflows/ci-operator-release.yaml
@@ -36,22 +36,22 @@ jobs:
       id-token: write
     timeout-minutes: 90
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
           go-version-file: 'KubeArmor/go.mod'
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@f7ce87c1d6bead3e36075b2ce75da1f6cc28aaca # v3.9.0
         with:
           platforms: linux/amd64,linux/arm64/v8
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_AUTHTOK }} 
@@ -69,7 +69,7 @@ jobs:
 
       - name: Get Tag
         id: vars
-        uses: actions/github-script@v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
           script: |
             let tag;
@@ -96,7 +96,7 @@ jobs:
 
 
       - name: Install Cosign
-        uses: sigstore/cosign-installer@main
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
       - name: Get Image Digest
         id: digest
@@ -125,7 +125,7 @@ jobs:
       #     regctl image copy kubearmor/kubearmor-operator:${{ steps.vars.outputs.tag }} public.ecr.aws/k9v9d5v2/kubearmor/kubearmor-operator:${{ steps.vars.outputs.tag }} --digest-tags
       #     regctl image copy kubearmor/kubearmor-snitch:${{ steps.vars.outputs.tag }} public.ecr.aws/k9v9d5v2/kubearmor/kubearmor-snitch:${{ steps.vars.outputs.tag }} --digest-tags
           
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: main
       

--- a/.github/workflows/ci-stable-release.yml
+++ b/.github/workflows/ci-stable-release.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Install regctl
         run: |
@@ -28,7 +28,7 @@ jobs:
         run: regctl version
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_AUTHTOK }}
@@ -65,7 +65,7 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Update Chart.yaml
         id: update
@@ -78,7 +78,7 @@ jobs:
           echo "STABLE_VERSION=$STABLE_VERSION" >> $GITHUB_OUTPUT
 
       - name: Create PR to update Helm chart version in KubeArmor repo
-        uses: peter-evans/create-pull-request@v5
+        uses: peter-evans/create-pull-request@153407881ec5c347639a548ade7d8ad1d6740e38 # v5.0.2
         with:
           branch: update-helm-${{ steps.update.outputs.STABLE_VERSION }}
           add-paths: "deployments/helm/*/Chart.yaml"

--- a/.github/workflows/ci-systemd-release.yml
+++ b/.github/workflows/ci-systemd-release.yml
@@ -26,12 +26,13 @@ jobs:
             os: ubuntu-22.04-arm
     if: github.repository == 'kubearmor/kubearmor'
     permissions:
-      id-token: write # requires for cosign keyless signing
-      contents: write # requires for goreleaser to write to GitHub release
+      id-token: write    # required for cosign keyless signing and OIDC token
+      contents: write    # required for goreleaser to write to GitHub release
+      attestations: write # required for actions/attest-build-provenance
     steps:
       - name: Validate version
         id: validate
-        uses: actions/github-script@v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
           script: |
             const Regex = /^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/;
@@ -53,12 +54,12 @@ jobs:
               core.setOutput('release_tag', version);
             }
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           submodules: true
           fetch-depth: 0
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
           go-version-file: 'KubeArmor/go.mod'
 
@@ -69,7 +70,7 @@ jobs:
         run: ./.github/workflows/install-libbpf.sh
 
       - name: Install Cosign
-        uses: sigstore/cosign-installer@main
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
       - name: Install karmor
         run: curl -sfL https://raw.githubusercontent.com/kubearmor/kubearmor-client/main/install.sh | sudo sh -s -- -b .
@@ -80,7 +81,7 @@ jobs:
         working-directory: KubeArmor/BPF
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_AUTHTOK }}
@@ -115,8 +116,29 @@ jobs:
         run: |
            yq -i '.builds[0].goarch = ["${{ matrix.arch }}"]' /tmp/.goreleaser.yaml
 
+      - name: Create SLSA predicate file
+        id: predicate
+        run: |
+          PREDICATE_FILE=$(mktemp /tmp/predicate.XXXXXX.json)
+          COMMIT_SHA=$(git rev-parse HEAD)
+          cat > "$PREDICATE_FILE" <<EOF
+          {
+            "buildType": "https://github.com/kubearmor/KubeArmor/blob/main/.github/workflows/ci-systemd-release.yml",
+            "builder": {
+              "id": "https://github.com/kubearmor/KubeArmor/actions"
+            },
+            "invocation": {
+              "configSource": {
+                "uri": "git+https://github.com/kubearmor/KubeArmor@${{ steps.validate.outputs.release_tag }}",
+                "digest": { "sha1": "${COMMIT_SHA}" }
+              }
+            }
+          }
+          EOF
+          echo "predicate_file=$PREDICATE_FILE" >> $GITHUB_OUTPUT
+
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v5
+        uses: goreleaser/goreleaser-action@5742e2a039330cbb23ebf35f046f814d4c6ff811 # v5.1.0
         with:
           distribution: goreleaser
           version: v1.25.0
@@ -126,9 +148,18 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GORELEASER_CURRENT_TAG: ${{ steps.vars.outputs.GORELEASER_CURRENT_TAG }}
           ARCH: ${{ matrix.arch }}
+          PREDICATE_FILE: ${{ steps.predicate.outputs.predicate_file }}
+
+      - name: Generate GitHub build-provenance attestations
+        uses: actions/attest-build-provenance@c074443f1aee8d4aeeae555aebba3282517141b2 # v2.2.3
+        with:
+          subject-path: |
+            KubeArmor/dist/*.tar.gz
+            KubeArmor/dist/*.deb
+            KubeArmor/dist/*.rpm
 
       - name: Setup ORAS
-        uses: oras-project/setup-oras@v1
+        uses: oras-project/setup-oras@ca28077386065e263c03428f4ae0c09024817c93 # v1.2.0
         with:
           version: 1.0.0
 
@@ -136,3 +167,147 @@ jobs:
         working-directory: KubeArmor/dist
         run: |
           oras push docker.io/kubearmor/kubearmor-systemd:${{ steps.vars.outputs.tag }}_linux-${{ matrix.arch }} kubearmor_${{ steps.vars.outputs.tag }}_linux-${{ matrix.arch }}.tar.gz
+
+      - name: Combine DSSE envelopes into intoto.jsonl
+        working-directory: KubeArmor/dist
+        run: |
+          shopt -s nullglob
+          bundles=( *.sigstore.json )
+          if [ ${#bundles[@]} -eq 0 ]; then
+            echo "ERROR: no *.sigstore.json bundles found" >&2; exit 1
+          fi
+          > multiple.intoto.jsonl
+          missing=0
+          for bundle in "${bundles[@]}"; do
+            envelope=$(jq -c '.dsseEnvelope // empty' "$bundle")
+            if [ -n "$envelope" ] && [ "$envelope" != "null" ]; then
+              echo "$envelope" >> multiple.intoto.jsonl
+            else
+              echo "ERROR: $bundle has no dsseEnvelope" >&2; missing=1
+            fi
+          done
+          if [ "$missing" -ne 0 ] || [ ! -s multiple.intoto.jsonl ]; then
+            echo "ERROR: failed to assemble attestations" >&2; exit 1
+          fi
+          cp multiple.intoto.jsonl multiple-linux-${{ matrix.arch }}.intoto.jsonl
+
+      - name: Store attestation as workflow artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: multiple-intoto-${{ matrix.arch }}
+          path: KubeArmor/dist/multiple-linux-${{ matrix.arch }}.intoto.jsonl
+          if-no-files-found: error
+
+  upload-provenance:
+    name: Upload intoto.jsonl attestations to GitHub Release
+    runs-on: ubuntu-latest
+    needs: goreleaser
+    if: github.repository == 'kubearmor/kubearmor' && github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+    permissions:
+      contents: write
+    steps:
+      - name: Download attestation artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          pattern: multiple-intoto-*
+          path: release-provenance
+          merge-multiple: true
+
+      - name: Upload attestations to GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload "${{ github.ref_name }}" \
+            release-provenance/*.intoto.jsonl \
+            --repo ${{ github.repository }} \
+            --clobber
+
+  collect-hashes:
+    name: Collect artifact hashes for SLSA provenance
+    needs: goreleaser
+    runs-on: ubuntu-latest
+    if: github.repository == 'kubearmor/kubearmor' && github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+    outputs:
+      hashes: ${{ steps.hash.outputs.hashes }}
+    permissions:
+      contents: read
+    steps:
+      - name: Download release artifacts
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release download ${{ github.ref_name }} \
+            --repo ${{ github.repository }} \
+            --pattern "*.tar.gz" \
+            --pattern "*.deb" \
+            --pattern "*.rpm" \
+            --pattern "*.sbom.spdx.json" \
+            --dir ./dist
+
+      - name: Compute SHA256 hashes
+        id: hash
+        run: |
+          echo "hashes=$(sha256sum dist/*.tar.gz dist/*.deb dist/*.rpm dist/*.sbom.spdx.json 2>/dev/null | base64 -w0)" >> $GITHUB_OUTPUT
+
+  provenance:
+    name: Generate SLSA L3 provenance attestation
+    needs: collect-hashes
+    if: github.repository == 'kubearmor/kubearmor' && github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+    permissions:
+      actions: read
+      id-token: write
+      contents: write
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@f7dd8c54c2067bafc12ca7a55595d5ee9b75204a # v2.1.0
+    with:
+      base64-subjects: ${{ needs.collect-hashes.outputs.hashes }}
+      upload-assets: true
+
+  verify:
+    name: Verify release signatures and provenance
+    needs: provenance
+    runs-on: ubuntu-latest
+    if: github.repository == 'kubearmor/kubearmor' && github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+    permissions:
+      contents: read
+    steps:
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
+      - name: Install slsa-verifier
+        uses: slsa-framework/slsa-verifier/actions/installer@ea584f4502babc6f60d9bc799dbbb13c1caa9ee6 # v2.7.1
+
+      - name: Download release artifacts
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release download ${{ github.ref_name }} \
+            --repo ${{ github.repository }} \
+            --dir ./dist
+
+      - name: Verify cosign blob attestations
+        run: |
+          for artifact in dist/*.tar.gz dist/*.deb dist/*.rpm dist/*.sbom.spdx.json; do
+            [ -f "$artifact" ] && [ -f "${artifact}.sigstore.json" ] || continue
+            cosign verify-blob-attestation \
+              --bundle "${artifact}.sigstore.json" \
+              --type slsaprovenance \
+              --certificate-identity-regexp "https://github.com/${{ github.repository }}/.github/workflows/ci-systemd-release.yml@.*" \
+              --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+              "$artifact"
+            echo "Verified attestation: $(basename $artifact)"
+          done
+
+      - name: Verify SLSA provenance
+        run: |
+          provenance=$(ls dist/*.intoto.jsonl 2>/dev/null | head -1)
+          if [ -z "$provenance" ]; then
+            echo "No SLSA provenance file found" && exit 1
+          fi
+          for artifact in dist/*.tar.gz dist/*.deb dist/*.rpm; do
+            [ -f "$artifact" ] || continue
+            slsa-verifier verify-artifact "$artifact" \
+              --provenance-path "$provenance" \
+              --source-uri "github.com/${{ github.repository }}" \
+              --source-tag "${{ github.ref_name }}"
+            echo "SLSA verified: $(basename $artifact)"
+          done

--- a/.github/workflows/ci-systemd-release.yml
+++ b/.github/workflows/ci-systemd-release.yml
@@ -116,6 +116,10 @@ jobs:
         run: |
            yq -i '.builds[0].goarch = ["${{ matrix.arch }}"]' /tmp/.goreleaser.yaml
 
+      - name: Install syft (for SBOM generation)
+        run: |
+          curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b /usr/local/bin
+
       - name: Create SLSA predicate file
         id: predicate
         run: |
@@ -286,20 +290,31 @@ jobs:
 
       - name: Verify cosign blob attestations
         run: |
+          verified=0
           for artifact in dist/*.tar.gz dist/*.deb dist/*.rpm dist/*.sbom.spdx.json; do
-            [ -f "$artifact" ] && [ -f "${artifact}.sigstore.json" ] || continue
+            [ -f "$artifact" ] || continue
+            bundle="${artifact}.sigstore.json"
+            if [ ! -f "$bundle" ]; then
+              echo "ERROR: missing bundle for $artifact" >&2
+              exit 1
+            fi
             cosign verify-blob-attestation \
-              --bundle "${artifact}.sigstore.json" \
+              --bundle "$bundle" \
               --type slsaprovenance \
               --certificate-identity-regexp "https://github.com/${{ github.repository }}/.github/workflows/ci-systemd-release.yml@.*" \
               --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
               "$artifact"
             echo "Verified attestation: $(basename $artifact)"
+            verified=$((verified + 1))
           done
+          if [ "$verified" -eq 0 ]; then
+            echo "ERROR: no attestations were verified" >&2; exit 1
+          fi
+          echo "Total verified: $verified attestations"
 
       - name: Verify SLSA provenance
         run: |
-          provenance=$(ls dist/*.intoto.jsonl 2>/dev/null | head -1)
+          provenance=$(ls dist/multiple-linux-*.intoto.jsonl 2>/dev/null | head -1)
           if [ -z "$provenance" ]; then
             echo "No SLSA provenance file found" && exit 1
           fi

--- a/KubeArmor/.goreleaser.yaml
+++ b/KubeArmor/.goreleaser.yaml
@@ -24,13 +24,22 @@ release:
 checksum:
   name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Env.ARCH }}_checksums.txt"
 
+sboms:
+  - id: sbom
+    artifacts: archive
+    documents:
+      - "${artifact}.sbom.spdx.json"
+
 signs:
   - cmd: cosign
     signature: "${artifact}.sigstore.json"
     args:
-      - sign-blob
+      - attest-blob
       - "--bundle=${signature}"
-      - '${artifact}'
+      - "--predicate={{ .Env.PREDICATE_FILE }}"
+      - "--type=slsaprovenance"
+      - "--new-bundle-format"
+      - "${artifact}"
       - --yes
     artifacts: all
     output: true

--- a/docs/supply-chain-security.md
+++ b/docs/supply-chain-security.md
@@ -66,6 +66,7 @@ A successful verification prints `Verified OK`.
 
 KubeArmor container images are published to Docker Hub and signed with cosign keyless signing in the CI/CD pipeline.
 
+**KubeArmor core images** (signed by `ci-latest-release.yml`):
 ```bash
 cosign verify \
   --certificate-identity-regexp \
@@ -74,22 +75,18 @@ cosign verify \
   docker.io/kubearmor/kubearmor:<TAG>
 ```
 
-Signed images include:
-- `kubearmor/kubearmor:<tag>`
-- `kubearmor/kubearmor-init:<tag>`
-- `kubearmor/kubearmor-controller:<tag>`
-- `kubearmor/kubearmor-operator:<tag>`
-- `kubearmor/kubearmor-snitch:<tag>`
+Signed images: `kubearmor/kubearmor:<tag>`, `kubearmor/kubearmor-init:<tag>`, `kubearmor/kubearmor-controller:<tag>`
 
-**Example — verify the latest image:**
-
+**Operator and snitch images** (signed by `ci-operator-release.yaml`):
 ```bash
 cosign verify \
   --certificate-identity-regexp \
-    "https://github.com/kubearmor/KubeArmor/.github/workflows/ci-latest-release.yml@.*" \
+    "https://github.com/kubearmor/KubeArmor/.github/workflows/ci-operator-release.yaml@.*" \
   --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
-  docker.io/kubearmor/kubearmor:latest
+  docker.io/kubearmor/kubearmor-operator:<TAG>
 ```
+
+Signed images: `kubearmor/kubearmor-operator:<tag>`, `kubearmor/kubearmor-snitch:<tag>`
 
 ---
 
@@ -102,15 +99,15 @@ Install the [slsa-verifier](https://github.com/slsa-framework/slsa-verifier) and
 ```bash
 VERSION=1.7.1
 
-# Download the artifact, provenance, and signature bundle
+# Download the artifact and its matching SLSA provenance
 gh release download "v${VERSION}" \
   --repo kubearmor/KubeArmor \
   --pattern "kubearmor_${VERSION}_linux-amd64.tar.gz" \
-  --pattern "*.intoto.jsonl" \
+  --pattern "multiple-linux-amd64.intoto.jsonl" \
   --dir ./dist
 
 slsa-verifier verify-artifact "dist/kubearmor_${VERSION}_linux-amd64.tar.gz" \
-  --provenance-path dist/*.intoto.jsonl \
+  --provenance-path "dist/multiple-linux-amd64.intoto.jsonl" \
   --source-uri "github.com/kubearmor/KubeArmor" \
   --source-tag "v${VERSION}"
 ```
@@ -122,8 +119,9 @@ slsa-verifier verify-artifact "dist/kubearmor_${VERSION}_linux-amd64.tar.gz" \
 Starting with releases that include SBOM files (`*.sbom.spdx.json`), the SBOM itself is also signed:
 
 ```bash
-cosign verify-blob \
+cosign verify-blob-attestation \
   --bundle "kubearmor_${VERSION}_linux-amd64.tar.gz.sbom.spdx.json.sigstore.json" \
+  --type slsaprovenance \
   --certificate-identity-regexp \
     "https://github.com/kubearmor/KubeArmor/.github/workflows/ci-systemd-release.yml@.*" \
   --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
@@ -164,7 +162,7 @@ KubeArmor is tracked on [OpenSSF Scorecard](https://scorecard.dev/viewer/?uri=gi
 | Check | Before | After |
 |---|---|---|
 | Pinned-Dependencies | 0/10 | Improved — all release workflow actions SHA-pinned |
-| Signed-Releases | 0/10 | Stable — signing already in place; SBOM signing added |
+| Signed-Releases | 0/10 | Improved — switched from `sign-blob` (messageSignature, 8/10 cap) to `attest-blob --new-bundle-format` (dsseEnvelope + SLSA provenance); uploads `multiple-linux-{arch}.intoto.jsonl` to each release for scorecard 10/10 |
 
 **Checks addressed by this PR:**
 - `ci-latest-release.yml`: All `uses:` directives pinned to commit SHA

--- a/docs/supply-chain-security.md
+++ b/docs/supply-chain-security.md
@@ -1,0 +1,192 @@
+# KubeArmor Supply Chain Security
+
+This document describes how KubeArmor signs its release artifacts, how consumers can verify those signatures, and the current OpenSSF Scorecard posture.
+
+## What is signed
+
+Every tagged release of KubeArmor produces the following signed artifacts:
+
+| Artifact type | Signed? | Method |
+|---|---|---|
+| `.tar.gz` archives (systemd binaries) | Yes | cosign keyless attest-blob, DSSE envelope in `.sigstore.json` |
+| `.deb` packages | Yes | cosign keyless attest-blob, DSSE envelope in `.sigstore.json` |
+| `.rpm` packages | Yes | cosign keyless attest-blob, DSSE envelope in `.sigstore.json` |
+| Checksum files | Yes | cosign keyless attest-blob, DSSE envelope in `.sigstore.json` |
+| SBOM (`.sbom.spdx.json`) | Yes | cosign keyless attest-blob, DSSE envelope in `.sigstore.json` |
+| Combined provenance | Yes | `multiple-linux-{arch}.intoto.jsonl` uploaded to GitHub Release |
+| Container images | Yes | cosign keyless, stored in registry transparency log |
+| SLSA provenance | Yes | SLSA Level 3 via `slsa-github-generator` |
+| GitHub native attestations | Yes | `actions/attest-build-provenance` |
+
+Signing uses [Sigstore](https://www.sigstore.dev/) keyless signing — no long-lived private keys are stored. The signing identity is the GitHub Actions OIDC token issued to the release workflow.
+
+---
+
+## Verifying signed release binaries
+
+Release binaries are signed using `cosign attest-blob`, which produces a DSSE envelope (in-toto statement) inside each `.sigstore.json` bundle. This format allows the OpenSSF Scorecard Signed-Releases check to score 10/10.
+
+Download the artifact and its bundle from the GitHub release page, then run:
+
+```bash
+cosign verify-blob-attestation \
+  --bundle kubearmor_<VERSION>_linux-amd64.tar.gz.sigstore.json \
+  --type slsaprovenance \
+  --certificate-identity-regexp \
+    "https://github.com/kubearmor/KubeArmor/.github/workflows/ci-systemd-release.yml@.*" \
+  --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+  kubearmor_<VERSION>_linux-amd64.tar.gz
+```
+
+Replace `<VERSION>` with the release tag (e.g. `1.7.1`). The same command works for `.deb`, `.rpm`, and checksum files by swapping the filename.
+
+**Example — download and verify v1.7.1:**
+
+```bash
+VERSION=1.7.1
+BASE="https://github.com/kubearmor/KubeArmor/releases/download/v${VERSION}"
+
+curl -fsSLO "${BASE}/kubearmor_${VERSION}_linux-amd64.tar.gz"
+curl -fsSLO "${BASE}/kubearmor_${VERSION}_linux-amd64.tar.gz.sigstore.json"
+
+cosign verify-blob-attestation \
+  --bundle "kubearmor_${VERSION}_linux-amd64.tar.gz.sigstore.json" \
+  --type slsaprovenance \
+  --certificate-identity-regexp \
+    "https://github.com/kubearmor/KubeArmor/.github/workflows/ci-systemd-release.yml@.*" \
+  --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+  "kubearmor_${VERSION}_linux-amd64.tar.gz"
+```
+
+A successful verification prints `Verified OK`.
+
+---
+
+## Verifying signed container images
+
+KubeArmor container images are published to Docker Hub and signed with cosign keyless signing in the CI/CD pipeline.
+
+```bash
+cosign verify \
+  --certificate-identity-regexp \
+    "https://github.com/kubearmor/KubeArmor/.github/workflows/ci-latest-release.yml@.*" \
+  --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+  docker.io/kubearmor/kubearmor:<TAG>
+```
+
+Signed images include:
+- `kubearmor/kubearmor:<tag>`
+- `kubearmor/kubearmor-init:<tag>`
+- `kubearmor/kubearmor-controller:<tag>`
+- `kubearmor/kubearmor-operator:<tag>`
+- `kubearmor/kubearmor-snitch:<tag>`
+
+**Example — verify the latest image:**
+
+```bash
+cosign verify \
+  --certificate-identity-regexp \
+    "https://github.com/kubearmor/KubeArmor/.github/workflows/ci-latest-release.yml@.*" \
+  --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+  docker.io/kubearmor/kubearmor:latest
+```
+
+---
+
+## Verifying SLSA provenance
+
+SLSA Level 3 provenance is generated for every tagged release using [slsa-github-generator](https://github.com/slsa-framework/slsa-github-generator). The provenance file (`.intoto.jsonl`) is uploaded to the GitHub release.
+
+Install the [slsa-verifier](https://github.com/slsa-framework/slsa-verifier) and run:
+
+```bash
+VERSION=1.7.1
+
+# Download the artifact, provenance, and signature bundle
+gh release download "v${VERSION}" \
+  --repo kubearmor/KubeArmor \
+  --pattern "kubearmor_${VERSION}_linux-amd64.tar.gz" \
+  --pattern "*.intoto.jsonl" \
+  --dir ./dist
+
+slsa-verifier verify-artifact "dist/kubearmor_${VERSION}_linux-amd64.tar.gz" \
+  --provenance-path dist/*.intoto.jsonl \
+  --source-uri "github.com/kubearmor/KubeArmor" \
+  --source-tag "v${VERSION}"
+```
+
+---
+
+## Verifying SBOM signatures
+
+Starting with releases that include SBOM files (`*.sbom.spdx.json`), the SBOM itself is also signed:
+
+```bash
+cosign verify-blob \
+  --bundle "kubearmor_${VERSION}_linux-amd64.tar.gz.sbom.spdx.json.sigstore.json" \
+  --certificate-identity-regexp \
+    "https://github.com/kubearmor/KubeArmor/.github/workflows/ci-systemd-release.yml@.*" \
+  --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+  "kubearmor_${VERSION}_linux-amd64.tar.gz.sbom.spdx.json"
+```
+
+---
+
+## OpenSSF Scorecard baseline
+
+KubeArmor is tracked on [OpenSSF Scorecard](https://scorecard.dev/viewer/?uri=github.com/kubearmor/KubeArmor).
+
+**Baseline snapshot (2026-05-17, aggregate 6.3/10):**
+
+| Check | Score | Notes |
+|---|---|---|
+| Binary-Artifacts | 0/10 | Some pre-compiled binaries present in repo tree |
+| Branch-Protection | 1/10 | Branch protection not maximal on all release branches |
+| CI-Tests | 10/10 | All merged PRs checked by CI |
+| CII-Best-Practices | 5/10 | OpenSSF Best Practices badge: passing |
+| Code-Review | 10/10 | All changesets reviewed |
+| Contributors | 10/10 | 30+ organisations contributing |
+| Dangerous-Workflow | 10/10 | No dangerous workflow patterns |
+| Dependency-Update-Tool | 10/10 | Dependabot / Renovate detected |
+| Fuzzing | 10/10 | Project is fuzzed |
+| License | 10/10 | Apache-2.0 detected |
+| Maintained | 10/10 | Active commits and issues |
+| Packaging | 10/10 | Publishing workflow detected |
+| Pinned-Dependencies | 0/10 | Several GitHub Actions used floating tags |
+| SAST | 10/10 | CodeQL runs on all commits |
+| Security-Policy | 10/10 | SECURITY.md present |
+| **Signed-Releases** | **0/10** | Stale cached result — `.sigstore.json` bundles ARE present in releases; score will update on next weekly scan |
+| Token-Permissions | 0/10 | Some workflow tokens have write permissions not scoped to specific needs |
+| Vulnerabilities | 5/10 | 5 existing CVEs in dependencies |
+
+### What this PR improves
+
+| Check | Before | After |
+|---|---|---|
+| Pinned-Dependencies | 0/10 | Improved — all release workflow actions SHA-pinned |
+| Signed-Releases | 0/10 | Stable — signing already in place; SBOM signing added |
+
+**Checks addressed by this PR:**
+- `ci-latest-release.yml`: All `uses:` directives pinned to commit SHA
+- `ci-operator-release.yaml`: All `uses:` directives pinned to commit SHA
+- `ci-stable-release.yml`: All `uses:` directives pinned to commit SHA
+- `ci-systemd-release.yml`: Added `attestations: write` permission and `actions/attest-build-provenance` step; all SHAs pinned
+- `KubeArmor/.goreleaser.yaml`: SBOM generation added; SBOM is also signed by the existing `signs` block
+
+### Remaining gaps (not in scope for this PR)
+
+- **Binary-Artifacts**: Pre-compiled object files checked into the repo source tree should be removed or generated at build time.
+- **Branch-Protection**: Requires admin-level GitHub settings changes.
+- **Token-Permissions**: Individual workflow jobs need scoped permission blocks; tracked separately.
+
+---
+
+## Tools used
+
+| Tool | Purpose |
+|---|---|
+| [cosign](https://github.com/sigstore/cosign) v2+ | Keyless signing and verification of blobs and images |
+| [slsa-verifier](https://github.com/slsa-framework/slsa-verifier) | SLSA provenance verification |
+| [slsa-github-generator](https://github.com/slsa-framework/slsa-github-generator) | SLSA Level 3 provenance generation in CI |
+| [GoReleaser](https://goreleaser.com/) | Builds, packages, and signs binary release artifacts |
+| [scorecard](https://github.com/ossf/scorecard) | OpenSSF supply-chain risk scoring |


### PR DESCRIPTION
**Purpose of PR?**:

Enables and verifies the Signed-Releases check on KubeArmor's OpenSSF Scorecard, targeting 10/10.

The existing release pipeline used `cosign sign-blob` which produces Sigstore bundles with a `messageSignature` payload. Scorecard detects these signatures but caps Signed-Releases at 8/10 because it cannot derive provenance claims from a plain blob signature.

This PR switches GoReleaser to `cosign attest-blob --type=slsaprovenance`, embedding a DSSE envelope (in-toto statement) inside each `.sigstore.json` bundle. A post-GoReleaser step extracts the envelopes and combines them into `multiple-linux-{arch}.intoto.jsonl` files uploaded to the GitHub Release. Scorecard scans `*.intoto.jsonl` assets and awards 10/10.

Additionally, all GitHub Actions `uses:` directives across the four release workflows are pinned to full commit SHAs (fixing Pinned-Dependencies from 0/10), SBOM generation is added to GoReleaser, and GitHub native build-provenance attestations are added via `actions/attest-build-provenance`.

Fixes #2566

**Does this PR introduce a breaking change?**

No. `.sigstore.json` files are still produced per artifact; they now contain a `dsseEnvelope` instead of `messageSignature`. The `multiple-linux-{arch}.intoto.jsonl` upload is purely additive.

**If the changes in this PR are manually verified, list down the scenarios covered:**:

- `cosign attest-blob` produces bundles with `dsseEnvelope` (required for Scorecard 10/10 vs 8/10 cap with `sign-blob`)
- `cosign verify-blob-attestation --type slsaprovenance` successfully verifies the DSSE bundles
- No floating action tags (`@vN` or `@main`) remain in any of the four release workflows
- `multiple-linux-{arch}.intoto.jsonl` upload job runs on `ubuntu-latest` with scoped `contents: write` permission only
- SBOM generation added to GoReleaser; SBOM is also signed by the existing `signs` block

**Additional information for reviewer?** :

Changes per file:
- `KubeArmor/.goreleaser.yaml`: `sign-blob` → `attest-blob` with `--predicate`, `--type=slsaprovenance`, and `--new-bundle-format` (required to emit `dsseEnvelope` in Sigstore bundle v0.3 format); added `sboms` block for SBOM generation
- `.github/workflows/ci-systemd-release.yml`: SLSA predicate creation step, DSSE envelope combination into `multiple-linux-{arch}.intoto.jsonl`, `upload-provenance` job, all actions SHA-pinned, `attestations: write` permission, `actions/attest-build-provenance` step, verify step updated to `cosign verify-blob-attestation`
- `.github/workflows/ci-latest-release.yml`: all `uses:` pinned to commit SHA
- `.github/workflows/ci-operator-release.yaml`: all `uses:` pinned to commit SHA
- `.github/workflows/ci-stable-release.yml`: all `uses:` pinned to commit SHA
- `docs/supply-chain-security.md`: new file with binary/image/SLSA/SBOM verification guide and Scorecard baseline

**Checklist:**
- [ ] Bug fix. Fixes #2566
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
- [x] PR Title follows the convention of `<type>(<scope>): <subject>`
- [ ] Commit has unit tests
- [ ] Commit has integration tests

<img width="1346" height="1013" alt="Screenshot 2026-05-17 155853" src="https://github.com/user-attachments/assets/54b0a945-e7c5-4066-af76-a24c86787dd4" />

<img width="1079" height="501" alt="Screenshot 2026-05-17 120539" src="https://github.com/user-attachments/assets/43205ad8-1252-4053-8d9f-6887a844de44" />

<img width="1719" height="813" alt="Screenshot 2026-05-17 124421" src="https://github.com/user-attachments/assets/1034fc22-76b3-45fa-ad5f-4dd8ca3771d0" />
