### PR TITLE
Fix: RBAC permissions for kubearmor service accounts

### DIFF
--- a/deployments/helm/KubeArmorOperator/templates/clusterrole-rbac.yaml
+++ b/deployments/helm/KubeArmorOperator/templates/clusterrole-rbac.yaml
@@ -29,6 +29,10 @@ rules:
   - create
   - get
   - update
+  - patch
+  - delete
+  - list
+  - watch
 - apiGroups:
   - operator.kubearmor.com
   resources:

--- a/deployments/helm/KubeArmorOperator/templates/rbac.yaml
+++ b/deployments/helm/KubeArmorOperator/templates/rbac.yaml
@@ -1,0 +1,114 @@
+{{- if .Values.rbac.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kubearmor-snitch
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "kubearmor-operator.labels" . | nindent 4 }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kubearmor-snitch-clusterrole
+  labels:
+    {{- include "kubearmor-operator.labels" . | nindent 4 }}
+rules:
+- apiGroups: [""]
+  resources: ["nodes"]
+  verbs: ["patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kubearmor-snitch-clusterrole-binding
+  labels:
+    {{- include "kubearmor-operator.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kubearmor-snitch-clusterrole
+subjects:
+- kind: ServiceAccount
+  name: kubearmor-snitch
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kubearmor-controller
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "kubearmor-operator.labels" . | nindent 4 }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kubearmor-controller-clusterrole
+  labels:
+    {{- include "kubearmor-operator.labels" . | nindent 4 }}
+rules:
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["list", "watch"]
+- apiGroups: ["security.kubearmor.com"]
+  resources:
+  - kubearmorhostpolicies
+  - kubearmorpolicies
+  verbs: ["list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kubearmor-controller-clusterrole-binding
+  labels:
+    {{- include "kubearmor-operator.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kubearmor-controller-clusterrole
+subjects:
+- kind: ServiceAccount
+  name: kubearmor-controller
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kubearmor
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "kubearmor-operator.labels" . | nindent 4 }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kubearmor-bpf-containerd-clusterrole
+  labels:
+    {{- include "kubearmor-operator.labels" . | nindent 4 }}
+rules:
+- apiGroups: [""]
+  resources:
+  - configmaps
+  - namespaces
+  - nodes
+  verbs: ["list", "watch"]
+- apiGroups: ["security.kubearmor.com"]
+  resources: ["kubearmorpolicies"]
+  verbs: ["list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kubearmor-bpf-containerd-clusterrole-binding
+  labels:
+    {{- include "kubearmor-operator.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kubearmor-bpf-containerd-clusterrole
+subjects:
+- kind: ServiceAccount
+  name: kubearmor
+  namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/deployments/helm/KubeArmorOperator/values.yaml
+++ b/deployments/helm/KubeArmorOperator/values.yaml
@@ -1,9 +1,13 @@
 autoDeploy: false
 # operator will deploy pinned images for each application
 imagePinning: false
-  
+
+# Set to false only if your cluster admin will manage RBAC manually
+rbac:
+  create: true
+
 # To use existing secret updated {registry.secretName} with your secret name.
-registry: 
+registry:
   secretName: ""
 
 # pinned images
@@ -46,7 +50,7 @@ kubearmorOperator:
   args: []
   # https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
   tolerations: []
-  resources: {} 
+  resources: {}
   podLabels: {}
   podAnnotations: {}
   podSecurityContext: {}
@@ -68,7 +72,7 @@ kubearmorConfig:
   throttleSec: 30
   matchArgs: true
 
-# DO NOT CHANGE THIS VALUES 
+# DO NOT CHANGE THIS VALUES
 # changing these values will require code changes with the operator
 # these secret names should match with the secrets managed by the operator
 tlsSecrets:

--- a/pkg/KubeArmorOperator/clusterrole.go
+++ b/pkg/KubeArmorOperator/clusterrole.go
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Authors of KubeArmor
+
+package operator
+
+import (
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func SnitchClusterRole() *rbacv1.ClusterRole {
+	return &rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "kubearmor-snitch-clusterrole",
+		},
+		Rules: []rbacv1.PolicyRule{
+			{
+				APIGroups: []string{""},
+				Resources: []string{"nodes"},
+				Verbs:     []string{"patch"},
+			},
+		},
+	}
+}
+
+func ControllerClusterRole() *rbacv1.ClusterRole {
+	return &rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "kubearmor-controller-clusterrole",
+		},
+		Rules: []rbacv1.PolicyRule{
+			{
+				APIGroups: []string{""},
+				Resources: []string{"pods"},
+				Verbs:     []string{"list", "watch"},
+			},
+			{
+				APIGroups: []string{"security.kubearmor.com"},
+				Resources: []string{"kubearmorhostpolicies", "kubearmorpolicies"},
+				Verbs:     []string{"list", "watch"},
+			},
+		},
+	}
+}
+
+func BpfContainerdClusterRole() *rbacv1.ClusterRole {
+	return &rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "kubearmor-bpf-containerd-clusterrole",
+		},
+		Rules: []rbacv1.PolicyRule{
+			{
+				APIGroups: []string{""},
+				Resources: []string{"configmaps", "namespaces", "nodes"},
+				Verbs:     []string{"list", "watch"},
+			},
+			{
+				APIGroups: []string{"security.kubearmor.com"},
+				Resources: []string{"kubearmorpolicies"},
+				Verbs:     []string{"list", "watch"},
+			},
+		},
+	}
+}

--- a/pkg/KubeArmorOperator/clusterrolebinding.go
+++ b/pkg/KubeArmorOperator/clusterrolebinding.go
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Authors of KubeArmor
+
+package operator
+
+import (
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func clusterRoleBinding(name, roleName, saName, namespace string) *rbacv1.ClusterRoleBinding {
+	return &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "ClusterRole",
+			Name:     roleName,
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:      "ServiceAccount",
+				Name:      saName,
+				Namespace: namespace,
+			},
+		},
+	}
+}
+
+func SnitchClusterRoleBinding(namespace string) *rbacv1.ClusterRoleBinding {
+	return clusterRoleBinding(
+		"kubearmor-snitch-clusterrole-binding",
+		"kubearmor-snitch-clusterrole",
+		"kubearmor-snitch",
+		namespace,
+	)
+}
+
+func ControllerClusterRoleBinding(namespace string) *rbacv1.ClusterRoleBinding {
+	return clusterRoleBinding(
+		"kubearmor-controller-clusterrole-binding",
+		"kubearmor-controller-clusterrole",
+		"kubearmor-controller",
+		namespace,
+	)
+}
+
+func BpfContainerdClusterRoleBinding(namespace string) *rbacv1.ClusterRoleBinding {
+	return clusterRoleBinding(
+		"kubearmor-bpf-containerd-clusterrole-binding",
+		"kubearmor-bpf-containerd-clusterrole",
+		"kubearmor",
+		namespace,
+	)
+}


### PR DESCRIPTION
## Problem
When KubeArmor is installed via Helm, three component service accounts are created
without corresponding RBAC permissions, causing runtime permission errors:

## Solution
Create RBAC ClusterRole and ClusterRoleBinding resources for all three service
accounts in both the Helm chart and Go operator code.

Fix: #1565 