### PR TITLE
fix(operator): respect globalTolerations in snitch Job

### DIFF
--- a/pkg/KubeArmorOperator/internal/controller/cluster_test.go
+++ b/pkg/KubeArmorOperator/internal/controller/cluster_test.go
@@ -6,6 +6,7 @@ package controller
 import (
 	"testing"
 
+	"github.com/kubearmor/KubeArmor/pkg/KubeArmorOperator/common"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 )
@@ -183,4 +184,19 @@ func TestAddorUpdateNodeSelector(t *testing.T) {
 			"env": "test",
 		})
 	})
+}
+
+func TestDeploySnitchTolerations(t *testing.T) {
+	// Preserve and restore the global tolerations so we don't leak state into other tests.
+	saved := common.GlobalTolerations
+	defer func() { common.GlobalTolerations = saved }()
+
+	common.GlobalTolerations = []corev1.Toleration{
+		{Operator: corev1.TolerationOpExists},
+	}
+
+	job := deploySnitch("test-node", "containerd")
+
+	assert.Equal(t, common.GlobalTolerations, job.Spec.Template.Spec.Tolerations,
+		"snitch Job should apply the configured globalTolerations so it can schedule onto tainted nodes")
 }

--- a/pkg/KubeArmorOperator/internal/controller/resources.go
+++ b/pkg/KubeArmorOperator/internal/controller/resources.go
@@ -506,6 +506,12 @@ func deploySnitch(nodename string, runtime string) *batchv1.Job {
 			},
 		},
 	}
+
+	// The snitch runs as a Job pinned to a node via NodeName; apply the globally
+	// configured tolerations (globalTolerations) so it can still be scheduled onto
+	// tainted nodes, matching the daemonset, relay, and controller deployments.
+	utils.UpdateTolerationFromGlobal(common.GlobalTolerations, &job.Spec.Template.Spec.Tolerations)
+
 	return &job
 }
 


### PR DESCRIPTION
**Purpose of PR?**:

Fixes #2655

The operator's snitch Job (built in `deploySnitch()`) set `NodeName` on its PodSpec but never applied any tolerations. On nodes with taints the snitch pod was therefore rejected, so KubeArmor was never installed on those nodes. The daemonset, relay, and controller deployments already honor `globalTolerations` via `utils.UpdateTolerationFromGlobal`; this applies the same to the snitch Job so it can schedule onto tainted nodes (e.g. with `globalTolerations: [{operator: Exists}]`).

**Does this PR introduce a breaking change?**

No.

**If the changes in this PR are manually verified, list down the scenarios covered:**:

Added a unit test (`TestDeploySnitchTolerations`) that sets `common.GlobalTolerations` to `[{operator: Exists}]`, calls `deploySnitch(...)`, and asserts the resulting Job PodSpec carries those tolerations. `go test ./internal/controller/` and `go vet ./internal/controller/` pass.

**Additional information for reviewer?** :
_Mention if this PR is part of any design or a continuation of previous PRs_

This is the `globalTolerations` counterpart to the `globalNodeSelector` snitch fix tracked in #2469 (PR #2569).

**Checklist:**
- [x] Bug fix. Fixes #2655
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [x] Commit has unit tests
- [ ] Commit has integration tests
