### PR TITLE
<fix> panic: send on closed channel 

### DIFF
--- a/KubeArmor/feeder/feeder.go
+++ b/KubeArmor/feeder/feeder.go
@@ -656,8 +656,15 @@ func MarshalVisibilityLog(log tp.Log) *pb.Log {
 }
 
 // PushLog Function
-// PushLog Function
 func (fd *Feeder) PushLog(log tp.Log) {
+	// Safety net: recover from any 'send on closed channel' panics that may
+	// occur due to a race window between RemoveLogStruct and PushLog.
+	defer func() {
+		if r := recover(); r != nil {
+			kg.Printf("PushLog: recovered from panic (send on closed channel during client disconnect): %v", r)
+		}
+	}()
+
 	/* if enforcer == BPFLSM and log.Enforcer == ebpfmonitor ( block and default Posture Alerts from System
 	   monitor are converted to host/container logs)
 	   in case of enforcer = AppArmor only Default Posture logs will be converted to

--- a/KubeArmor/feeder/logServer.go
+++ b/KubeArmor/feeder/logServer.go
@@ -36,8 +36,10 @@ func (ls *LogService) WatchMessages(req *pb.RequestMessage, svr pb.LogService_Wa
 	kg.Printf("Added a new client (%s) for WatchMessages", uid)
 
 	defer func() {
-		close(conn)
+		// Remove from map FIRST so PushMessage can no longer find this channel
 		ls.EventStructs.RemoveMsgStruct(uid)
+		// THEN close the channel safely
+		close(conn)
 		kg.Printf("Deleted the client (%s) for WatchMessages", uid)
 	}()
 
@@ -70,8 +72,10 @@ func (ls *LogService) WatchAlerts(req *pb.RequestMessage, svr pb.LogService_Watc
 	kg.Printf("Added a new client (%s, %s) for WatchAlerts", uid, req.Filter)
 
 	defer func() {
-		close(conn)
+		// Remove from map FIRST so PushAlert can no longer find this channel
 		ls.EventStructs.RemoveAlertStruct(uid)
+		// THEN close the channel safely
+		close(conn)
 		kg.Printf("Deleted the client (%s) for WatchAlerts", uid)
 	}()
 
@@ -104,8 +108,10 @@ func (ls *LogService) WatchLogs(req *pb.RequestMessage, svr pb.LogService_WatchL
 	kg.Printf("Added a new client (%s, %s) for WatchLogs", uid, req.Filter)
 
 	defer func() {
-		close(conn)
+		// Remove from map FIRST so PushLog can no longer find this channel
 		ls.EventStructs.RemoveLogStruct(uid)
+		// THEN close the channel safely
+		close(conn)
 		kg.Printf("Deleted the client (%s) for WatchLogs", uid)
 	}()
 


### PR DESCRIPTION
**Purpose of PR?**:

Fixes #
``` 2026-06-08 07:10:10.014230	[34mINFO[0m	log channel busy, log dropped.
2026-06-08 07:10:09.929339	[33mWARN[0m	Failed to send a log=[Timestamp:1780902595  UpdatedTime:"2026-06-08T07:09:55.615894Z"  HostName:"ip-10-4-23-59.us-east-2.compute.internal"  NamespaceName:"agents"  Owner:{Ref:"Deployment"  Name:"discovery-engine"  Namespace:"agents"}  PodName:"discovery-engine-6c54f8c847-pqc8j"  Labels:"app=discovery-engine,topology.kubernetes.io/region=us-east-2,topology.kubernetes.io/zone=us-east-2b"  ContainerID:"e3e177b4f8855953ecfb27a74f578f5af1f4ee170fbb240476638f503f2c459b"  ContainerName:"summary-engine"  ContainerImage:"public.ecr.aws/k9v9d5v2/discovery-engine-sumengine:v0.3.21@sha256:dae00feac7a8282d912ece1d625232060d3b86ce4136c09fcd7a710932a10b9a"  ParentProcessName:"/usr/bin/containerd-shim-runc-v2"  ProcessName:"/Sumengine/sumengine"  HostPPID:575942  HostPID:3104428  PID:1  UID:1000  Type:"ContainerLog"  Source:"/Sumengine/sumengine"  Operation:"Network"  Resource:"domain=AF_INET type=SOCK_DGRAM|SOCK_NONBLOCK|SOCK_CLOEXEC protocol=HOPOPT"  Data:"syscall=SYS_SOCKET"  EventData:{key:"Domain"  value:"AF_INET"}  EventData:{key:"Protocol"  value:"HOPOPT"}  EventData:{key:"Syscall"  value:"SYS_SOCKET"}  EventData:{key:"Type"  value:"SOCK_DGRAM|SOCK_NONBLOCK|SOCK_CLOEXEC"}  Result:"Passed"  Cwd:"/"  ExecEvent:{ExecID:"0"  ExecutableName:"sumengine"}] err=[rpc error: code = Unavailable desc = transport is closing]
2026-06-08 07:10:10.015216	[34mINFO[0m	log channel busy, log dropped.
panic: send on closed channel

goroutine 496103 [running]:
github.com/kubearmor/KubeArmor/KubeArmor/feeder.(*Feeder).PushLog(_, {0x6a266ad1, {0x152611925440, 0x1b}, {0x0, 0x0}, {0x15260e2aae10, 0x28}, {0x0, 0x0}, ...})
	/usr/src/KubeArmor/KubeArmor/feeder/feeder.go:914 +0x19d8
created by github.com/kubearmor/KubeArmor/KubeArmor/monitor.(*SystemMonitor).UpdateLogs in goroutine 39
	/usr/src/KubeArmor/KubeArmor/monitor/logUpdate.go:594 +0x2199 
```

