### PR TITLE
chore(init-container): fix init ubi container build issue

### DIFF
--- a/Dockerfile.init
+++ b/Dockerfile.init
@@ -31,7 +31,10 @@ LABEL name="kubearmor-init" \
       description="kubearmor-init image for kubearmor init container image"
 
 RUN microdnf -y update && \
-    microdnf -y install --nodocs --setopt=install_weak_deps=0 --setopt=keepcache=0 shadow-utils git clang llvm make gcc libbpf tar gzip && \
+    microdnf -y install --nodocs --setopt=install_weak_deps=0 --setopt=keepcache=0 \
+        glibc-devel && \
+    microdnf -y install --nodocs --setopt=install_weak_deps=0 --setopt=keepcache=0 \
+        shadow-utils git clang llvm make gcc libbpf tar gzip && \
     microdnf clean all
 
 # install bpftool  


### PR DESCRIPTION
**Purpose of PR?**:
ubi based init container image build was failing due to glibc-devel package dependency. this PR fixes the issue installing glibc-devel package before installing gcc. 
```
6.252 Error: 
6.252  Problem 1: package gcc-14.3.1-4.4.el10.x86_64 from ubi-10-for-x86_64-appstream-rpms requires glibc-devel >= 2.2.90-12, but none of the providers can be installed
6.252   - conflicting requests
6.252   - nothing provides glibc = 2.39-124.el10_2 needed by glibc-devel-2.39-124.el10_2.x86_64 from ubi-10-for-x86_64-appstream-rpms
6.252  Problem 2: package gcc-c++-14.3.1-4.4.el10.x86_64 from ubi-10-for-x86_64-appstream-rpms requires gcc = 14.3.1-4.4.el10, but none of the providers can be installed
6.252   - package clang-21.1.8-1.el10.x86_64 from ubi-10-for-x86_64-appstream-rpms requires gcc-c++, but none of the providers can be installed
6.252   - package gcc-14.3.1-4.4.el10.x86_64 from ubi-10-for-x86_64-appstream-rpms requires glibc-devel >= 2.2.90-12, but none of the providers can be installed
6.252   - conflicting requests
6.252   - nothing provides glibc = 2.39-124.el10_2 needed by glibc-devel-2.39-124.el10_2.x86_64 from ubi-10-for-x86_64-appstream-rpms
6.252 (try to add '--skip-broken' to skip uninstallable packages or '--nobest' to use not only best candidate packages)
------
WARNING: No output specified with docker-container driver. Build result will only remain in the build cache. To push result image into registry use --push or to load image into docker use --load
Dockerfile.init:33
--------------------
  32 |     
  33 | >>> RUN dnf -y update && \
  34 | >>>     dnf -y install --nodocs --setopt=install_weak_deps=0 --setopt=keepcache=0 shadow-utils git clang llvm make gcc libbpf tar gzip && \
  35 | >>>     dnf clean all
  36 |     
--------------------
```

**Does this PR introduce a breaking change?**

**If the changes in this PR are manually verified, list down the scenarios covered:**:

**Additional information for reviewer?** :
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [x] Bug fix.
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Commit has unit tests
- [ ] Commit has integration tests

<!--

The PR title message must follow convention:
`<type>(<scope>): <subject>`.

Where: <br />
- `type` is to define what type of PR is this.
  Most common types are:
    - `feat`      - for new features, not a new feature for build script
    - `fix`       - for bug fixes or improvements, not a fix for build script
    - `chore`     - changes not related to production code
    - `docs`      - changes related to documentation
    - `style`     - formatting, missing semi colons, linting fix etc; no significant production code changes
    - `test`      - adding missing tests, refactoring tests; no production code change
    - `refactor`  - refactoring production code, eg. renaming a variable or function name, there should not be any significant production code changes

- `scope` is a single word that best describes where the changes fit.
    - feature(`monitor`,`enforcer`)
    - test(`tests`, `bdd`)
    - chore(`build`)
- `subject` is a single line brief description of the changes made in the pull request.

-->