### PR TITLE
cert: fix GenerateCA returning nil error on self-signed cert failure

### DIFF
--- a/KubeArmor/cert/cert.go
+++ b/KubeArmor/cert/cert.go
@@ -208,7 +208,7 @@ func GenerateCA(cfg *CertConfig) (*CertBytes, error) {
 	}
 	crtBytes, err := GenerateSelfSignedCert(crtTemp, cfg)
 	if err != nil {
-		return &CertBytes{}, nil
+		return &CertBytes{}, err
 	}
 	return &CertBytes{
 		Crt: crtBytes.Crt,

--- a/KubeArmor/cert/cert_test.go
+++ b/KubeArmor/cert/cert_test.go
@@ -1,0 +1,81 @@
+package cert
+
+import (
+	"crypto/x509"
+	"testing"
+)
+
+func TestGenerateCA_Success(t *testing.T) {
+	cfg := &CertConfig{
+		CN:           "test-ca",
+		Organization: "test-org",
+		IsCa:         true,
+		KeyUsage:     x509.KeyUsageCertSign,
+	}
+
+	certBytes, err := GenerateCA(cfg)
+	if err != nil {
+		t.Fatalf("GenerateCA() expected no error, got: %v", err)
+	}
+	if len(certBytes.Crt) == 0 {
+		t.Error("GenerateCA() returned empty certificate")
+	}
+	if len(certBytes.Key) == 0 {
+		t.Error("GenerateCA() returned empty key")
+	}
+}
+
+func TestGenerateSelfSignedCert_Success(t *testing.T) {
+	ca, err := GenerateCA(&CertConfig{
+		CN:           "test-root",
+		Organization: "test",
+		IsCa:         true,
+		KeyUsage:     x509.KeyUsageCertSign,
+	})
+	if err != nil {
+		t.Fatalf("failed to generate CA: %v", err)
+	}
+
+	caPair, err := GetCertKeyPairFromCertBytes(ca)
+	if err != nil {
+		t.Fatalf("failed to parse CA cert bytes: %v", err)
+	}
+
+	cfg := &CertConfig{
+		CN:           "test-leaf",
+		Organization: "test",
+	}
+
+	cert, err := GenerateSelfSignedCert(caPair, cfg)
+	if err != nil {
+		t.Fatalf("GenerateSelfSignedCert() expected no error, got: %v", err)
+	}
+	if len(cert.Crt) == 0 {
+		t.Error("GenerateSelfSignedCert() returned empty certificate")
+	}
+	if len(cert.Key) == 0 {
+		t.Error("GenerateSelfSignedCert() returned empty key")
+	}
+}
+
+func TestGetPemCertFromx509Cert(t *testing.T) {
+	ca, err := GenerateCA(&CertConfig{
+		CN:           "test",
+		Organization: "test",
+		IsCa:         true,
+		KeyUsage:     x509.KeyUsageCertSign,
+	})
+	if err != nil {
+		t.Fatalf("GenerateCA() failed: %v", err)
+	}
+
+	caPair, err := GetCertKeyPairFromCertBytes(ca)
+	if err != nil {
+		t.Fatalf("GetCertKeyPairFromCertBytes() failed: %v", err)
+	}
+
+	pemBytes := GetPemCertFromx509Cert(*caPair.Crt)
+	if len(pemBytes) == 0 {
+		t.Error("GetPemCertFromx509Cert() returned empty bytes")
+	}
+}


### PR DESCRIPTION
## What

\GenerateCA()\ silently swallows errors from \GenerateSelfSignedCert()\. When self-signed certificate generation fails, the function returns an empty \CertBytes\ struct with a \
il\ error, causing callers to believe certificate generation succeeded.

## Why

The error return was hardcoded to \
il\ instead of propagating the actual error. This was a copy-paste mistake — the preceding error handling block correctly returns the error.

## Impact

Callers like the operator's PKI initialization and gRPC TLS setup proceed with zero-value cert/key bytes, leading to runtime TLS failures that are difficult to diagnose because the root cause error was discarded.

## How to Reproduce

Trigger a failure in \GenerateSelfSignedCert\ (e.g., invalid cert config). \GenerateCA\ logs the error but returns nil error, leaving callers with an empty certificate.

## Fix

Changed \eturn &CertBytes{}, nil\ to \eturn &CertBytes{}, err\ — a one-line change.

Fixes #2689