### PR TITLE
fix(core): allow BPF-LSM host policy enforcement when SELinux co-exists on Bottlerocket

### DIFF
--- a/KubeArmor/core/kubeUpdate.go
+++ b/KubeArmor/core/kubeUpdate.go
@@ -74,17 +74,21 @@ func (dm *KubeArmorDaemon) HandleNodeAnnotations(node *tp.Node) {
 
 	hasAppArmor := strings.Contains(lsm, "apparmor")
 	hasSelinux := strings.Contains(lsm, "selinux")
-	hasBPF := strings.Contains(lsm, "bpf")
+	// hasBPFLSM checks whether BPF-LSM is listed as an active LSM in
+	// /sys/kernel/security/lsm — distinct from general eBPF support.
+	hasBPFLSM := strings.Contains(lsm, "bpf")
 
-	if !hasBPF && !hasSelinux && !hasAppArmor {
-		// exception: neither AppArmor, SELinux or BPF
+	if !hasBPFLSM && !hasSelinux && !hasAppArmor {
+		// exception: neither AppArmor, SELinux or BPF-LSM
 		if node.Annotations["kubearmor-policy"] == "enabled" {
 			node.Annotations["kubearmor-policy"] = "audited"
 		}
 	}
 
-	if kl.IsInK8sCluster() && hasSelinux {
-		// exception: KubeArmor in a daemonset even though SELinux is enabled
+	if kl.IsInK8sCluster() && hasSelinux && !hasBPFLSM {
+		// exception: KubeArmor in a daemonset with SELinux but no BPF-LSM active.
+		// When BPF-LSM is also active (e.g. Bottlerocket), KubeArmor uses it for
+		// enforcement; downgrading to audited in that case is incorrect.
 		if node.Annotations["kubearmor-policy"] == "enabled" {
 			node.Annotations["kubearmor-policy"] = "audited"
 		}


### PR DESCRIPTION
## Purpose of PR

Fixes #2595 

### Does this PR introduce a breaking change?

**No.**

This change only affects nodes where both **SELinux** and **BPF-LSM** are present in `/sys/kernel/security/lsm` (for example, Bottlerocket nodes).

Nodes running SELinux without BPF-LSM continue to behave exactly as before.

---

## Manual Verification

### Scenario: Host policy enforcement on Bottlerocket (EKS)

1. Applied a `KubeArmorHostPolicy` that blocks access to `/etc/passwd`.
2. Verified that **before the fix**:

   * `cat /etc/passwd` was **not blocked**.
   * Policy enforcement was silently skipped.
   * No relay logs were generated.
3. Verified that **after the fix**:

   * `cat /etc/passwd` is correctly **blocked**.
   * Policy enforcement occurs as expected.
   * Relay logs are generated and visible.

---

## Additional Information for Reviewers

On Bottlerocket nodes, `/sys/kernel/security/lsm` contains both `selinux` and `bpf`.

`HandleNodeAnnotations()` in `core/kubeUpdate.go` was unconditionally downgrading node policy mode from **enabled** to **audited** whenever SELinux was detected in a Kubernetes cluster, even when BPF-LSM was available.

As a result:

* `UpdateHostSecurityPolicies()` skipped enforcement because it only proceeds when:

  ```go
  PolicyEnabled == KubeArmorPolicyEnabled
  ```
* Host security policies were never pushed to the BPF map.
* `KubeArmorHostPolicy` rules were not enforced.
* No blocking occurred.
* No relay logs were emitted.

This fix narrows the SELinux exception to cases where **BPF-LSM is not available** (`!hasBPF`).

When BPF-LSM is present alongside SELinux (as on Bottlerocket), KubeArmor should use BPF-LSM for enforcement, and downgrading the node to audit-only mode is incorrect.

---

## Checklist

* [x] Bug fix. Fixes #2595
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] This change requires a documentation update
* [x] PR title follows the convention of `<type>(<scope>): <subject>`
* [ ] Commit has unit tests
* [ ] Commit has integration tests
