### PR TITLE
fix(helm/operator): apply KubeArmorConfig CRD on every upgrade via Helm hooks

### DIFF
--- a/deployments/helm/KubeArmorOperator/README.md
+++ b/deployments/helm/KubeArmorOperator/README.md
@@ -32,10 +32,29 @@ helm upgrade --install kubearmor-operator . -n kubearmor --create-namespace
 | kubearmorConfig | object | [values.yaml](values.yaml) | KubeArmor default configurations |
 | kubearmorOperator.annotateResource | bool | false | flag to control RBAC permissions conditionally, use `--annotateResource=<value>` arg as well to pass the same value to operator configuration |
 | autoDeploy | bool | false | Auto deploy KubeArmor with default configurations |
+| crds.install | bool | true | Install and upgrade the KubeArmorConfig CRD via Helm hooks. Set to false if you manage CRDs separately (e.g. GitOps workflows) |
 
 The operator needs a `KubeArmorConfig` object in order to create resources related to KubeArmor. A default config is present in Helm `values.yaml` which can be overridden during Helm install. To install KubeArmor with default configuration use `--set autoDeploy=true` flag with helm install/upgrade command. It is possible to specify configuration even after KubeArmor resources have been installed by directly editing the created `KubeArmorConfig` CR.
 
 By Default the helm does not deploys the default KubeArmor Configurations (KubeArmorConfig CR) and once installed, the operator waits for the user to create a `KubeArmorConfig` object.
