### PR TITLE
feat(examples): add environment file protection policy

### DIFF
--- a/yourusernexamples/examples/protect-env-files/block-env-access.yaml
+++ b/yourusernexamples/examples/protect-env-files/block-env-access.yaml
@@ -1,0 +1,14 @@
+apiVersion: security.kubearmor.com/v1
+kind: KubeArmorPolicy
+metadata:
+  name: block-env-file-access
+  namespace: default
+spec:
+  selector:
+    matchLabels:
+      app: ubuntu
+  file:
+    matchPaths:
+    - path: /app/.env
+  action:
+    Block


### PR DESCRIPTION
## Purpose of PR

This PR adds a new KubeArmor policy example to protect sensitive `.env` files inside containers.

## Changes Made

* Added `block-env-access.yaml`
* Added example documentation in `README.md`

## Use Case

This policy helps prevent unauthorized access to:

* API keys
* database credentials
* secret tokens
* environment configuration files
