### PR TITLE
feat: add openEuler 24.03 LTS-SP3 to support matrix

### DIFF
--- a/getting-started/support_matrix.md
+++ b/getting-started/support_matrix.md
@@ -34,6 +34,7 @@ KubeArmor supports following types of workloads:
 | Mirantis     | [MKE] | Ubuntu>=20.04 | x86_64 | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | AppArmor | [1181] |
 | Digital Ocean | [DOKS] | Debian GNU/Linux 11 (bullseye) | x86_64 | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | [BPFLSM] | [1120] |
 | Alibaba Cloud | [Alibaba] | Alibaba Cloud Linux 3.2104 LTS | x86_64 | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | [BPFLSM] | [1650] |
+| Huawei Cloud | [k3s] | [OpenEuler] 24.03 LTS-SP3 | x86_64 | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | [BPFLSM] | [2685] |
 
 [Observability]: workload_visibility.md
 [TalosK8s]: https://www.siderolabs.com/platform/talos-os-for-kubernetes/
@@ -70,6 +71,8 @@ KubeArmor supports following types of workloads:
 [1120]: https://github.com/kubearmor/KubeArmor/issues/1120
 [1650]: https://github.com/kubearmor/KubeArmor/issues/1650
 [Alibaba]: https://www.alibabacloud.com/
+[OpenEuler]: https://www.openeuler.org/en/
+[2685]: https://github.com/kubearmor/KubeArmor/issues/2685
 ## Supported Linux Distributions
 
 Following distributions are tested for VM/Bare-metal based installations:
@@ -88,6 +91,7 @@ Following distributions are tested for VM/Bare-metal based installations:
 | RaspberryPi (ARM) | Debian | Full | Full |
 | ArchLinux | ArchLinux-6.2.1   | Full | Full |
 | Alibaba | Alibaba Cloud Linux  3.2104 LTS 64 bit  | Full | Full |
+| OpenEuler | OpenEuler 24.03 LTS-SP3 | Full | Full |
 
 > **Note**
 > Full: Supports both enforcement and observability  


### PR DESCRIPTION
**Purpose of PR?**: Fixes #2685 -- adds openEuler 24.03 LTS-SP3 to the KubeArmor support matrix after full verification of systemd mode and k8s mode (k3s) on AWS EC2 (ap-south-1, kernel `6.6.0-132.0.0.111.oe2403sp3.x86_64`).

**Does this PR introduce a breaking change?** No.

**If the changes in this PR are manually verified, list down the scenarios covered:**

### 1. Kernel Support Verification
<img width="1355" height="152" alt="1" src="https://github.com/user-attachments/assets/ece112e1-db58-4136-aee9-2fb124ec13e7" />


<img width="970" height="42" alt="2" src="https://github.com/user-attachments/assets/50ba19e3-256f-4650-b548-7a4574c8ebe6" />


- `CONFIG_BPF_LSM=y` ✅
- `CONFIG_DEBUG_INFO_BTF=y` ✅
- `CONFIG_BPF_SYSCALL=y` ✅
- `/sys/kernel/btf/vmlinux` present (5.1MB, CO-RE supported) ✅
- Active LSMs at runtime: `lockdown,capability,yama,apparmor,bpf` ✅

### 2. karmor probe (before install)
<img width="1859" height="137" alt="3" src="https://github.com/user-attachments/assets/e3c314fd-de4c-46c4-8d02-0f37363193e7" />


- Observability/Audit: **Supported** (Kernel Version 6.6.0) ✅
- Enforcement: **Full** (Supported LSMs: lockdown,capability,yama,apparmor,bpf) ✅

### 3. Systemd Mode Deployment
<img width="1867" height="580" alt="4" src="https://github.com/user-attachments/assets/884f8f03-18cb-4272-b5f7-dc8fd82938a1" />

<img width="1864" height="139" alt="5" src="https://github.com/user-attachments/assets/e431748a-c450-4a63-aefe-81a73468f1d2" />


KubeArmor v1.7.3 installed via tarball method (non-Debian path per `kubearmor_vm.md`). BPF-LSM Enforcer initialized successfully.

> **Note:** openEuler 24.03 on AWS defaults to cgroup v1. cgroup v2 must be enabled before deploying k3s by adding `systemd.unified_cgroup_hierarchy=1` to `GRUB_CMDLINE_LINUX` in `/etc/default/grub` and regenerating grub config.

### 4. k8s Mode (k3s) Deployment
<img width="1849" height="62" alt="6" src="https://github.com/user-attachments/assets/fdd7dd7d-edda-49fa-8f19-ad863b968db3" />


<img width="1853" height="241" alt="7" src="https://github.com/user-attachments/assets/1318d468-c8bd-495f-b49c-d2c9674915ab" />


<img width="1818" height="562" alt="8" src="https://github.com/user-attachments/assets/37393199-8115-4f2e-8b7d-299c8f3f2c55" />


- Active LSM: **BPFLSM** ✅
- Container Security: **true** ✅
- All 4 KubeArmor components running ✅

### 5. Policy Enforcement Test (k8s mode)
<img width="933" height="386" alt="10" src="https://github.com/user-attachments/assets/ce67f18a-6f91-4163-8b1b-c25611fc0b34" />


<img width="1826" height="63" alt="12" src="https://github.com/user-attachments/assets/ced18dcb-604b-47ff-9193-f4759af07456" />


<img width="1853" height="213" alt="11" src="https://github.com/user-attachments/assets/7865abd3-4661-4ccf-8e60-df18d6af7311" />


BPF-LSM enforcement confirmed. `exec /usr/bin/sleep: permission denied` with `"Enforcer":"BPFLSM"`, `"Action":"Block"`, `"Result":"Permission denied"` in alert log.

### Verification Summary

| Mode | Observability | Enforcement | LSM |
|------|--------------|-------------|-----|
| Systemd | Full | Full | BPFLSM |
| k8s (k3s) | Full | Full | BPFLSM |

**Additional information for reviewer?**: Tested on AWS EC2 ami-09f64635d2f33f6f0 (openEuler 24.03 LTS-SP3 x86_64, ap-south-1). Kernel config reference for this version is also available at nyrahul/linux-kernel-configs. cgroup v2 is a prerequisite for k3s/k8s mode on this distro when running on AWS.

**Checklist:**
- [ ] Bug fix. Fixes #<issue number>
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
- [x] PR Title follows the convention of `feat(docs): add openEuler 24.03 LTS-SP3 to support matrix`
- [ ] Commit has unit tests
- [ ] Commit has integration tests