### PR TITLE
fix(monitor): system monitor verifier error on Ubuntu 18 with clang 12

### DIFF
--- a/KubeArmor/BPF/system_monitor.c
+++ b/KubeArmor/BPF/system_monitor.c
@@ -1025,8 +1025,9 @@ static __always_inline int save_all_hashes_to_the_buffer(bufs_t *bufs_p, bool ad
     if (num_of_hashes_idx >= MAX_BUFFER_SIZE || num_of_hashes_idx + num_of_hashes >= MAX_BUFFER_SIZE)
         return -1;
 
-    u32 idx = num_of_hashes_idx & (MAX_BUFFER_SIZE - 1);
+    u32 idx = num_of_hashes_idx;
     volatile_reg(idx);
+    idx &= (MAX_BUFFER_SIZE - 1);
 
     if (bpf_probe_read(&(bufs_p->buf[idx]), sizeof(u8), &num_of_hashes) != 0)
     {


### PR DESCRIPTION
**Purpose of PR?**:
System Monitor was failing to load on Ubuntu 18.04 (kernel version 4.15.0-213-generic) with clang version 12 with an eBPF verifier issue
```
R0=inv0 R1=map_value(id=0,off=0,ks=4,vs=32768,umax_value=4294967295,var_off=(0x0; 0xffffffff)) R2=inv1 R3=fp-28 R6=inv0 R7=map_value(id=0,off=0,ks=4,vs=32768,umax_value=4294967295,var_off=(0x0; 0xffffffff)) R8=inv0 R9=inv(id=0,umax_value=4294967295,var_off=(0x0; 0xffffffff)) R10=fp0 fp-264=ctx
	R1 unbounded memory access, make sure to bounds check any array access into a map
2026-05-21 05:55:04.924820	ERROR	Failed to initialize KubeArmor Monitor: failed to initialize BPF: bpf module is nil program kretprobe__execveat: load program: permission denied: R0=inv0 R1=map_value(id=0,off=0,ks=4,vs=32768,umax_value=4294967295,var_off=(0x0; 0xffffffff)) R2=inv1 R3=fp-28 R6=inv0 R7=map_value(id=0,off=0,ks=4,vs=32768,umax_value=4294967295,var_off=(0x0; 0xffffffff)) R8=inv0 R9=inv(id=0,umax_value=4294967295,var_off=(0x0; 0xffffffff)) R10=fp0 fp-264=ctx: R1 unbounded memory access, make sure to bounds check any array access into a map (413 line(s) omitted)
github.com/kubearmor/KubeArmor/KubeArmor/log.Err
	/home/vagrant/KubeArmor/KubeArmor/log/logger.go:103
github.com/kubearmor/KubeArmor/KubeArmor/feeder.(*Feeder).Errf
	/home/vagrant/KubeArmor/KubeArmor/feeder/feeder.go:501
github.com/kubearmor/KubeArmor/KubeArmor/core.KubeArmor
	/home/vagrant/KubeArmor/KubeArmor/core/kubeArmor.go:679
main.main
	/home/vagrant/KubeArmor/KubeArmor/main.go:74
runtime.main
	/usr/local/go/src/runtime/proc.go:290
```

Fixes #2606 

**Does this PR introduce a breaking change?**
No

**If the changes in this PR are manually verified, list down the scenarios covered:**
Ubuntu 18.04.6 LTS (kernel version 4.15.0-213-generic) with Clang 12
<img width="1871" height="788" alt="image" src="https://github.com/user-attachments/assets/5573b69b-f95d-4209-a468-f94e180ef1b4" />

Also tested on Ubuntu 24.04.4 LTS (kernel version 6.17.0-29-generic) with Clang 19

**Additional information for reviewer?** :
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [x] Bug fix. Fixes #2606 
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Commit has unit tests
- [ ] Commit has integration tests

<!--

The PR title message must follow convention:
`<type>(<scope>): <subject>`.

Where: <br />
- `type` is to define what type of PR is this.
  Most common types are:
    - `feat`      - for new features, not a new feature for build script
    - `fix`       - for bug fixes or improvements, not a fix for build script
    - `chore`     - changes not related to production code
    - `docs`      - changes related to documentation
    - `style`     - formatting, missing semi colons, linting fix etc; no significant production code changes
    - `test`      - adding missing tests, refactoring tests; no production code change
    - `refactor`  - refactoring production code, eg. renaming a variable or function name, there should not be any significant production code changes

- `scope` is a single word that best describes where the changes fit.
    - feature(`monitor`,`enforcer`)
    - test(`tests`, `bdd`)
    - chore(`build`)
- `subject` is a single line brief description of the changes made in the pull request.

-->