### PR TITLE
feat(core): Improve policy matching for hostnames

### DIFF
--- a/KubeArmor/common/common.go
+++ b/KubeArmor/common/common.go
@@ -513,21 +513,67 @@ func MatchIdentities(identities, superIdentities []string) bool {
 			continue
 		}
 
-		if strings.Contains(identity, "kubearmor.io/hostname") {
-			if !MatchesRegex("kubearmor.io/hostname", identity, superIdentities) {
+		// kubearmor.io/hostnamereg=node-*, will match for kubearmor.io/hostname=node-1, kubearmor.io/hostname=node-2, etc
+		if strings.HasPrefix(identity, "kubearmor.io/hostnamereg=") {
+			pattern := strings.TrimPrefix(identity, "kubearmor.io/hostnamereg=")
+			pattern = strings.ReplaceAll(pattern, "*", ".*")
+			fullRegexElement := "kubearmor\\.io/hostname=" + pattern
+
+			if !MatchesRegex("kubearmor.io/hostname", fullRegexElement, superIdentities) {
 				matched = false
 				break
 			}
-
 			continue
 		}
 
-		if strings.Contains(identity, "kubernetes.io/hostname") {
-			if !MatchesRegex("kubernetes.io/hostname", identity, superIdentities) {
+		// kubernetes.io/hostnamereg=node-*, will match for kubernetes.io/hostname=node-1, kubernetes.io/hostname=node-2, etc, but only in k8s env
+		if strings.HasPrefix(identity, "kubernetes.io/hostnamereg=") && IsK8sEnv() {
+			pattern := strings.TrimPrefix(identity, "kubernetes.io/hostnamereg=")
+			pattern = strings.ReplaceAll(pattern, "*", ".*")
+			fullRegexElement := "kubernetes\\.io/hostname=" + pattern
+
+			if !MatchesRegex("kubernetes.io/hostname", fullRegexElement, superIdentities) {
+				matched = false
+				break
+			}
+			continue
+		}
+
+		// comma-separated hostnames (kubearmor.io/hostname=node1,node2, kubernetes.io/hostname=node1,node2 in k8s env, or * for all hostnames)
+		if strings.HasPrefix(identity, "kubearmor.io/hostname=") || (strings.HasPrefix(identity, "kubernetes.io/hostname=") && IsK8sEnv()) {
+			parts := strings.SplitN(identity, "=", 2)
+
+			if len(parts) != 2 {
 				matched = false
 				break
 			}
 
+			key := parts[0] // kubearmor.io/hostname or kubernetes.io/hostname
+			found := false
+
+			for _, val := range strings.Split(parts[1], ",") {
+				if val == "*" {
+					// check if the target machine has ANY label starting with this key
+					for _, super := range superIdentities {
+						if strings.HasPrefix(super, key+"=") {
+							found = true
+							break
+						}
+					}
+				} else if ContainsElement(superIdentities, key+"="+val) {
+					// exact match
+					found = true
+				}
+
+				if found {
+					break
+				}
+			}
+
+			if !found {
+				matched = false
+				break
+			}
 			continue
 		}
 


### PR DESCRIPTION
**Purpose of PR?**:
1. Add regex based policy matching for hostname label. For example, `kubearmor.io/hostnamereg=node-*` matches for nodes with label `kubearmor.io/hostname=node-1` and `kubearmor.io/hostname=node-2`. Similarly for `kubernetes.io/hostnamereg=` for k8s env.
2. Adds matching comma-separated list of hostnames. For example, `kubernetes.io/hostname=node-1,node-2` matches nodes with label `kubernetes.io/hostname=node-1` and `kubernetes.io/hostname=node-2`, and `kubernetes.io/hostname= "*"` matches for all nodes. Similarly, `kubearmor.io/hostname=` for unorchestrated env.

Fixes #

**Does this PR introduce a breaking change?**
No

**If the changes in this PR are manually verified, list down the scenarios covered:**

**Additional information for reviewer?** :
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [ ] Bug fix. Fixes #<issue number>
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Commit has unit tests
- [ ] Commit has integration tests

<!--

The PR title message must follow convention:
`<type>(<scope>): <subject>`.

Where: <br />
- `type` is to define what type of PR is this.
  Most common types are:
    - `feat`      - for new features, not a new feature for build script
    - `fix`       - for bug fixes or improvements, not a fix for build script
    - `chore`     - changes not related to production code
    - `docs`      - changes related to documentation
    - `style`     - formatting, missing semi colons, linting fix etc; no significant production code changes
    - `test`      - adding missing tests, refactoring tests; no production code change
    - `refactor`  - refactoring production code, eg. renaming a variable or function name, there should not be any significant production code changes

- `scope` is a single word that best describes where the changes fit.
    - feature(`monitor`,`enforcer`)
    - test(`tests`, `bdd`)
    - chore(`build`)
- `subject` is a single line brief description of the changes made in the pull request.

-->