+
+### CRD lifecycle
+
+The `KubeArmorConfig` CRD is managed via `pre-install` and `pre-upgrade` Helm hooks (weight `-5`), which means it is applied before any other chart resource on both fresh installs and upgrades. This ensures that CRD schema changes are always propagated when running `helm upgrade`, unlike the default `crds/` directory which Helm silently skips on upgrades.
+
+The CRD carries `helm.sh/resource-policy: keep`, so it is **not** removed when you run `helm uninstall`. To fully clean up, delete the CRD manually after uninstalling the chart:
+
+```bash
+kubectl delete crd kubearmorconfigs.operator.kubearmor.com
+```
+
+If you manage CRDs outside of Helm (e.g. via a GitOps pipeline where a cluster-admin owns CRD lifecycle), you can disable hook-based CRD installation:
+
+```bash
+helm upgrade --install kubearmor-operator kubearmor/kubearmor-operator \
+  -n kubearmor --create-namespace \
+  --set crds.install=false
+```
 ## KubeArmorConfig specification
 
 ```yaml

--- a/deployments/helm/KubeArmorOperator/templates/crds/kubearmorconfig-crd.yaml
+++ b/deployments/helm/KubeArmorOperator/templates/crds/kubearmorconfig-crd.yaml
@@ -1,10 +1,17 @@
+{{- if .Values.crds.install }}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.19.0
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/resource-policy": keep
   name: kubearmorconfigs.operator.kubearmor.com
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
 spec:
   group: operator.kubearmor.com
   names:
@@ -535,7 +542,7 @@ spec:
                           description: |-
                             Operator represents a key's relationship to the value.
                             Valid operators are Exists and Equal. Defaults to Equal.
-                            Exists is equivalent to wildcard for value, so that a pod can
+                            Exists is compatible to wildcard for value, so that a pod can
                             tolerate all taints of a particular category.
                           type: string
                         tolerationSeconds:
@@ -769,7 +776,7 @@ spec:
                           description: |-
                             Operator represents a key's relationship to the value.
                             Valid operators are Exists and Equal. Defaults to Equal.
-                            Exists is equivalent to wildcard for value, so that a pod can
+                            Exists is compatible to wildcard for value, so that a pod can
                             tolerate all taints of a particular category.
                           type: string
                         tolerationSeconds:
@@ -1003,7 +1010,7 @@ spec:
                           description: |-
                             Operator represents a key's relationship to the value.
                             Valid operators are Exists and Equal. Defaults to Equal.
-                            Exists is equivalent to wildcard for value, so that a pod can
+                            Exists is compatible to wildcard for value, so that a pod can
                             tolerate all taints of a particular category.
                           type: string
                         tolerationSeconds:
@@ -1237,7 +1244,7 @@ spec:
                           description: |-
                             Operator represents a key's relationship to the value.
                             Valid operators are Exists and Equal. Defaults to Equal.
-                            Exists is equivalent to wildcard for value, so that a pod can
+                            Exists is compatible to wildcard for value, so that a pod can
                             tolerate all taints of a particular category.
                           type: string
                         tolerationSeconds:
@@ -1471,7 +1478,7 @@ spec:
                           description: |-
                             Operator represents a key's relationship to the value.
                             Valid operators are Exists and Equal. Defaults to Equal.
-                            Exists is equivalent to wildcard for value, so that a pod can
+                            Exists is compatible to wildcard for value, so that a pod can
                             tolerate all taints of a particular category.
                           type: string
                         tolerationSeconds:
@@ -1552,3 +1559,4 @@ spec:
     storage: true
     subresources:
       status: {}
+{{- end }}

--- a/deployments/helm/KubeArmorOperator/values.yaml
+++ b/deployments/helm/KubeArmorOperator/values.yaml
@@ -1,3 +1,10 @@
+# When true (default), the KubeArmorConfig CRD is installed and kept up-to-date
+# via pre-install and pre-upgrade Helm hooks, so schema changes are applied on
+# every upgrade. Set to false only if you manage CRDs separately (e.g. GitOps
+# workflows where a cluster-admin owns CRD lifecycle).
+crds:
+  install: true
+
 autoDeploy: false
 # operator will deploy pinned images for each application
 imagePinning: false


### PR DESCRIPTION
## What problem does this fix?

Helm's `crds/` directory is explicitly designed to install CRDs **only on `helm install`** and is silently skipped on `helm upgrade`. This means:

- CRD schema changes between chart versions were never applied to existing clusters, leaving installations running against a stale schema.
- When `--set autoDeploy=true` was used after the CRD had somehow drifted or been deleted, the `KubeArmorConfig` CR creation in the `post-install` hook would fail because the CRD was not registered.

The Helm docs are explicit on this: *"CRDs are never reinstalled. If Helm determines that the CRDs in the current Helm package are already installed (regardless of version), Helm will not attempt to install or upgrade them."*

Closes #2597

## What changed?

| File | Change |
|---|---|
| `crds/operator.kubearmor.com_kubearmorconfigs.yaml` | Removed (old static location) |
| `templates/crds/kubearmorconfig-crd.yaml` | New home for the CRD, with Helm hook annotations |
| `values.yaml` | Added `crds.install` toggle (default: `true`) |
| `README.md` | Documented CRD lifecycle and the `crds.install` opt-out |

### Hook annotations on the CRD

```yaml
"helm.sh/hook": pre-install,pre-upgrade   # applied before any other resource, on every install and upgrade
"helm.sh/hook-weight": "-5"               # runs first among hooks, before the operator Deployment
"helm.sh/resource-policy": keep           # not deleted on helm uninstall (matches previous crds/ behaviour)
```

The `pre-install,pre-upgrade` hook guarantees the CRD schema is current in the API server before the operator Deployment and the optional `KubeArmorConfig` CR (`post-install,post-upgrade`) are created.

The `resource-policy: keep` annotation preserves the CRD when the chart is uninstalled, which matches the previous behaviour of files in the `crds/` directory. Users who want to fully clean up must delete the CRD manually:
```bash
kubectl delete crd kubearmorconfigs.operator.kubearmor.com
```

### `crds.install` opt-out

For GitOps pipelines and environments where a cluster-admin manages CRD lifecycle outside of Helm:
```bash
helm upgrade --install kubearmor-operator kubearmor/kubearmor-operator \
  -n kubearmor --create-namespace \
  --set crds.install=false
```

## How to test

**Fresh install — CRD must be created:**
```bash
helm upgrade --install kubearmor-operator . -n kubearmor --create-namespace
kubectl get crd kubearmorconfigs.operator.kubearmor.com
```

**Upgrade — CRD schema must be updated (not skipped):**
```bash
# Simulate a schema change by bumping a description field, then:
helm upgrade kubearmor-operator . -n kubearmor
kubectl get crd kubearmorconfigs.operator.kubearmor.com -o jsonpath='{.metadata.resourceVersion}'
# resourceVersion should increment, confirming the CRD was patched
```

**With autoDeploy — should not fail due to missing CRD:**
```bash
helm upgrade --install kubearmor-operator . -n kubearmor --set autoDeploy=true
kubectl get kubearmorconfig -n kubearmor
```

**Opt-out — CRD must not appear in rendered templates:**
```bash
helm template test . --set crds.install=false | grep -c CustomResourceDefinition
# Expected: 0
```

**Helm lint:**
```bash
helm lint deployments/helm/KubeArmorOperator/
# Expected: 0 chart(s) failed
```