### PR TITLE
fix(operator): honour globalNodeSelector when deploying Snitch Jobs

### DIFF
--- a/pkg/KubeArmorOperator/internal/controller/cluster.go
+++ b/pkg/KubeArmorOperator/internal/controller/cluster.go
@@ -259,7 +259,7 @@ func (clusterWatcher *ClusterWatcher) WatchNodes() {
 			if node, ok := obj.(*corev1.Node); ok {
 				runtime := node.Status.NodeInfo.ContainerRuntimeVersion
 				runtime = strings.Split(runtime, ":")[0]
-				if val, ok := node.Labels[common.OsLabel]; ok && val == "linux" {
+				if val, ok := node.Labels[common.OsLabel]; ok && val == "linux" && nodeMatchesGlobalSelector(node.Labels) {
 					log.Infof("Installing snitch on node %s", node.Name)
 					snitchJob, err := clusterWatcher.Client.BatchV1().Jobs(common.Namespace).Create(context.Background(), deploySnitch(node.Name, runtime), v1.CreateOptions{})
 					if err != nil {
@@ -283,7 +283,7 @@ func (clusterWatcher *ClusterWatcher) WatchNodes() {
 						runtime := node.Status.NodeInfo.ContainerRuntimeVersion
 						runtime = strings.Split(runtime, ":")[0]
 						clusterWatcher.Log.Infof("Node might have been restarted, redeploying snitch ")
-						if val, ok := node.Labels[common.OsLabel]; ok && val == "linux" {
+						if val, ok := node.Labels[common.OsLabel]; ok && val == "linux" && nodeMatchesGlobalSelector(node.Labels) {
 							log.Infof("Installing snitch on node %s", node.Name)
 							snitchJob, err := clusterWatcher.Client.BatchV1().Jobs(common.Namespace).Create(context.Background(), deploySnitch(node.Name, runtime), v1.CreateOptions{})
 							if err != nil {
@@ -959,6 +959,18 @@ func UpdateEnvIfDefinedAndUpdated(defaultEnv *[]corev1.EnvVar, in []corev1.EnvVa
 	}
 
 	return changed || deleted
+}
+
+// nodeMatchesGlobalSelector returns true when the node's labels contain every
+// key-value pair configured in GlobalNodeSelectors. An empty selector matches
+// all nodes, preserving the original behaviour when no selector is set.
+func nodeMatchesGlobalSelector(nodeLabels map[string]string) bool {
+	for k, v := range common.GlobalNodeSelectors {
+		if nodeLabels[k] != v {
+			return false
+		}
+	}
+	return true
 }
 
 func AddOrUpdateNodeSelector(dst map[string]string, src map[string]string) {


### PR DESCRIPTION
﻿## Problem

`WatchNodes()` in `pkg/KubeArmorOperator/internal/controller/cluster.go` deploys a Snitch Job for every Linux node that joins or restarts, without checking whether that node matches the operator-level `globalNodeSelector`.

When a cluster operator sets `globalNodeSelector` (e.g. to target only nodes labelled `kubearmor=enabled`), the KubeArmor DaemonSet is only scheduled on those nodes. However the Snitch Job was still dispatched to ALL Linux nodes, causing:

- Snitch Jobs running on nodes that will never run KubeArmor
- Wasted cluster resources and spurious Job failures
- Inconsistency with every other component (relay, controller, DaemonSet) that already respects `globalNodeSelector`

## Fix

Add a `nodeMatchesGlobalSelector()` helper that checks whether a node's labels contain every key-value pair in `common.GlobalNodeSelectors`. Guard both the AddFunc and UpdateFunc (node-restart) paths in `WatchNodes()` with this check.

An empty `GlobalNodeSelectors` matches all nodes, so the default behaviour (no selector configured) is unchanged.

## Testing

1. Configure `globalNodeSelector: {kubearmor: enabled}` in the KubeArmorConfig.
2. Add a node without the label and observe that no Snitch Job is created for it.
3. Add the label to that node; the Snitch Job is now created.
4. Restart a non-matching node; confirm no Snitch Job is triggered.

Fixes #2469

Signed-off-by: B R GOVIND <brgovind2005@gmail.com>
