### PR TITLE
fix(core): prevent stale CRI policy snapshots from overwriting KSP rules

### DIFF
--- a/KubeArmor/core/containerdHandler.go
+++ b/KubeArmor/core/containerdHandler.go
@@ -525,17 +525,7 @@ func (dm *KubeArmorDaemon) UpdateContainerdContainer(ctx context.Context, contai
 				dm.Presets.RegisterContainer(container.ContainerID, container.PidNS, container.MntNS)
 			}
 
-			if len(endPoint.SecurityPolicies) > 0 { // struct can be empty or no policies registered for the endPoint yet
-				dm.Logger.UpdateSecurityPolicies("ADDED", endPoint)
-				if dm.RuntimeEnforcer != nil && endPoint.PolicyEnabled == tp.KubeArmorPolicyEnabled {
-					// enforce security policies
-					dm.RuntimeEnforcer.UpdateSecurityPolicies(endPoint)
-				}
-				if dm.Presets != nil && endPoint.PolicyEnabled == tp.KubeArmorPolicyEnabled {
-					// enforce preset rules
-					dm.Presets.UpdateSecurityPolicies(endPoint)
-				}
-			}
+			dm.enforceEndpointSecurityPolicies("ADDED", container.NamespaceName, container.EndPointName, container.ContainerID)
 		}
 
 		if cfg.GlobalCfg.StateAgent {

--- a/KubeArmor/core/crioHandler.go
+++ b/KubeArmor/core/crioHandler.go
@@ -241,8 +241,6 @@ func (dm *KubeArmorDaemon) UpdateCrioContainer(ctx context.Context, containerID,
 			return fmt.Errorf("container ID is empty")
 		}
 
-		endpoint := tp.EndPoint{}
-
 		dm.ContainersLock.Lock()
 		if _, ok := dm.Containers[container.ContainerID]; !ok {
 			dm.Containers[container.ContainerID] = container
@@ -278,8 +276,6 @@ func (dm *KubeArmorDaemon) UpdateCrioContainer(ctx context.Context, containerID,
 						dm.EndPoints[idx].PrivilegedContainers[container.ContainerName] = struct{}{}
 					}
 
-					endpoint = dm.EndPoints[idx]
-
 					break
 				}
 			}
@@ -305,17 +301,7 @@ func (dm *KubeArmorDaemon) UpdateCrioContainer(ctx context.Context, containerID,
 				dm.Presets.RegisterContainer(containerID, container.PidNS, container.MntNS)
 			}
 
-			if len(endpoint.SecurityPolicies) > 0 { // struct can be empty or no policies registered for the endpoint yet
-				dm.Logger.UpdateSecurityPolicies("ADDED", endpoint)
-				if dm.RuntimeEnforcer != nil && endpoint.PolicyEnabled == tp.KubeArmorPolicyEnabled {
-					// enforce security policies
-					dm.RuntimeEnforcer.UpdateSecurityPolicies(endpoint)
-				}
-				if dm.Presets != nil && endpoint.PolicyEnabled == tp.KubeArmorPolicyEnabled {
-					// enforce preset rules
-					dm.Presets.UpdateSecurityPolicies(endpoint)
-				}
-			}
+			dm.enforceEndpointSecurityPolicies("ADDED", container.NamespaceName, container.EndPointName, containerID)
 		}
 
 		if !dm.K8sEnabled {

--- a/KubeArmor/core/dockerHandler.go
+++ b/KubeArmor/core/dockerHandler.go
@@ -406,6 +406,10 @@ func (dm *KubeArmorDaemon) GetAlreadyDeployedDockerContainers() {
 							}
 							dm.SecurityPoliciesLock.RUnlock()
 
+							if len(endPoint.SecurityPolicies) > 0 {
+								endPoint.PolicyRevision = 1
+							}
+
 							dm.EndPoints[endPointIdx] = endPoint
 						}
 						dm.EndPointsLock.Unlock()
@@ -483,17 +487,7 @@ func (dm *KubeArmorDaemon) GetAlreadyDeployedDockerContainers() {
 						dm.Presets.RegisterContainer(container.ContainerID, container.PidNS, container.MntNS)
 					}
 
