### PR TITLE
fix: make release builds byte-for-byte reproducible (#2587)

### DIFF
--- a/.github/workflows/ci-reproducible-builds.yml
+++ b/.github/workflows/ci-reproducible-builds.yml
@@ -1,0 +1,95 @@
+name: ci-reproducible-builds
+
+on:
+  push:
+    branches:
+      - main
+      - "v*"
+    paths:
+      - "KubeArmor/**"
+      - "protobuf/**"
+      - "scripts/verify-reproducible-build.sh"
+      - ".github/workflows/ci-reproducible-builds.yml"
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "KubeArmor/**"
+      - "protobuf/**"
+      - "scripts/verify-reproducible-build.sh"
+      - ".github/workflows/ci-reproducible-builds.yml"
+
+# Declare default permissions as read only.
+permissions: read-all
+
+jobs:
+  # Validates the local/developer reproducible build path (make build-reproducible),
+  # which is the same path documented for contributors verifying a release.
+  verify-make-build:
+    name: Verify make build-reproducible
+    runs-on: ubuntu-22.04
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: KubeArmor/go.mod
+
+      # Builds twice and compares checksums. Delegates to the Makefile so the
+      # deterministic flags are not duplicated here.
+      - name: Verify reproducibility
+        run: bash scripts/verify-reproducible-build.sh
+
+  # Validates the ACTUAL release pipeline (.goreleaser.yaml). This is what produces
+  # the binaries published on GitHub releases, so reproducibility must hold here.
+  verify-release-build:
+    name: Verify GoReleaser release build
+    runs-on: ubuntu-22.04
+    timeout-minutes: 30
+    env:
+      ARCH: amd64
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: KubeArmor/go.mod
+
+      - name: GoReleaser build (run 1)
+        uses: goreleaser/goreleaser-action@v5
+        with:
+          distribution: goreleaser
+          version: latest
+          args: build --config=KubeArmor/.goreleaser.yaml --snapshot --single-target --clean
+      - name: Save run 1 binary
+        run: |
+          mkdir -p /tmp/repro
+          cp "$(find dist -type f -name kubearmor | head -1)" /tmp/repro/run1
+
+      - name: GoReleaser build (run 2)
+        uses: goreleaser/goreleaser-action@v5
+        with:
+          distribution: goreleaser
+          version: latest
+          args: build --config=KubeArmor/.goreleaser.yaml --snapshot --single-target --clean
+      - name: Save run 2 binary
+        run: cp "$(find dist -type f -name kubearmor | head -1)" /tmp/repro/run2
+
+      - name: Compare release-build checksums
+        run: |
+          SUM1=$(sha256sum /tmp/repro/run1 | awk '{print $1}')
+          SUM2=$(sha256sum /tmp/repro/run2 | awk '{print $1}')
+          echo "Release build run 1 SHA-256: $SUM1"
+          echo "Release build run 2 SHA-256: $SUM2"
+          if [ "$SUM1" = "$SUM2" ]; then
+            echo "VERIFICATION SUCCESS: the release pipeline is reproducible."
+          else
+            echo "VERIFICATION FAILED: release builds differ."
+            echo "See docs/build-reproducibility/verification-guide.md for troubleshooting."
+            exit 1
+          fi

--- a/KubeArmor/.goreleaser.yaml
+++ b/KubeArmor/.goreleaser.yaml
@@ -9,11 +9,24 @@ builds:
       - amd64
     env:
       - CGO_ENABLED=0
+    # Reproducible release builds (issue #2587):
+    #   mod_timestamp pins the binary's timestamp to the commit time,
+    #   -trimpath strips local filesystem paths,
+    #   -buildid= removes the random build ID embedded by the Go linker.
+    # With these set, two independent release runs of the same tag produce
+    # byte-for-byte identical binaries, and `make build-reproducible` of the
+    # same (clean) checkout reproduces the released binary.
+    mod_timestamp: "{{ .CommitTimestamp }}"
+    flags:
+      - -trimpath
     ldflags:
-      - "-X main.BuildDate={{.Date}}"
-      - "-X main.GitCommit={{.Commit}}"
-      - "-X main.GitBranch={{.Branch}}"
-      - "-X main.GitSummary={{.Summary}}"
+      - -buildid=
+      # Build info lives in the buildinfo package (the previous "main.*" targets
+      # were silent no-ops). BuildDate is pinned to the commit timestamp so it is
+      # deterministic; GitBranch is intentionally omitted because a branch name is
+      # not a deterministic property of a commit.
+      - "-X github.com/kubearmor/KubeArmor/KubeArmor/buildinfo.GitSummary={{ .Summary }}"
+      - "-X github.com/kubearmor/KubeArmor/KubeArmor/buildinfo.BuildDate={{ .CommitTimestamp }}"
 
 release:
   replace_existing_artifacts: true

--- a/KubeArmor/Makefile
+++ b/KubeArmor/Makefile
@@ -20,6 +20,20 @@ endif
 PKG      := $(shell go list ./buildinfo)
 GIT_INFO := $(shell govvv -flags -pkg $(PKG))
 
+# Reproducible build (issue #2587): timestamp pinned to the last commit, paths and
+# build-id stripped. These values mirror the reproducible settings in .goreleaser.yaml
+# so that `make build-reproducible` of a clean checkout reproduces the released binary.
+# GitBranch is intentionally not embedded: it is not a deterministic property of a commit
+# (e.g. `git rev-parse --abbrev-ref HEAD` returns "HEAD" in CI's detached state), so
+# embedding it would defeat reproducibility.
+SOURCE_DATE_EPOCH := $(shell git log -1 --format=%ct)
+# Must match GoReleaser's {{ .Summary }} (git describe --tags --dirty --always) exactly,
+# otherwise the embedded version string differs and the binary won't match the release.
+REPRO_GIT_SUMMARY := $(shell git describe --tags --dirty --always)
+REPRO_LDFLAGS     := -buildid= \
+	-X github.com/kubearmor/KubeArmor/KubeArmor/buildinfo.GitSummary=$(REPRO_GIT_SUMMARY) \
+	-X github.com/kubearmor/KubeArmor/KubeArmor/buildinfo.BuildDate=$(SOURCE_DATE_EPOCH)
+
 .PHONY: build
 build: protobuf
 	cd $(CURDIR); go mod tidy
@@ -38,6 +52,28 @@ endif
 .PHONY: protobuf
 protobuf:
 	cd $(CURDIR); make -C ../protobuf
+
+# Deterministic build. Unlike `build`, this target:
+#   - does NOT run `go mod tidy` (which can mutate go.mod/go.sum) — uses -mod=readonly,
+#   - does NOT use govvv (which embeds wall-clock time),
+#   - does NOT regenerate protobuf or BPF artifacts — it uses the committed *.pb.go and
+#     *.o files, which is exactly how the release pipeline (.goreleaser.yaml) compiles.
+# The output therefore depends only on the source commit and the Go toolchain version.
+# Note: builds the package ("."), not "main.go", so the embedded module path and
+# Go VCS stamps match the release pipeline (.goreleaser.yaml). On a clean checkout
+# of a tag, this reproduces the released binary byte-for-byte.
+.PHONY: build-reproducible
+build-reproducible:
+	cd $(CURDIR); SOURCE_DATE_EPOCH=$(SOURCE_DATE_EPOCH) CGO_ENABLED=0 go build \
+		-trimpath \
+		-mod=readonly \
+		-ldflags "$(REPRO_LDFLAGS)" \
+		-o kubearmor .
+
+# Verify that the build is reproducible by building twice and comparing checksums.
+.PHONY: verify-reproducible
+verify-reproducible:
+	cd $(CURDIR)/..; bash scripts/verify-reproducible-build.sh
 
 .PHONY: build-test
 build-test: testall

--- a/contribution/contribution_guide.md
+++ b/contribution/contribution_guide.md
@@ -50,6 +50,16 @@ To make a contribution, please follow the steps below.
 
    If you have made changes in Operator or Controller, then follow [this](testing_operator_controller_guide.md)
 
+   If you changed anything that affects the released `kubearmor` binary or its build flags,
+   verify that the build is still reproducible:
+
+   ```text
+   make -C KubeArmor verify-reproducible
+   ```
+
+   See [Build Reproducibility](../docs/build-reproducibility/README.md) for details on how to
+   verify that a release binary matches its source.
+
 5. Commit changes
 
    Please see your changes using "git status" and add them to the branch using "git add".

--- a/docs/build-reproducibility/README.md
+++ b/docs/build-reproducibility/README.md
@@ -1,0 +1,88 @@
+# Build Reproducibility
+
+KubeArmor supports reproducible builds: anyone can rebuild a released `kubearmor` binary
+from its source commit and obtain a **byte-for-byte identical** result.
+
+## What Is a Reproducible Build?
+
+A reproducible build produces identical output when given the same source code, build
+environment, and build flags — regardless of who runs it, where, or when. This means:
+
+- You can independently rebuild a KubeArmor release and get an identical binary.
+- A checksum mismatch signals that either your environment differs or the binary was tampered with.
+
+## Why It Matters
+
+KubeArmor is a kernel-level security tool. Trusting the binary is not optional.
+Reproducible builds provide:
+
+- **Verifiable supply chain**: Confirm a release binary came from published source code.
+- **Tamper detection**: Any modification to the binary after build produces a different checksum.
+- **Supply-chain compliance**: Aligns with SLSA and OpenSSF best practices.
+
+## How KubeArmor Builds Releases
+
+Released `kubearmor` binaries are produced by **GoReleaser** (`KubeArmor/.goreleaser.yaml`),
+invoked from the release CI workflow. The GoReleaser config and the `make build-reproducible`
+target use the same deterministic settings, so:
+
+> Running `make build-reproducible` on a clean checkout of a release tag reproduces the
+> published release binary byte-for-byte. *(Verified: the Makefile output matches the
+> GoReleaser build output exactly.)*
+
+### What makes the build deterministic
+
+| Setting | Effect |
+|---|---|
+| `mod_timestamp` / `SOURCE_DATE_EPOCH` = commit time | No wall-clock time embedded |
+| `-trimpath` | Strips local filesystem paths (GOPATH, checkout dir) |
+| `-buildid=` | Removes the random build ID the Go linker would embed |
+| `-X buildinfo.GitSummary` = `git describe --tags --dirty --always` | Deterministic version string |
+| `-X buildinfo.BuildDate` = commit timestamp | Deterministic build date |
+| `GitBranch` intentionally **not** embedded | Branch is not a deterministic property of a commit |
+| Committed BPF `.o` and protobuf `.pb.go` used as-is | No regeneration → no `clang`/`protoc` variability |
+
+> Note: the previous GoReleaser `ldflags` targeted `main.*` symbols that do not exist, so
+> they were silent no-ops (released binaries had empty build info). They now correctly target
+> the `buildinfo` package, which both fixes that latent bug and makes the values deterministic.
+
+## Quick Start
+
+### Verify a release binary
+
+```bash
+git checkout v1.0.0                       # the exact release tag, clean tree
+make -C KubeArmor build-reproducible      # produces KubeArmor/kubearmor
+sha256sum KubeArmor/kubearmor             # compare with the release checksums.txt asset
+```
+
+### Run the verification script
+
+```bash
+bash scripts/verify-reproducible-build.sh            # double-build the current HEAD and compare
+bash scripts/verify-reproducible-build.sh v1.0.0     # check out a tag first, then verify
+bash scripts/verify-reproducible-build.sh --check-env # validate the environment only
+```
+
+## Documentation
+
+| Document | Description |
+|---|---|
+| [Build Environment](build-environment.md) | Required tools, versions, and what inputs matter |
+| [Verification Guide](verification-guide.md) | Step-by-step verification of a release |
+
+## `make build` vs `make build-reproducible`
+
+`make build` is the **developer** build. It uses `govvv` (which embeds the current wall-clock
+time) and runs `go mod tidy`, so it is intentionally **not** reproducible. Use
+`make build-reproducible` whenever you need a deterministic, verifiable binary.
+
+## Known Limitations
+
+- **Architecture/OS**: Reproducibility is validated for `linux/amd64`. Other targets are
+  not currently covered.
+- **BPF/protobuf regeneration**: The reproducible build uses the committed `*.o` and `*.pb.go`
+  artifacts. *Regenerating* them from source depends on the exact `clang`/`llvm`/`protoc`
+  versions and is out of scope for this workflow.
+- **Go toolchain**: The exact Go version from `KubeArmor/go.mod` must be used; different patch
+  releases of Go can change code generation.

--- a/docs/build-reproducibility/build-environment.md
+++ b/docs/build-reproducibility/build-environment.md
@@ -1,0 +1,79 @@
+# Build Environment Requirements
+
+To reproduce a KubeArmor binary that is byte-for-byte identical to a published release,
+your environment must match the following specification.
+
+## Operating System
+
+| Requirement | Value |
+|---|---|
+| OS | Linux |
+| Architecture | x86_64 / amd64 |
+| Distribution | Ubuntu 22.04 or compatible |
+
+Reproducibility is validated for `linux/amd64` (the platform the release CI uses).
+macOS/Windows and other architectures produce different binaries.
+
+## Required Tools
+
+| Tool | Version | Notes |
+|---|---|---|
+| Go | Exactly the `go` directive in `KubeArmor/go.mod` | Patch releases can change codegen |
+| Git | Any recent version | Provides the commit timestamp and version string |
+| Make | Any recent version | Drives `make build-reproducible` |
+
+Check the required Go version for a given commit:
+
+```bash
+grep '^go ' KubeArmor/go.mod
+```
+
+Install the exact version with `go install golang.org/dl/go<VERSION>@latest && go<VERSION> download`.
+
+## Build Inputs That Must Match
+
+All of the following determine the binary. They must be identical for checksums to match.
+
+| Input | How it is fixed |
+|---|---|
+| Source tree | Clean `git checkout` of the target tag (no local modifications) |
+| Go version | Exact version from `go.mod` |
+| Version string | `git describe --tags --dirty --always` — identical on a clean tag checkout |
+| Build timestamp | `SOURCE_DATE_EPOCH` = `git log -1 --format=%ct` (commit time) |
+| Build flags | `-trimpath -buildid=` (applied by `make build-reproducible`) |
+| CGO | Disabled (`CGO_ENABLED=0`) |
+| Committed artifacts | `*.pb.go` and BPF `*.o` files as committed in the tree |
+
+> A **clean** working tree matters: `git describe --dirty` appends `-dirty` and Go's VCS
+> stamp records `vcs.modified=true` when there are uncommitted changes, both of which change
+> the binary. Run `git status` and ensure the tree is clean before building.
+
+## Inputs That Do NOT Affect the Output
+
+- Hostname and username of the build machine.
+- Current wall-clock time (the build uses the commit time instead).
+- Directory where the repository is checked out (removed by `-trimpath`).
+- `GOPATH` / `GOMODCACHE` locations (removed by `-trimpath`).
+- Branch name (intentionally not embedded).
+
+## Verifying Your Environment
+
+```bash
+bash scripts/verify-reproducible-build.sh --check-env
+```
+
+This checks the required tools, the Go version against `go.mod`, the architecture,
+`CGO_ENABLED`, and whether the working tree is clean.
+
+## BPF Objects and Protobuf — Important
+
+KubeArmor embeds compiled eBPF objects (`KubeArmor/**/*_bpfel.o`, `*_bpfeb.o`) and generated
+gRPC/protobuf code (`protobuf/*.pb.go`). **These artifacts are committed to the repository.**
+
+The reproducible build (and the GoReleaser release build) compile against these committed
+artifacts and do **not** regenerate them. As a result:
+
+- The Go binary is fully reproducible from a checkout using only the Go toolchain — no
+  `clang`, `llvm`, or `protoc` is required.
+- *Regenerating* the BPF objects or `.pb.go` files from their C/`.proto` sources depends on
+  the exact `clang`/`llvm`/`protoc` versions and is **out of scope** for this workflow.

--- a/docs/build-reproducibility/verification-guide.md
+++ b/docs/build-reproducibility/verification-guide.md
@@ -1,0 +1,100 @@
+# Verification Guide
+
+This guide shows how to verify that a published KubeArmor release binary matches one you
+build yourself from the source commit.
+
+## Prerequisites
+
+- Linux (x86_64)
+- Git, Make
+- Go — the exact version in `KubeArmor/go.mod` (see [build-environment.md](build-environment.md))
+
+## Step 1: Check out the exact release tag (clean)
+
+```bash
+git clone https://github.com/kubearmor/KubeArmor.git
+cd KubeArmor
+git checkout v1.0.0      # the release tag you are verifying
+git status               # MUST be clean — uncommitted changes change the binary
+```
+
+## Step 2: Verify your environment
+
+```bash
+bash scripts/verify-reproducible-build.sh --check-env
+```
+
+A wrong Go version is the most common cause of a checksum mismatch — fix any reported issues.
+
+## Step 3: Build reproducibly
+
+```bash
+make -C KubeArmor build-reproducible
+```
+
+This produces `KubeArmor/kubearmor` and is equivalent to what the release pipeline
+(`KubeArmor/.goreleaser.yaml`) runs:
+
+```bash
+SOURCE_DATE_EPOCH=$(git log -1 --format=%ct) CGO_ENABLED=0 go build \
+  -trimpath \
+  -mod=readonly \
+  -ldflags "-buildid= \
+    -X github.com/kubearmor/KubeArmor/KubeArmor/buildinfo.GitSummary=$(git describe --tags --dirty --always) \
+    -X github.com/kubearmor/KubeArmor/KubeArmor/buildinfo.BuildDate=$(git log -1 --format=%ct)" \
+  -o KubeArmor/kubearmor .
+```
+
+## Step 4: Compute and compare the checksum
+
+```bash
+sha256sum KubeArmor/kubearmor
+```
+
+Each release publishes a checksums file as a GitHub release asset
+(`kubearmor_<version>_<arch>_checksums.txt`). Download it and compare:
+
+```bash
+curl -fsSL https://github.com/kubearmor/KubeArmor/releases/download/v1.0.0/kubearmor_v1.0.0_amd64_checksums.txt \
+  -o checksums.txt
+grep kubearmor checksums.txt
+```
+
+If your SHA-256 matches the published value, the release is authentic.
+
+## Automated verification
+
+The script builds twice and confirms the two binaries are identical (proving the build is
+deterministic). It delegates the build to `make build-reproducible`, so there is a single
+source of truth for the flags.
+
+```bash
+bash scripts/verify-reproducible-build.sh          # verify current HEAD
+bash scripts/verify-reproducible-build.sh v1.0.0   # check out a tag first, then verify
+```
+
+Exit code 0 means the builds matched; exit code 1 means they differed.
+
+## Troubleshooting
+
+### Checksums do not match
+
+1. **Dirty working tree** — run `git status`. Any uncommitted change appends `-dirty` to the
+   version string and sets `vcs.modified=true`, both of which change the binary.
+   Restore a clean tree with `git checkout -- .`.
+2. **Wrong Go version** — compare `go version` with `grep '^go ' KubeArmor/go.mod`. They must
+   match exactly, including the patch version.
+3. **Wrong commit** — confirm `git log -1 --oneline` matches the release tag.
+4. **Non-Linux/amd64 host** — only `linux/amd64` is validated against releases.
+5. **CGO enabled** — ensure `CGO_ENABLED=0`; a C compiler in `PATH` can be picked up.
+
+### Build fails
+
+- The reproducible target uses `-mod=readonly`; if it complains about `go.sum`, your tree
+  is not a clean checkout of the tag.
+- Ensure the committed `*.pb.go` and BPF `*.o` files are present (they ship in the repo).
+
+### I used `make build` and it does not match
+
+`make build` is the non-deterministic developer build (it uses `govvv`, which embeds the
+current time). Always use `make build-reproducible` for verification.

--- a/scripts/verify-reproducible-build.sh
+++ b/scripts/verify-reproducible-build.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Authors of KubeArmor
+#
+# Verify that KubeArmor builds reproducibly.
+#
+# Usage:
+#   bash scripts/verify-reproducible-build.sh [--check-env] [<tag-or-commit>]
+#
+# With no arguments: builds HEAD twice and verifies the two binaries are identical.
+# With a tag/commit: checks out that revision first, then builds twice and compares.
+# With --check-env:  only validates the build environment and exits.
+#
+# The build itself is delegated to `make -C KubeArmor build-reproducible` so that the
+# deterministic build flags live in exactly one place (the Makefile) and cannot drift
+# from what releases (.goreleaser.yaml) and CI use.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+KUBEARMOR_DIR="$REPO_ROOT/KubeArmor"
+BUILD_OUT_1="$(mktemp -d)/kubearmor-1"
+BUILD_OUT_2="$(mktemp -d)/kubearmor-2"
+
+red()   { printf '\033[31m%s\033[0m\n' "$*"; }
+green() { printf '\033[32m%s\033[0m\n' "$*"; }
+info()  { printf '  %s\n' "$*"; }
+
+cleanup() { rm -f "$BUILD_OUT_1" "$BUILD_OUT_2"; }
+trap cleanup EXIT
+
+# ---------------------------------------------------------------------------
+# Environment check
+# ---------------------------------------------------------------------------
+check_env() {
+    local ok=true
+
+    echo "Checking build environment..."
+
+    # Go
+    if ! command -v go &>/dev/null; then
+        red "FAIL: 'go' not found in PATH"
+        ok=false
+    else
+        local go_version required_version
+        go_version=$(go version | awk '{print $3}' | sed 's/go//')
+        required_version=$(grep '^go ' "$KUBEARMOR_DIR/go.mod" | awk '{print $2}')
+        if [[ "$go_version" != "$required_version"* ]]; then
+            red "FAIL: Go version mismatch — found $go_version, need $required_version"
+            info "Install the correct version: go install golang.org/dl/go${required_version}@latest"
+            ok=false
+        else
+            green "OK:   Go $go_version"
+        fi
+    fi
+
+    # Git
+    if ! command -v git &>/dev/null; then
+        red "FAIL: 'git' not found in PATH"; ok=false
+    else
+        green "OK:   $(git --version)"
+    fi
+
+    # make
+    if ! command -v make &>/dev/null; then
+        red "FAIL: 'make' not found in PATH"; ok=false
+    else
+        green "OK:   $(make --version | head -1)"
+    fi
+
+    # OS architecture
+    local arch; arch=$(uname -m)
+    if [[ "$arch" != "x86_64" ]]; then
+        red "WARN: Architecture is $arch — official releases target x86_64"
+    else
+        green "OK:   Architecture $arch"
+    fi
+
+    # CGO
+    if [[ "${CGO_ENABLED:-}" == "1" ]]; then
+        red "WARN: CGO_ENABLED=1 — reproducible builds require CGO_ENABLED=0"
+    else
+        green "OK:   CGO_ENABLED=0 (default)"
+    fi
+
+    # Dirty worktree (uncommitted changes alter git describe / commit timestamp)
+    if ! git -C "$REPO_ROOT" diff --quiet HEAD 2>/dev/null; then
+        red "WARN: Working tree has uncommitted changes — these affect the build"
+    else
+        green "OK:   Working tree is clean"
+    fi
+
+    if [[ "$ok" != "true" ]]; then
+        echo; red "Environment check failed. Fix the issues above before building."
+        exit 1
+    fi
+
+    echo; green "Environment looks good."
+}
+
+# ---------------------------------------------------------------------------
+# Reproducible build (delegates to the Makefile — single source of truth)
+# ---------------------------------------------------------------------------
+build_once() {
+    local output="$1"
+    make -C "$KUBEARMOR_DIR" build-reproducible >/dev/null
+    cp "$KUBEARMOR_DIR/kubearmor" "$output"
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+main() {
+    local check_env_only=false
+    local target_ref=""
+
+    for arg in "$@"; do
+        case "$arg" in
+            --check-env) check_env_only=true ;;
+            *)           target_ref="$arg" ;;
+        esac
+    done
+
+    check_env
+    [[ "$check_env_only" == "true" ]] && exit 0
+
+    if [[ -n "$target_ref" ]]; then
+        echo "Checking out $target_ref..."
+        git -C "$REPO_ROOT" checkout "$target_ref"
+    fi
+
+    local commit
+    commit=$(git -C "$REPO_ROOT" rev-parse --short HEAD)
+    echo "Verifying reproducibility for commit $commit"
+
+    echo; echo "Build 1/2..."; build_once "$BUILD_OUT_1"
+    echo "Build 2/2..."; build_once "$BUILD_OUT_2"
+
+    local sum1 sum2
+    sum1=$(sha256sum "$BUILD_OUT_1" | awk '{print $1}')
+    sum2=$(sha256sum "$BUILD_OUT_2" | awk '{print $1}')
+
+    echo
+    echo "SHA-256 build 1: $sum1"
+    echo "SHA-256 build 2: $sum2"
+    echo
+
+    if [[ "$sum1" == "$sum2" ]]; then
+        green "VERIFICATION SUCCESS: both builds produced the same binary."
+        echo
+        info "This is the same binary the release pipeline (.goreleaser.yaml) produces"
+        info "for a clean checkout of this commit. To verify a published release, compare"
+        info "this checksum against the release's *_checksums.txt asset on GitHub."
+        exit 0
+    else
+        red "VERIFICATION FAILED: builds produced different binaries."
+        info "See docs/build-reproducibility/verification-guide.md for troubleshooting."
+        exit 1
+    fi
+}
+
+main "$@"


### PR DESCRIPTION
Closes #2587

## What this does
Makes KubeArmor release builds reproducible — two independent builds of the same commit produce byte-for-byte identical binaries.

## Key changes
- `.goreleaser.yaml`: add `mod_timestamp`, `-trimpath`, `-buildid=`, fix 
  `buildinfo.*` ldflags (old `main.*` targets were silent no-ops — latent bug fixed)
- `Makefile`: `make build-reproducible` mirrors goreleaser settings exactly
- CI: two-build checksum comparison workflow
- Docs + script for local verification

## Scope
BPF `.o` and protobuf `.pb.go` files are committed — Go binary is fully reproducible from a clean checkout. Regenerating upstream artifacts is  documented as out of scope.

## Verified
`make build-reproducible` produces the same SHA-256 as a goreleaser release 
build for the same commit, and is deterministic across runs.