### PR TITLE
fix(bpf): populate correct source binary path in protectproc events

### DIFF
--- a/KubeArmor/BPF/protectproc.bpf.c
+++ b/KubeArmor/BPF/protectproc.bpf.c
@@ -93,7 +93,7 @@ int BPF_PROG(enforce_file, struct file *file) {
     __builtin_memset(event_data->data.source, 0, sizeof(event_data->data.source));
 
     bpf_probe_read_str(event_data->data.path, 80, path_store->path);
-    bpf_probe_read_str(event_data->data.source, MAX_STRING_SIZE, source_store->source);
+    bpf_probe_read_str(event_data->data.source, MAX_STRING_SIZE, source_store->path);
     
     init_context(event_data);
     event_data->event_id = PROTECT_PROC;


### PR DESCRIPTION
### Description
Fixes #2615

This PR fixes a bug in `protectproc.bpf.c` where the source binary field (`event_data->data.source`) is consistently reported as empty in generated security alerts.

### Root Cause
The inline helper function `get_full_path_from_file_ptr()` resolves paths into `store->path`. However, `protectproc.bpf.c` was trying to read the string out of `source_store->source`, which is unpopulated/zeroed out. 

Updating this to `source_store->path` (aligning it with the correct implementation already present in `protectenv.bpf.c`) ensures that the culprit binary's path is properly captured and passed down to audit logs.

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)