### PR TITLE
feat(core): add hash-based host policy identity for observability

### DIFF
--- a/KubeArmor/common/common.go
+++ b/KubeArmor/common/common.go
@@ -5,6 +5,8 @@
 package common
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -52,6 +54,21 @@ const (
 func Clone(src, dst any) error {
 	arr, _ := json.Marshal(src)
 	return json.Unmarshal(arr, dst)
+}
+
+// ComputeHash returns a deterministic, hex-encoded SHA-256 digest of the JSON
+// serialization of v. json.Marshal sorts map keys, so callers only need to
+// ensure that any slices inside v are in a stable order before calling.
+//
+// This is for observability only (logs, probe output, debugging). It MUST NOT
+// be used for any enforcement or trust decision.
+func ComputeHash(v any) (string, error) {
+	arr, err := json.Marshal(v)
+	if err != nil {
+		return "", fmt.Errorf("compute hash: %w", err)
+	}
+	sum := sha256.Sum256(arr)
+	return hex.EncodeToString(sum[:]), nil
 }
 
 // RemoveStringElement function

--- a/KubeArmor/common/common_test.go
+++ b/KubeArmor/common/common_test.go
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Authors of KubeArmor
+
+package common
+
+import (
+	"slices"
+	"strings"
+	"testing"
+
+	tp "github.com/kubearmor/KubeArmor/KubeArmor/types"
+)
+
+// sortByName mirrors how callers normalize a host policy slice before hashing,
+// so these tests exercise the documented "pre-sort your slices" contract.
+func sortByName(in []tp.HostSecurityPolicy) []tp.HostSecurityPolicy {
+	out := make([]tp.HostSecurityPolicy, len(in))
+	copy(out, in)
+	slices.SortStableFunc(out, func(a, b tp.HostSecurityPolicy) int {
+		return strings.Compare(a.Metadata["policyName"], b.Metadata["policyName"])
+	})
+	return out
+}
+
+func policy(name string) tp.HostSecurityPolicy {
+	return tp.HostSecurityPolicy{Metadata: map[string]string{"policyName": name}}
+}
+
+func TestComputeHash_DeterministicForEqualInput(t *testing.T) {
+	in := []tp.HostSecurityPolicy{policy("alpha"), policy("beta")}
+
+	h1, err := ComputeHash(in)
+	if err != nil {
+		t.Fatalf("ComputeHash failed: %v", err)
+	}
+	h2, err := ComputeHash(in)
+	if err != nil {
+		t.Fatalf("ComputeHash failed: %v", err)
+	}
+	if h1 != h2 {
+		t.Fatalf("expected identical hashes, got %s vs %s", h1, h2)
+	}
+}
+
+func TestComputeHash_OrderIndependentAfterSort(t *testing.T) {
+	one := sortByName([]tp.HostSecurityPolicy{policy("alpha"), policy("beta")})
+	two := sortByName([]tp.HostSecurityPolicy{policy("beta"), policy("alpha")})
+
+	h1, _ := ComputeHash(one)
+	h2, _ := ComputeHash(two)
+	if h1 != h2 {
+		t.Fatalf("sorted permutations must hash identically, got %s vs %s", h1, h2)
+	}
+}
+
+func TestComputeHash_DifferentContentDifferentHash(t *testing.T) {
+	h1, _ := ComputeHash([]tp.HostSecurityPolicy{policy("alpha")})
+	h2, _ := ComputeHash([]tp.HostSecurityPolicy{policy("alpha-modified")})
+	if h1 == h2 {
+		t.Fatalf("different content must produce different hashes, both were %s", h1)
+	}
+}
+
+func TestComputeHash_EmptyIsStableNonEmptySentinel(t *testing.T) {
+	h1, _ := ComputeHash([]tp.HostSecurityPolicy{})
+	h2, _ := ComputeHash([]tp.HostSecurityPolicy{})
+	if h1 != h2 {
+		t.Fatalf("empty inputs must hash identically: %s vs %s", h1, h2)
+	}
+	if h1 == "" {
+		t.Fatalf("empty input must still produce a non-empty hash")
+	}
+}
+
+func TestComputeHash_HexLengthIsSHA256(t *testing.T) {
+	h, err := ComputeHash("anything")
+	if err != nil {
+		t.Fatalf("ComputeHash failed: %v", err)
+	}
+	if len(h) != 64 { // SHA-256 = 32 bytes = 64 hex chars
+		t.Fatalf("expected 64-char hex digest, got %d chars: %s", len(h), h)
+	}
+}

--- a/KubeArmor/core/karmorprobedata.go
+++ b/KubeArmor/core/karmorprobedata.go
@@ -27,6 +27,7 @@ type KarmorData struct {
 	ContainerDefaultPosture tp.DefaultPosture
 	HostDefaultPosture      tp.DefaultPosture
 	HostVisibility          string
+	HostPolicyHash          string
 }
 
 // Probe provides structure to serve Policy gRPC service
@@ -68,6 +69,11 @@ func (dm *KubeArmorDaemon) SetKarmorData() {
 	}
 	kd.KernelHeaderPresent = true //this is always true since KubeArmor is running
 	kd.HostVisibility = dm.Node.Annotations["kubearmor-visibility"]
+
+	dm.HostPolicyHashLock.RLock()
+	kd.HostPolicyHash = dm.HostPolicyHash
+	dm.HostPolicyHashLock.RUnlock()
+
 	err := kl.WriteToFile(kd, "/tmp/karmorProbeData.cfg")
 	if err != nil {
 		dm.Logger.Errf("Error writing karmor config data (%s)", err.Error())

--- a/KubeArmor/core/kubeArmor.go
+++ b/KubeArmor/core/kubeArmor.go
@@ -82,6 +82,11 @@ type KubeArmorDaemon struct {
 	HostSecurityPolicies     []tp.HostSecurityPolicy
 	HostSecurityPoliciesLock *sync.RWMutex
 
+	// Deterministic fingerprint of this node's effective host policy state
+	// (observability only — never used for enforcement). See ComputeHash.
+	HostPolicyHash     string
+	HostPolicyHashLock *sync.RWMutex
+
 	// Network Security policies
 	NetworkSecurityPolicies     []tp.NetworkSecurityPolicy
 	NetworkSecurityPoliciesLock *sync.RWMutex
@@ -150,6 +155,9 @@ func NewKubeArmorDaemon() *KubeArmorDaemon {
 
 	dm.HostSecurityPolicies = []tp.HostSecurityPolicy{}
 	dm.HostSecurityPoliciesLock = new(sync.RWMutex)
+
+	dm.HostPolicyHash = ""
+	dm.HostPolicyHashLock = new(sync.RWMutex)
 
 	dm.NetworkSecurityPolicies = []tp.NetworkSecurityPolicy{}
 	dm.NetworkSecurityPoliciesLock = new(sync.RWMutex)

--- a/KubeArmor/core/kubeUpdate.go
+++ b/KubeArmor/core/kubeUpdate.go
@@ -2588,6 +2588,11 @@ func (dm *KubeArmorDaemon) UpdateHostSecurityPolicies() {
 		}
 	}
 
+	// Fingerprint the effective host policy state (observability only). This is
+	// computed even when host enforcement is disabled, so the hash can confirm
+	// what a node actually resolved while debugging "applied but not enforced".
+	dm.updateHostPolicyHash(secPolicies)
+
 	if cfg.GlobalCfg.HostPolicy {
 		// update host security policies
 		dm.Logger.UpdateHostSecurityPolicies("UPDATED", secPolicies)
@@ -2605,6 +2610,34 @@ func (dm *KubeArmorDaemon) UpdateHostSecurityPolicies() {
 				dm.USBDeviceHandler.UpdateHostSecurityPolicies(secPolicies)
 			}
 		}
+	}
+}
+
+// updateHostPolicyHash computes a deterministic SHA-256 fingerprint of the
+// node's effective host security policies and stores it for observability
+// (exposed via logs and karmor probe). Policies are sorted by name so that
+// ordering does not affect the hash. This never influences enforcement.
+func (dm *KubeArmorDaemon) updateHostPolicyHash(secPolicies []tp.HostSecurityPolicy) {
+	sorted := make([]tp.HostSecurityPolicy, len(secPolicies))
+	copy(sorted, secPolicies)
+	slices.SortStableFunc(sorted, func(a, b tp.HostSecurityPolicy) int {
+		return strings.Compare(a.Metadata["policyName"], b.Metadata["policyName"])
+	})
+
+	hash, err := kl.ComputeHash(sorted)
+	if err != nil {
+		kg.Warnf("Failed to compute host policy hash: %s", err.Error())
+		return
+	}
+
+	dm.HostPolicyHashLock.Lock()
+	changed := dm.HostPolicyHash != hash
+	dm.HostPolicyHash = hash
+	dm.HostPolicyHashLock.Unlock()
+
+	// Log only on change to keep steady-state reconciles quiet.
+	if changed {
+		kg.Printf("Effective host policy hash updated: count=%d hash=%s", len(secPolicies), hash)
 	}
 }
 

--- a/KubeArmor/core/kubeUpdate_race_test.go
+++ b/KubeArmor/core/kubeUpdate_race_test.go
@@ -118,6 +118,7 @@ func TestUpdateHostSecurityPoliciesRaceCondition(t *testing.T) {
 	dm := &KubeArmorDaemon{
 		HostSecurityPolicies:     []tp.HostSecurityPolicy{},
 		HostSecurityPoliciesLock: &sync.RWMutex{},
+		HostPolicyHashLock:       &sync.RWMutex{},
 		Node: tp.Node{
 			Identities: []string{"hostname=test-node"},
 		},


### PR DESCRIPTION
## What this does

When you're debugging a policy issue across a cluster, it's surprisingly hard to
answer a simple question: *"Are these nodes actually running the same policy?"*
Logs tell you what was applied, but there's no single value you can glance at to
confirm two nodes resolved to the identical effective state — or to spot silent
drift when they didn't.

This PR adds a deterministic **SHA-256 fingerprint of each node's effective host
security policy set**. Same policies, same hash — on every node, every time.
Different hash means the nodes diverged, and now you can see it immediately.

This is purely for observability and debugging. It never touches enforcement,
policy sources, or any trust decision.

## How it works

- A small reusable helper `ComputeHash` (in `common`) returns a hex SHA-256 of
  the JSON serialization of any value.
- On every host policy reconcile, the daemon takes the node's effective policy
  set, sorts it by policy name so ordering can't affect the result, hashes it,
  and stores it in memory under its own lock.
- The hash is computed **even when host enforcement is disabled**, so it's useful
  exactly in the "policy applied but not enforced" scenario.
- It's logged **only when it changes**, so steady-state reconciles stay quiet.
- It's exposed through `karmor probe` data (`HostPolicyHash`), so you can read it
  without grepping logs.

## Why it's safe

- The fingerprint is derived only from the effective rule content (`policyName` +
  `spec`). Host policy metadata carries no volatile fields like resourceVersion or
  timestamps, so identical rules always produce an identical hash — which is what
  makes cross-node comparison meaningful.
- A dedicated lock means reading the hash for probe output never blocks policy
  updates.
- Hashing happens only on policy changes, never on the enforcement or eBPF hot
  path — negligible overhead.
- No new dependencies, no new config, no gRPC/proto changes, existing logs
  unchanged.

## Scope

- **In scope:** host security policies (the case where cross-node comparison is
  most valuable and the content is genuinely comparable).
- **Out of scope (deliberate):** per-pod/endpoint policies (they churn per node
  and aren't meaningfully comparable across nodes) and surfacing the hash over the
  gRPC `ProbeResponse` (the CLI display lives in the separate `kubearmor-client`
  repo — a clean follow-up if wanted).

## Testing

- Unit tests for `ComputeHash`: determinism, order-independence after sort,
  content-sensitivity, stable non-empty hash for empty input, and correct
  SHA-256 length — all passing under `-race`.
- Existing host policy race test (`TestUpdateHostSecurityPoliciesRaceCondition`)
  updated to initialize the new lock and passing under `-race`.
- `go build ./...`, `go vet`, and the broader `core` race tests all clean.

Closes #2323