-					if len(endPoint.SecurityPolicies) > 0 { // struct can be empty or no policies registered for the endpoint yet
-						dm.Logger.UpdateSecurityPolicies("ADDED", endPoint)
-						if dm.RuntimeEnforcer != nil && endPoint.PolicyEnabled == tp.KubeArmorPolicyEnabled {
-							// enforce security policies
-							dm.RuntimeEnforcer.UpdateSecurityPolicies(endPoint)
-						}
-						if dm.Presets != nil && endPoint.PolicyEnabled == tp.KubeArmorPolicyEnabled {
-							// enforce preset rules
-							dm.Presets.UpdateSecurityPolicies(endPoint)
-						}
-					}
+					dm.enforceEndpointSecurityPolicies("ADDED", container.NamespaceName, container.EndPointName, container.ContainerID)
 				}
 
 				dm.Logger.Printf("Detected a container (added/%.12s)", container.ContainerID)
@@ -613,6 +607,10 @@ func (dm *KubeArmorDaemon) UpdateDockerContainer(containerID, action string) {
 					}
 					dm.SecurityPoliciesLock.RUnlock()
 
+					if len(endPoint.SecurityPolicies) > 0 {
+						endPoint.PolicyRevision = 1
+					}
+
 					dm.EndPoints[endPointIdx] = endPoint
 				}
 				dm.EndPointsLock.Unlock()
@@ -684,18 +682,7 @@ func (dm *KubeArmorDaemon) UpdateDockerContainer(containerID, action string) {
 				dm.Presets.RegisterContainer(containerID, container.PidNS, container.MntNS)
 			}
 
-			if len(endPoint.SecurityPolicies) > 0 { // struct can be empty or no policies registered for the endpoint yet
-				dm.Logger.UpdateSecurityPolicies("ADDED", endPoint)
-				if dm.RuntimeEnforcer != nil && endPoint.PolicyEnabled == tp.KubeArmorPolicyEnabled {
-					// enforce security policies
-					dm.RuntimeEnforcer.UpdateSecurityPolicies(endPoint)
-				}
-
-				if dm.Presets != nil && endPoint.PolicyEnabled == tp.KubeArmorPolicyEnabled {
-					// enforce preset rules
-					dm.Presets.UpdateSecurityPolicies(endPoint)
-				}
-			}
+			dm.enforceEndpointSecurityPolicies("ADDED", container.NamespaceName, container.EndPointName, containerID)
 		}
 
 		if cfg.GlobalCfg.StateAgent {

--- a/KubeArmor/core/endpointEnforce.go
+++ b/KubeArmor/core/endpointEnforce.go
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Authors of KubeArmor
+
+package core
+
+import (
+	kl "github.com/kubearmor/KubeArmor/KubeArmor/common"
+	cfg "github.com/kubearmor/KubeArmor/KubeArmor/config"
+	tp "github.com/kubearmor/KubeArmor/KubeArmor/types"
+)
+
+// getFreshEndPointForContainer re-reads the canonical endpoint under EndPointsLock.
+func (dm *KubeArmorDaemon) getFreshEndPointForContainer(ns, epName, containerID string) (tp.EndPoint, bool) {
+	dm.EndPointsLock.RLock()
+	defer dm.EndPointsLock.RUnlock()
+
+	for _, ep := range dm.EndPoints {
+		if ep.NamespaceName == ns && ep.EndPointName == epName && kl.ContainsElement(ep.Containers, containerID) {
+			return ep, true
+		}
+	}
+
+	return tp.EndPoint{}, false
+}
+
+// bumpPolicyRevision increments the policy revision on an endpoint after a material policy change.
+func bumpPolicyRevision(ep *tp.EndPoint) {
+	ep.PolicyRevision++
+}
+
+// enforceEndpointSecurityPolicies applies security policies using a fresh endpoint snapshot.
+func (dm *KubeArmorDaemon) enforceEndpointSecurityPolicies(action, ns, epName, containerID string) {
+	if !cfg.GlobalCfg.Policy {
+		return
+	}
+
+	freshEP, ok := dm.getFreshEndPointForContainer(ns, epName, containerID)
+	if !ok || len(freshEP.SecurityPolicies) == 0 || freshEP.PolicyEnabled != tp.KubeArmorPolicyEnabled {
+		return
+	}
+
+	if dm.Logger != nil {
+		dm.Logger.UpdateSecurityPolicies(action, freshEP)
+	}
+	if dm.RuntimeEnforcer != nil {
+		dm.RuntimeEnforcer.UpdateSecurityPolicies(freshEP)
+	}
+	if dm.Presets != nil {
+		dm.Presets.UpdateSecurityPolicies(freshEP)
+	}
+}

--- a/KubeArmor/core/hook_handler.go
+++ b/KubeArmor/core/hook_handler.go
@@ -111,8 +111,6 @@ func (dm *KubeArmorDaemon) handleK8sConn(conn net.Conn, ready *atomic.Bool) {
 	}
 }
 func (dm *KubeArmorDaemon) handleContainerCreate(container types.Container) {
-	endpoint := types.EndPoint{}
-
 	dm.Logger.Printf("Detected a container (added/%.12s/pidns=%d/mntns=%d)", container.ContainerID, container.PidNS, container.MntNS)
 
 	dm.ContainersLock.Lock()
@@ -145,8 +143,6 @@ func (dm *KubeArmorDaemon) handleContainerCreate(container types.Container) {
 					dm.EndPoints[idx].PrivilegedContainers[container.ContainerName] = struct{}{}
 				}
 
-				endpoint = dm.EndPoints[idx]
-
 				break
 			}
 		}
