### PR TITLE
Fix link to CODE_OF_CONDUCT.md in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to KubeArmor
 
-Welcome to KubeArmor, and thank you for showcasing your interest in contributing to the KubeArmor community. We are excited to have you join us in improving Linux runtime security through Kubernetes. The KubeArmor community abides by the CNCF [code of conduct](code-of-conduct.md). Here is an excerpt:
+Welcome to KubeArmor, and thank you for showcasing your interest in contributing to the KubeArmor community. We are excited to have you join us in improving Linux runtime security through Kubernetes. The KubeArmor community abides by the CNCF [code of conduct](CODE_OF_CONDUCT.md). Here is an excerpt:
 
 _As contributors and maintainers of this project, and in the interest of fostering an open and welcoming community, we pledge to respect all people who contribute through reporting issues, posting feature requests, updating documentation, submitting pull requests or patches, and other activities._
 


### PR DESCRIPTION
docs: fix broken code of conduct link in CONTRIBUTING.md

The link pointed to code-of-conduct.md but the actual file is CODE_OF_CONDUCT.md, causing a 404 error.

**Purpose of PR?**
Fixes a broken link that was resulting in 404 error. The reference was pointing to code-of-conduct.md instead of the actual file name CODE_OF_CONDUCT.md.

**Does this PR introduce a breaking change?**
NO

**If the changes in this PR are manually verified, list down the scenarios covered:**
- Navigated to the file with the broken link
- Verified that the link is now correctly resolved to CODE_OF_CONDUCT.md after the change.

**Additional information for reviewer?**
This is a minor documentation fix to resolve repository navigation issues.

**Checklist:**
- [x] Bug fix. Fixes: Broken CODE_OF_CONDUCT.md link (404 error)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] PR Title follows the convention of `<type>(<scope>): <subject>`
- [ ] Commit has unit tests
- [ ] Commit has integration tests