### PR TITLE
fix(test): use KarmorGetTargetAlert in blockposture to fix intermittent CI failures

### DIFF
--- a/tests/k8s_env/blockposture/block_test.go
+++ b/tests/k8s_env/blockposture/block_test.go
@@ -6,6 +6,7 @@ package blockposture
 import (
 	"time"
 
+	pb "github.com/kubearmor/KubeArmor/protobuf"
 	"github.com/kubearmor/KubeArmor/tests/util"
 	. "github.com/kubearmor/KubeArmor/tests/util"
 	. "github.com/onsi/ginkgo/v2"
@@ -84,11 +85,12 @@ var _ = Describe("Posture", func() {
 				MatchRegexp("<!DOCTYPE html>((?:.*\r?\n?)*)</html>"), true,
 			)
 			// check policy violation alert
-			_, alerts, err := KarmorGetLogs(10*time.Second, 1)
+			res, err := KarmorGetTargetAlert(10*time.Second, &pb.Alert{
+				PolicyName: "DefaultPosture",
+				Action:     "Block",
+			})
 			Expect(err).To(BeNil())
-			Expect(len(alerts)).To(BeNumerically(">=", 1))
-			Expect(alerts[0].PolicyName).To(Equal("DefaultPosture"))
-			Expect(alerts[0].Action).To(Equal("Block"))
+			Expect(res.Found).To(BeTrue())
 		})
 	})
 


### PR DESCRIPTION
**Purpose of PR?**: The `blockposture` suite fails intermittently on the `containerd` CI job due to a race condition in how `KarmorGetLogs` handles mixed event types.

**Fixes:** #2634

**Root cause**: `KarmorGetLogs` counts both `Log` and `Alert` events toward the `maxEvents` limit. With `maxEvents: 1`, the first event off the channel is a `Log` from the allowed `cat /usr/share/nginx/html/index.html` command. This hits `evtCnt >= 1` and triggers early exit before the `Alert` for the blocked `cat docker-entrypoint.sh` arrives, returning an empty alerts slice. The 10s timeout is never the bottleneck - the function exits immediately on the first log event regardless of runner load.

**Fix**: Switch to `KarmorGetTargetAlert` which ignores `Log` events entirely and only returns when it finds an alert matching `PolicyName` and `Action`, or the timeout fires. The original 10s timeout is kept unchanged. No CI time increase.

**Does this PR introduce a breaking change?** No.

**If the changes in this PR are manually verified, list down the scenarios covered?**: The fix is verifiable by code inspection - `KarmorGetTargetAlert` cannot exit early on a log event by construction. `go build` and `go vet` pass cleanly on the changed file. The intermittent nature of the original failure (runner-load-dependent) makes local reproduction impractical, but the root cause is confirmed by reading `KarmorGetLogs` in `tests/util/karmorlog.go`: the `evtCnt` counter increments on every event type, not just alerts.

**Additional information for reviewer?**: All other `KarmorGetLogs` call sites use `maxEvents: 50` and collect logs in bulk, so they are unaffected by this bug. Only `blockposture` and `throttling` use `maxEvents: 1` while caring only about alerts - `blockposture` is fixed here. The `throttling` tests may have the same latent issue.

**Checklist:**
- [x] Bug fix. Fixes #2634
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] PR Title follows the convention of `<type>(<scope>): <subject>`
- [ ] Commit has unit tests
- [ ] Commit has integration tests