### PR TITLE
feat: support hostNetwork and dnsPolicy for kubearmor-controller webh…

### DIFF
--- a/pkg/KubeArmorOperator/api/operator.kubearmor.com/v1/kubearmorconfig_types.go
+++ b/pkg/KubeArmorOperator/api/operator.kubearmor.com/v1/kubearmorconfig_types.go
@@ -130,6 +130,13 @@ type KubeArmorConfigSpec struct {
 	DropResourceFromProcessLogs bool `json:"dropResourceFromProcessLogs,omitempty"`
 
 	MatchArgs bool `json:"matchArgs,omitempty"`
+
+	// +kubebuilder:default:=false
+	ControllerHostNetwork bool `json:"controllerHostNetwork,omitempty"`
+
+	// +kubebuilder:validation:Enum=ClusterFirst;ClusterFirstWithHostNet;Default;None
+	// +kubebuilder:default:=ClusterFirst
+	ControllerDNSPolicy string `json:"controllerDNSPolicy,omitempty"`
 }
 
 // KubeArmorConfigStatus defines the observed state of KubeArmorConfig

--- a/pkg/KubeArmorOperator/common/defaults.go
+++ b/pkg/KubeArmorOperator/common/defaults.go
@@ -153,6 +153,8 @@ var (
 	KubeArmorControllerWebhookServiceName                               = "kubearmor-controller-webhook-service"
 	KubeArmorControllerNodeSelector                                     = map[string]string{}
 	KubeArmorControllerEnv                                              = []corev1.EnvVar{}
+	KubeArmorControllerHostNetwork                                      bool   = false
+	KubeArmorControllerDNSPolicy                                        string = "ClusterFirst"
 
 	SeccompProfile     = "kubearmor-seccomp.json"
 	SeccompInitProfile = "kubearmor-init-seccomp.json"

--- a/pkg/KubeArmorOperator/internal/controller/cluster.go
+++ b/pkg/KubeArmorOperator/internal/controller/cluster.go
@@ -473,6 +473,7 @@ func (clusterWatcher *ClusterWatcher) WatchConfigCrd() {
 						UpdatedSeccomp(&cfg.Spec)
 						UpdateRecommendedPolicyConfig(&cfg.Spec)
 						utils.UpdateControllerPort(&cfg.Spec)
+						utils.UpdateControllerNetworkConfig(&cfg.Spec)
 						// update status to (Installation) Created
 						go clusterWatcher.UpdateCrdStatus(cfg.Name, common.CREATED, common.CREATED_MSG)
 						go clusterWatcher.WatchRequiredResources()
@@ -494,13 +495,14 @@ func (clusterWatcher *ClusterWatcher) WatchConfigCrd() {
 						configChanged := UpdateConfigMapData(&cfg.Spec)
 						imageUpdated := UpdateImages(&cfg.Spec)
 						controllerPortUpdated := utils.UpdateControllerPort(&cfg.Spec)
+						controllerNetworkUpdated := utils.UpdateControllerNetworkConfig(&cfg.Spec)
 						relayEnvUpdated := UpdatedKubearmorRelayEnv(&cfg.Spec)
 						seccompEnabledUpdated := UpdatedSeccomp(&cfg.Spec)
 						tlsUpdated := UpdateTlsData(&cfg.Spec)
 						UpdateRecommendedPolicyConfig(&cfg.Spec)
 
 						// return if only status has been updated
-						if !tlsUpdated && !relayEnvUpdated && !configChanged && cfg.Status != oldObj.(*opv1.KubeArmorConfig).Status && len(imageUpdated) < 1 && !controllerPortUpdated {
+						if !tlsUpdated && !relayEnvUpdated && !configChanged && cfg.Status != oldObj.(*opv1.KubeArmorConfig).Status && len(imageUpdated) < 1 && !controllerPortUpdated && !controllerNetworkUpdated {
 							return
 						}
 						if tlsUpdated {
@@ -527,6 +529,9 @@ func (clusterWatcher *ClusterWatcher) WatchConfigCrd() {
 						if controllerPortUpdated {
 							clusterWatcher.UpdateKubeArmorImages([]string{"controller"})
 							clusterWatcher.UpdateWebhookSvcPort(cfg.Spec.ControllerPort)
+						}
+						if controllerNetworkUpdated {
+							clusterWatcher.UpdateKubeArmorImages([]string{"controller"})
 						}
 					}
 				}
@@ -705,6 +710,10 @@ func (clusterWatcher *ClusterWatcher) UpdateKubeArmorImages(images []string) err
 					}
 				}
 				UpdateArgsIfDefinedAndUpdated(&controller.Spec.Template.Spec.Containers[0].Args, []string{"webhook-port=" + strconv.Itoa(common.KubeArmorControllerPort)})
+
+				// apply hostNetwork/dnsPolicy changes
+				controller.Spec.Template.Spec.HostNetwork = common.KubeArmorControllerHostNetwork
+				controller.Spec.Template.Spec.DNSPolicy = corev1.DNSPolicy(common.KubeArmorControllerDNSPolicy)
 
 				// update with globalNodeSelector
 				AddOrUpdateNodeSelector(controller.Spec.Template.Spec.NodeSelector, common.GlobalNodeSelectors)

--- a/pkg/KubeArmorOperator/internal/controller/resources.go
+++ b/pkg/KubeArmorOperator/internal/controller/resources.go
@@ -609,6 +609,11 @@ func (clusterWatcher *ClusterWatcher) deployControllerDeployment(deployment *app
 		deployment.Spec.Template.Spec.NodeSelector = make(map[string]string)
 	}
 
+	// apply hostNetwork and dnsPolicy for overlay CNI environments (e.g. EKS with Cilium/Calico VXLAN)
+	// where pod IPs are not VPC-routable and the API server cannot reach webhook pod IPs directly
+	deployment.Spec.Template.Spec.HostNetwork = common.KubeArmorControllerHostNetwork
+	deployment.Spec.Template.Spec.DNSPolicy = corev1.DNSPolicy(common.KubeArmorControllerDNSPolicy)
+
 	// update envs from kubearmorconfig
 	AddOrUpdateEnv(&deployment.Spec.Template.Spec.Containers[0].Env, common.GlobalEnv)
 	AddOrUpdateEnv(&deployment.Spec.Template.Spec.Containers[0].Env, common.KubeArmorControllerEnv)

--- a/pkg/KubeArmorOperator/utils/utils.go
+++ b/pkg/KubeArmorOperator/utils/utils.go
@@ -121,3 +121,20 @@ func UpdateControllerPort(config *opv1.KubeArmorConfigSpec) bool {
 
 	return updated
 }
+
+func UpdateControllerNetworkConfig(config *opv1.KubeArmorConfigSpec) bool {
+	updated := false
+	if config.ControllerHostNetwork != common.KubeArmorControllerHostNetwork {
+		common.KubeArmorControllerHostNetwork = config.ControllerHostNetwork
+		updated = true
+	}
+	dnsPolicy := config.ControllerDNSPolicy
+	if dnsPolicy == "" {
+		dnsPolicy = "ClusterFirst"
+	}
+	if dnsPolicy != common.KubeArmorControllerDNSPolicy {
+		common.KubeArmorControllerDNSPolicy = dnsPolicy
+		updated = true
+	}
+	return updated
+}


### PR DESCRIPTION
## PR Review

Hey @achrefbensaad @Ankurk99 @kranurag7 @daemon1024 @nam-jaehyun @nyrahul @rksharma95 @DelusionalOptimist 

---

### Summary

This PR adds `controllerHostNetwork` (default: `false`) and `controllerDNSPolicy` (default: `ClusterFirst`) fields to the `KubeArmorConfigSpec` CRD, allowing the controller webhook deployment to bind to the node IP. This fixes webhook reachability on overlay CNI environments (EKS + Cilium/Calico VXLAN) where pod IPs are not VPC-routable — closes #2642.

---

### What looks good

- CRD fields follow existing patterns with proper `+kubebuilder` markers for defaults and enum validation.
- `UpdateControllerNetworkConfig` in `utils/utils.go` mirrors the shape of `UpdateControllerPort` — consistent style.
- Both the **create** and **update** paths in `WatchConfigCrd` call `UpdateControllerNetworkConfig`, so the config is applied on first install and on live updates.
- `deployControllerDeployment` applies `HostNetwork`/`DNSPolicy` at deployment creation time, and `UpdateKubeArmorImages(["controller"])` triggers a rollout on live config changes — the reconciliation flow is correct.
- The enum constraint `ClusterFirst|ClusterFirstWithHostNet|Default|None` matches the valid values for `corev1.DNSPolicy`.

---

### Concerns / suggestions

1. **`hostNetwork: true` + `dnsPolicy: ClusterFirst` is a broken combination.**  
   When `hostNetwork` is enabled, Kubernetes requires `dnsPolicy: ClusterFirstWithHostNet` for cluster DNS to function; `ClusterFirst` silently falls back to the node's `/etc/resolv.conf`. Consider adding a kubebuilder validation rule or a warning in `UpdateControllerNetworkConfig` when this combination is set:
   ```go
   if config.ControllerHostNetwork && dnsPolicy == "ClusterFirst" {
       // log warning: ClusterFirstWithHostNet is recommended with hostNetwork
   }
   ```

2. **No tests added.**  
   `UpdateControllerNetworkConfig` is straightforward but has no unit tests. The checklist items for unit/integration tests are unchecked — worth adding at minimum a table-driven unit test covering the default-fill (`dnsPolicy == ""`) and the `updated` flag logic.

3. **PR checklist is empty.**  
   Please fill out the checklist (this is a new feature, non-breaking, relates to `KubeArmorOperator` scope) and reference the fix (`Fixes #2642`) in the dedicated field.

4. **Minor: duplicated assignment in `cluster.go` and `resources.go`.**  
   `HostNetwork` and `DNSPolicy` are set in both `UpdateKubeArmorImages` (cluster.go:714-715) and `deployControllerDeployment` (resources.go:612-613). This is fine since they read from the same global `common.*` vars, but worth a comment noting the globals are the source of truth, or consolidating into a shared helper.

---

Overall this is a clean, targeted fix for a real CNI compatibility gap. Resolving concern #1 (the broken `ClusterFirst`+`hostNetwork` combo) and adding minimal tests would make this merge-ready. Happy to help with either.