@@ -163,13 +159,7 @@ func (dm *KubeArmorDaemon) handleContainerCreate(container types.Container) {
 		dm.SystemMonitor.AddContainerIDToNsMap(container.ContainerID, container.NamespaceName, container.PidNS, container.MntNS)
 		dm.RuntimeEnforcer.RegisterContainer(container.ContainerID, container.PidNS, container.MntNS)
 
-		if len(endpoint.SecurityPolicies) > 0 { // struct can be empty or no policies registered for the endpoint yet
-			dm.Logger.UpdateSecurityPolicies("ADDED", endpoint)
-			if dm.RuntimeEnforcer != nil && endpoint.PolicyEnabled == types.KubeArmorPolicyEnabled {
-				// enforce security policies
-				dm.RuntimeEnforcer.UpdateSecurityPolicies(endpoint)
-			}
-		}
+		dm.enforceEndpointSecurityPolicies("ADDED", container.NamespaceName, container.EndPointName, container.ContainerID)
 	}
 }
 func (dm *KubeArmorDaemon) handleContainerDelete(containerID string) {

--- a/KubeArmor/core/hook_handlier_non_k8s.go
+++ b/KubeArmor/core/hook_handlier_non_k8s.go
@@ -190,14 +190,7 @@ func (dm *KubeArmorDaemon) UpdateContainer(containerID string, container tp.Cont
 			dm.SystemMonitor.AddContainerIDToNsMap(containerID, container.NamespaceName, container.PidNS, container.MntNS)
 			dm.RuntimeEnforcer.RegisterContainer(containerID, container.PidNS, container.MntNS)
 
-			if len(endPoint.SecurityPolicies) > 0 { // struct can be empty or no policies registered for the endPoint yet
-				dm.Logger.UpdateSecurityPolicies("ADDED", endPoint)
-				if dm.RuntimeEnforcer != nil && endPoint.PolicyEnabled == tp.KubeArmorPolicyEnabled {
-					dm.Logger.Printf("Enforcing security policies for container ID %s", containerID)
-					// enforce security policies
-					dm.RuntimeEnforcer.UpdateSecurityPolicies(endPoint)
-				}
-			}
+			dm.enforceEndpointSecurityPolicies("ADDED", container.NamespaceName, container.EndPointName, containerID)
 		}
 
 		if cfg.GlobalCfg.StateAgent {

--- a/KubeArmor/core/kubeUpdate.go
+++ b/KubeArmor/core/kubeUpdate.go
@@ -349,6 +349,10 @@ func (dm *KubeArmorDaemon) UpdateEndPointWithPod(action string, pod tp.K8sPod) {
 
 		dm.EndPointsLock.Lock()
 
+		for i := range endpoints {
+			endpoints[i].PolicyRevision = 1
+		}
+
 		// add the endpoint into the endpoint list
 		dm.EndPoints = append(dm.EndPoints, endpoints...)
 
@@ -532,6 +536,7 @@ func (dm *KubeArmorDaemon) UpdateEndPointWithPod(action string, pod tp.K8sPod) {
 			for nidx := 0; nidx < len(endpoints); nidx++ {
 				for idx := 0; idx < len(dm.EndPoints); idx++ {
 					if pod.Metadata["namespaceName"] == dm.EndPoints[idx].NamespaceName && pod.Metadata["podName"] == dm.EndPoints[idx].EndPointName && endpoints[nidx].ContainerName == dm.EndPoints[idx].ContainerName {
+						endpoints[nidx].PolicyRevision = dm.EndPoints[idx].PolicyRevision + 1
 						dm.EndPoints[idx] = endpoints[nidx]
 						break
 					}
@@ -1161,6 +1166,8 @@ func (dm *KubeArmorDaemon) UpdateSecurityPolicy(action string, secPolicyType str
 						dm.EndPoints[idx].EndPointName == endPoint.EndPointName &&
 						dm.EndPoints[idx].ContainerName == endPoint.ContainerName {
 						dm.EndPoints[idx] = endPoint
+						dm.EndPoints[idx].PolicyRevision++
+						endPoint = dm.EndPoints[idx]
 
 						if cfg.GlobalCfg.Policy {
 							// update security policies
@@ -1242,6 +1249,8 @@ func (dm *KubeArmorDaemon) UpdateSecurityPolicy(action string, secPolicyType str
 						dm.EndPoints[idx].EndPointName == endPoint.EndPointName &&
 						dm.EndPoints[idx].ContainerName == endPoint.ContainerName {
 						dm.EndPoints[idx] = endPoint
+						dm.EndPoints[idx].PolicyRevision++
+						endPoint = dm.EndPoints[idx]
 
 						if cfg.GlobalCfg.Policy {
 							// update security policies

--- a/KubeArmor/core/kubeUpdate_race_test.go
+++ b/KubeArmor/core/kubeUpdate_race_test.go
@@ -324,3 +324,89 @@ func TestConcurrentEndpointAccess(t *testing.T) {
 	wg.Wait()
 	t.Logf("Concurrent access test completed. Final endpoint count: %d", len(dm.EndPoints))
 }
+
+// TestContainerEventAndPolicyUpdateRace exercises concurrent policy updates and fresh endpoint reads.
+func TestContainerEventAndPolicyUpdateRace(t *testing.T) {
+	dm := &KubeArmorDaemon{
+		EndPoints: []tp.EndPoint{{
+			NamespaceName:    "default",
+			EndPointName:     "test-pod",
+			ContainerName:    "app",
+			Containers:       []string{"cid-1"},
+			Identities:       []string{"namespaceName=default"},
+			PolicyEnabled:    tp.KubeArmorPolicyEnabled,
+			SecurityPolicies: []tp.SecurityPolicy{},
+		}},
+		EndPointsLock:            &sync.RWMutex{},
+		SecurityPolicies:         []tp.SecurityPolicy{},
+		SecurityPoliciesLock:     &sync.RWMutex{},
+		DefaultPostures:          map[string]tp.DefaultPosture{},
+		DefaultPosturesLock:      &sync.Mutex{},
+		HostSecurityPolicies:     []tp.HostSecurityPolicy{},
+		HostSecurityPoliciesLock: &sync.RWMutex{},
+	}
+
+	testPolicy := tp.SecurityPolicy{
+		Metadata: map[string]string{
+			"namespaceName": "default",
+			"policyName":    "test-policy",
+		},
+		Spec: tp.SecuritySpec{
+			Selector: tp.SelectorType{
+				Identities: []string{"namespaceName=default"},
+			},
+		},
+	}
+
+	var wg sync.WaitGroup
+	stopCh := make(chan struct{})
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stopCh:
+				return
+			default:
+				dm.UpdateSecurityPolicy(addEvent, KubeArmorPolicy, testPolicy)
+				dm.UpdateSecurityPolicy(updateEvent, KubeArmorPolicy, testPolicy)
+				time.Sleep(1 * time.Millisecond)
+			}
+		}
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stopCh:
+				return
+			default:
+				dm.enforceEndpointSecurityPolicies("ADDED", "default", "test-pod", "cid-1")
+				_, _ = dm.getFreshEndPointForContainer("default", "test-pod", "cid-1")
+				time.Sleep(1 * time.Millisecond)
+			}
+		}
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+	close(stopCh)
+	wg.Wait()
+
+	dm.EndPointsLock.RLock()
+	defer dm.EndPointsLock.RUnlock()
+	for _, ep := range dm.EndPoints {
+		if ep.EndPointName != "test-pod" {
+			continue
+		}
+		if ep.PolicyRevision == 0 {
+			t.Errorf("PolicyRevision should be > 0 after policy updates, got %d", ep.PolicyRevision)
+		}
+		fresh, ok := dm.getFreshEndPointForContainer("default", "test-pod", "cid-1")
+		if ok && len(fresh.SecurityPolicies) != len(ep.SecurityPolicies) {
+			t.Errorf("final fresh read policy count %d != canonical %d", len(fresh.SecurityPolicies), len(ep.SecurityPolicies))
+		}
+	}
+}

--- a/KubeArmor/core/nriHandler.go
+++ b/KubeArmor/core/nriHandler.go
@@ -330,8 +330,6 @@ func (dm *KubeArmorDaemon) MonitorNRIEvents() {
 	defer dm.WgDaemon.Done()
 
 	handleNewContainer := func(container tp.Container) {
-		endpoint := tp.EndPoint{}
-
 		dm.ContainersLock.Lock()
 
 		if len(dm.OwnerInfo) > 0 {
@@ -372,8 +370,6 @@ func (dm *KubeArmorDaemon) MonitorNRIEvents() {
 						dm.EndPoints[idx].Containers = append(dm.EndPoints[idx].Containers, container.ContainerID)
 					}
 
-					endpoint = dm.EndPoints[idx]
-
 					break
 				}
 			}
@@ -396,17 +392,7 @@ func (dm *KubeArmorDaemon) MonitorNRIEvents() {
 				dm.Presets.RegisterContainer(container.ContainerID, container.PidNS, container.MntNS)
 			}
 
-			if len(endpoint.SecurityPolicies) > 0 { // struct can be empty or no policies registered for the endpoint yet
-				dm.Logger.UpdateSecurityPolicies("ADDED", endpoint)
-				if dm.RuntimeEnforcer != nil && endpoint.PolicyEnabled == tp.KubeArmorPolicyEnabled {
-					// enforce security policies
-					dm.RuntimeEnforcer.UpdateSecurityPolicies(endpoint)
-				}
-				if dm.Presets != nil && endpoint.PolicyEnabled == tp.KubeArmorPolicyEnabled {
-					// enforce preset rules
-					dm.Presets.UpdateSecurityPolicies(endpoint)
-				}
-			}
+			dm.enforceEndpointSecurityPolicies("ADDED", container.NamespaceName, container.EndPointName, container.ContainerID)
 		}
 
 		if !dm.K8sEnabled {

--- a/KubeArmor/core/unorchestratedUpdates.go
+++ b/KubeArmor/core/unorchestratedUpdates.go
@@ -113,6 +113,8 @@ func (dm *KubeArmorDaemon) MatchandUpdateContainerSecurityPolicies(cid string) {
 			ctr.EndPointName = ep.EndPointName
 			dm.Containers[cid] = ctr
 			if cfg.GlobalCfg.Policy {
+				dm.EndPoints[idx].PolicyRevision++
+				ep = dm.EndPoints[idx]
 				// update security policies
 				dm.Logger.UpdateSecurityPolicies("MODIFIED", ep)
 				if ep.PolicyEnabled == tp.KubeArmorPolicyEnabled {
@@ -196,6 +198,7 @@ func (dm *KubeArmorDaemon) handlePolicyEvent(eventType string, createEndPoint bo
 		dm.RuntimeEnforcer.UpdateAppArmorProfiles(containername, "ADDED", appArmorAnnotations, privilegedProfiles)
 
 		newPoint.SecurityPolicies = append(newPoint.SecurityPolicies, secPolicy)
+		newPoint.PolicyRevision++
 		if createEndPoint {
 			// Create new EndPoint - possible scenarios:
 			// policy received before container
@@ -236,6 +239,7 @@ func (dm *KubeArmorDaemon) handlePolicyEvent(eventType string, createEndPoint bo
 			}
 		}
 	case "MODIFIED":
+		newPoint.PolicyRevision++
 		dm.EndPoints[endpointIdx] = newPoint
 		if cfg.GlobalCfg.Policy {
 			// update security policies
@@ -255,6 +259,7 @@ func (dm *KubeArmorDaemon) handlePolicyEvent(eventType string, createEndPoint bo
 	default: // DELETED
 		// update security policies after policy deletion
 		if endpointIdx >= 0 {
+			newPoint.PolicyRevision++
 			dm.EndPoints[endpointIdx] = newPoint
 			dm.Logger.UpdateSecurityPolicies("DELETED", newPoint)
 			dm.RuntimeEnforcer.UpdateSecurityPolicies(newPoint)
@@ -714,6 +719,7 @@ func (dm *KubeArmorDaemon) ParseAndUpdateContainerSecurityPolicy(event tp.K8sKub
 					// delete unnecessary security policies
 					dm.Logger.UpdateSecurityPolicies("DELETED", endPoint)
 					endPoint.SecurityPolicies = append(endPoint.SecurityPolicies[:0], endPoint.SecurityPolicies[1:]...)
+					endPoint.PolicyRevision++
 					dm.RuntimeEnforcer.UpdateSecurityPolicies(endPoint)
 					if dm.Presets != nil {
 						dm.Presets.UpdateSecurityPolicies(endPoint)
@@ -729,6 +735,7 @@ func (dm *KubeArmorDaemon) ParseAndUpdateContainerSecurityPolicy(event tp.K8sKub
 						dm.EndPoints[idx].SecurityPolicies[policyIndex+1:]...,
 					)
 					endPoint = dm.EndPoints[idx]
+					endPoint.PolicyRevision++
 
 					if cfg.GlobalCfg.Policy {
 						// update security policies

--- a/KubeArmor/enforcer/bpflsm/enforcer.go
+++ b/KubeArmor/enforcer/bpflsm/enforcer.go
@@ -457,7 +457,7 @@ func (be *BPFEnforcer) UpdateSecurityPolicies(endPoint tp.EndPoint) {
 
 	for _, cid := range endPoint.Containers {
 		be.Logger.Printf("Updating container rules for %s", cid)
-		be.UpdateContainerRules(cid, endPoint.SecurityPolicies, endPoint.DefaultPosture)
+		be.UpdateContainerRules(cid, endPoint.SecurityPolicies, endPoint.DefaultPosture, endPoint.PolicyRevision)
 	}
 
 }

--- a/KubeArmor/enforcer/bpflsm/hostRulesHandling.go
+++ b/KubeArmor/enforcer/bpflsm/hostRulesHandling.go
@@ -36,5 +36,5 @@ func (be *BPFEnforcer) UpdateHostRules(securityPolicies []tp.HostSecurityPolicy)
 		CapabilitiesAction: cfg.GlobalCfg.HostDefaultCapabilitiesPosture,
 	}
 
-	be.UpdateContainerRules(id, hostPolicies, dp)
+	be.UpdateContainerRules(id, hostPolicies, dp, 0)
 }

--- a/KubeArmor/enforcer/bpflsm/mapHelpers.go
+++ b/KubeArmor/enforcer/bpflsm/mapHelpers.go
@@ -16,6 +16,8 @@ type ContainerKV struct {
 	Map   *ebpf.Map
 	Rules RuleList
 
+	AppliedPolicyRevision uint64
+
 	// -----------------//
 	Arg_Key ArgumentsKey
 	Arg_Map *ebpf.Map

--- a/KubeArmor/enforcer/bpflsm/rulesHandling.go
+++ b/KubeArmor/enforcer/bpflsm/rulesHandling.go
@@ -112,7 +112,7 @@ func (r *RuleList) Init() {
 }
 
 // UpdateContainerRules updates individual container map with new rules and resolves conflicting rules
-func (be *BPFEnforcer) UpdateContainerRules(id string, securityPolicies []tp.SecurityPolicy, defaultPosture tp.DefaultPosture) {
+func (be *BPFEnforcer) UpdateContainerRules(id string, securityPolicies []tp.SecurityPolicy, defaultPosture tp.DefaultPosture, revision uint64) {
 
 	var newrules RuleList
 
@@ -421,7 +421,14 @@ func (be *BPFEnforcer) UpdateContainerRules(id string, securityPolicies []tp.Sec
 		return
 	}
 
-	if be.ContainerMap[id].Map == nil && !(len(newrules.FileRuleList) == 0 && len(newrules.ProcessRuleList) == 0 && len(newrules.NetworkRuleList) == 0 && len(newrules.CapabilitiesRuleList) == 0) {
+	kv := be.ContainerMap[id]
+	// Only guard endpoint-originated updates (revision > 0). Host policy passes revision=0.
+	if revision > 0 && revision < kv.AppliedPolicyRevision {
+		be.Logger.Printf("Skipping stale policy update for %s (rev %d < %d)", id, revision, kv.AppliedPolicyRevision)
+		return
+	}
+
+	if kv.Map == nil && !(len(newrules.FileRuleList) == 0 && len(newrules.ProcessRuleList) == 0 && len(newrules.NetworkRuleList) == 0 && len(newrules.CapabilitiesRuleList) == 0) {
 		// We create the inner map only when we have policies specific to that
 		be.Logger.Printf("Creating inner map for %s", id)
 		be.CreateContainerInnerMap(id)
@@ -445,6 +452,9 @@ func (be *BPFEnforcer) UpdateContainerRules(id string, securityPolicies []tp.Sec
 		list.Rules.NetWhiteListPosture = newrules.NetWhiteListPosture
 		list.Rules.DNSNetWhiteListPosture = newrules.DNSNetWhiteListPosture
 		list.Rules.CapWhiteListPosture = newrules.CapWhiteListPosture
+		if revision > 0 {
+			list.AppliedPolicyRevision = revision
+		}
 
 		be.ContainerMap[id] = list
 	}

--- a/KubeArmor/enforcer/bpflsm/rulesHandling_test.go
+++ b/KubeArmor/enforcer/bpflsm/rulesHandling_test.go
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Authors of KubeArmor
+
+package bpflsm
+
+import (
+	"sync"
+	"testing"
+
+	tp "github.com/kubearmor/KubeArmor/KubeArmor/types"
+)
+
+func TestUpdateContainerRulesStaleRevisionSkip(t *testing.T) {
+	be := &BPFEnforcer{
+		ContainerMap:     make(map[string]ContainerKV),
+		ContainerMapLock: new(sync.RWMutex),
+	}
+
+	const containerID = "test-container"
+	be.ContainerMap[containerID] = ContainerKV{
+		AppliedPolicyRevision: 2,
+	}
+
+	be.UpdateContainerRules(containerID, []tp.SecurityPolicy{}, tp.DefaultPosture{}, 1)
+
+	if be.ContainerMap[containerID].AppliedPolicyRevision != 2 {
+		t.Fatalf("expected AppliedPolicyRevision to remain 2, got %d", be.ContainerMap[containerID].AppliedPolicyRevision)
+	}
+}
+
+func TestUpdateContainerRulesHostRevisionBypass(t *testing.T) {
+	be := &BPFEnforcer{
+		ContainerMap:     make(map[string]ContainerKV),
+		ContainerMapLock: new(sync.RWMutex),
+	}
+
+	const containerID = "test-container"
+	be.ContainerMap[containerID] = ContainerKV{
+		AppliedPolicyRevision: 5,
+	}
+
+	// revision=0 is the host-policy path and must not be rejected by the endpoint revision guard.
+	be.UpdateContainerRules(containerID, []tp.SecurityPolicy{}, tp.DefaultPosture{}, 0)
+
+	if be.ContainerMap[containerID].AppliedPolicyRevision != 5 {
+		t.Fatalf("expected host revision bypass to leave AppliedPolicyRevision at 5, got %d", be.ContainerMap[containerID].AppliedPolicyRevision)
+	}
+}

--- a/KubeArmor/types/types.go
+++ b/KubeArmor/types/types.go
@@ -92,6 +92,10 @@ type EndPoint struct {
 
 	SecurityPolicies []SecurityPolicy `json:"securityPolicies"`
 
+	// PolicyRevision is incremented on every authoritative security-policy write
+	// for this endpoint. BPF enforcer uses it to reject stale updates.
+	PolicyRevision uint64 `json:"policyRevision"`
+
 	// only needed for unorchestrated containers
 	PrivilegedContainers map[string]struct{} `json:"privilegdContainers"`
 


### PR DESCRIPTION
## Purpose of PR?

Fixes #2123

When container runtime handlers (Docker, containerd, CRI-O, NRI, OCI hooks) captured an `endPoint` snapshot before `RegisterContainer`, a concurrent KubeArmorPolicy update could be rolled back in the BPF map because `ContainerMapLock` serializes writes but last-writer-wins on policy content.

This PR fixes that with two layers:

1. **Fresh read at enforcement time** — CRI/Docker/hook handlers call `enforceEndpointSecurityPolicies()`, which re-reads the live endpoint via `getFreshEndPointForContainer()` before pushing to Logger, RuntimeEnforcer, and Presets.
2. **Monotonic `PolicyRevision` guard** — Authoritative policy writes increment `EndPoint.PolicyRevision`. BPF `UpdateContainerRules()` rejects updates when `revision > 0 && revision < AppliedPolicyRevision`, closing the remaining TOCTOU window. Host policy updates pass `revision=0` and are not blocked.

## Does this PR introduce a breaking change?

**No.** `PolicyRevision` is an additive field on `EndPoint` (defaults to 0). Existing APIs and enforcer interfaces are unchanged.

## If the changes in this PR are manually verified, list down the scenarios covered:

- [x] **Stale snapshot race (issue #2123):** CRI handler no longer pushes a captured `endPoint`; fresh read used at enforce time.
- [x] **BPF last-writer-wins:** Stale revision rejected (`TestUpdateContainerRulesStaleRevisionSkip` — rev 1 skipped when AppliedPolicyRevision is 2).
- [x] **Host policy path:** Host updates with `revision=0` bypass the guard (`TestUpdateContainerRulesHostRevisionBypass`).
- [x] **K8s-first ordering:** Docker/CRI still enforce after `RegisterContainer` via `enforceEndpointSecurityPolicies` (no K8s-only skip regression).
- [x] **Non-K8s Docker:** Fresh read + revision guard; `PolicyRevision = 1` on first policy attach.
- [x] **Concurrent policy + container events:** No panics/data races under `-race` (`TestContainerEventAndPolicyUpdateRace`, existing race tests).
- [x] **All 6 handler paths migrated:** docker, containerd, crio, nri, hook_handler, hook_handlier_non_k8s — no remaining stale `UpdateSecurityPolicies(endPoint)` in handlers.

## Local verification

Run from the **`KubeArmor/` module root** (where `go.mod` lives):
<img width="1306" height="523" alt="Screenshot From 2026-06-24 17-31-12" src="https://github.com/user-attachments/assets/af5bbc65-985e-4ea6-ad57-2debb0bc973c" />
```bash
cd KubeArmor

# 1. Format touched files
gofmt -w \
  types/types.go \
  core/endpointEnforce.go \
  core/kubeUpdate.go \
  core/unorchestratedUpdates.go \
  core/dockerHandler.go \
  core/containerdHandler.go \
  core/crioHandler.go \
  core/nriHandler.go \
  core/hook_handler.go \
  core/hook_handlier_non_k8s.go \
  core/kubeUpdate_race_test.go \
  enforcer/bpflsm/mapHelpers.go \
  enforcer/bpflsm/enforcer.go \
  enforcer/bpflsm/hostRulesHandling.go \
  enforcer/bpflsm/rulesHandling.go \
  enforcer/bpflsm/rulesHandling_test.go

## Local verification

> **Important:** Run all commands from the Go module root `KubeArmor/` (the inner directory that contains `go.mod`), not the repository root.

```bash
cd KubeArmor   # from repo root; or: cd /path/to/KubeArmor/KubeArmor

go build ./...
go vet ./core/... ./enforcer/bpflsm/... ./types/...
go test -race -count=1 -timeout=120s ./core/... -run 'Race|ContainerEvent'
go test -race -count=1 -timeout=120s ./enforcer/bpflsm/... -v
go test -race -count=1 -timeout=180s ./core/...
go test -race -count=1 -timeout=180s ./enforcer/...
