### PR TITLE
fix(ci): wait for k3s apiserver readiness before helm install on crio

### DIFF
--- a/.github/workflows/ci-test-ginkgo.yml
+++ b/.github/workflows/ci-test-ginkgo.yml
@@ -64,6 +64,43 @@ jobs:
       - name: Setup a Kubernetes environment
         run: ./.github/workflows/install-k3s.sh
 
+      - name: Wait for k3s nodes and CoreDNS to be ready
+        run: |
+          set -Eeuo pipefail
+          dump_k3s_diagnostics() {
+            echo "::group::k3s diagnostics"
+            echo "Wait for k3s readiness failed; dumping cluster state..."
+            kubectl get nodes -o wide || true
+            kubectl -n kube-system get pods -o wide || true
+            kubectl get events -A --sort-by=.metadata.creationTimestamp | tail -n 100 || true
+            echo "::endgroup::"
+          }
+          trap 'dump_k3s_diagnostics' ERR
+          echo "Waiting for at least one Kubernetes node to be registered..."
+          for i in $(seq 1 60); do
+            if [ "$(kubectl get nodes --no-headers 2>/dev/null | wc -l)" -gt 0 ]; then
+              break
+            fi
+            sleep 5
+            if [ "$i" -eq 60 ]; then
+              echo "Timed out waiting for any Kubernetes node to be registered"
+              exit 1
+            fi
+          done
+          kubectl wait --for=condition=Ready node --all --timeout=5m
+          echo "Waiting for CoreDNS deployment to be created..."
+          for i in $(seq 1 60); do
+            if kubectl -n kube-system get deployment/coredns >/dev/null 2>&1; then
+              break
+            fi
+            sleep 5
+            if [ "$i" -eq 60 ]; then
+              echo "Timed out waiting for CoreDNS deployment to be created"
+              exit 1
+            fi
+          done
+          kubectl -n kube-system rollout status deployment/coredns --timeout=5m
+
       - name: Generate KubeArmor artifacts
         run: |
           #set the $IS_COVERAGE env var to 'true' to build the kubearmor-test image for coverage calculation
@@ -143,7 +180,7 @@ jobs:
           docker buildx prune -a -f
           helm upgrade --install kubearmor-operator ./deployments/helm/KubeArmorOperator -n kubearmor --create-namespace --set kubearmorOperator.image.tag=latest  --set kubearmorOperator.annotateExisting=true
           
-          kubectl rollout status --timeout=5m deployment -n kubearmor -l kubearmor-app=kubearmor-operator
+          kubectl rollout status --timeout=7m deployment -n kubearmor -l kubearmor-app=kubearmor-operator
           
           kubectl get pods -A
           if [[ ${{ steps.filter.outputs.controller }} == 'true' ]]; then


### PR DESCRIPTION
**Purpose of PR?**: Fixes the `crio` matrix job in `ci-test-ginkgo` which fails with `apiserver not ready` because the k3s control plane is not fully stable before subsequent steps run. Confirmed failing on upstream PRs.

**Fixes**: #2622

**Does this PR introduce a breaking change?** No.

**If the changes in this PR are manually verified, list down the scenarios covered?**: The `crio` matrix job `Auto-testing Framework / oracle-vm-16cpu-64gb-x86-64 / crio` was observed failing consistently across multiple PRs. The `deploy pre existing pod` step fails with `connection to server 127.0.0.1:6443 was refused` because the apiserver is not stable after `install-k3s.sh` exits.

`Setup a Kubernetes environment` runs for 15m 51s with the wait loop spinning on connection refused:
<img width="1494" height="695" alt="Screenshot from 2026-05-22 16-42-32" src="https://github.com/user-attachments/assets/1932d3f4-ef9e-4636-b4c8-420537abc514" />


The job then fails at `deploy pre existing pod` with apiserver still not ready:
<img width="1482" height="114" alt="Screenshot from 2026-05-22 16-44-23" src="https://github.com/user-attachments/assets/818c222e-870e-4fd1-9b8d-947a1212fb1b" />


**Additional information for reviewer?**: The `install-k3s.sh` script exits as soon as the k3s wait loop condition is met, but the apiserver is not always fully stable at that point. Subsequent steps like `deploy pre existing pod` immediately issue `kubectl apply` and `kubectl get pods` while the apiserver is still settling, causing `connection refused` errors. The fix moves two explicit readiness gates into a dedicated step right after `Setup a Kubernetes environment` and before any kubectl usage: one for node Ready condition and one for CoreDNS rollout status, which is a reliable proxy for full control plane stabilization. Previously these gates were placed inside `Run KubeArmor` which was too late. This is the same class of crio timing issue addressed in commits `35dca991` and `8b414d5b`. Failing runs observed in PRs #2539 #2527 #2531 #2530 #2538.

**Screenshot of current CI test results**: 
<img width="770" height="812" alt="image" src="https://github.com/user-attachments/assets/eac3d58d-7aab-463d-8f63-c69d919a8c60" />


**Checklist:**
- [x] Bug fix. Fixes #
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] PR Title follows the convention of `<type>(<scope>): <subject>`
- [ ] Commit has unit tests
- [ ] Commit has integration tests