### PR TITLE
feat(examples): add zero-trust self-protection policies for KubeArmor

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -3,3 +3,4 @@
 1. [Multiubuntu](multiubuntu.md)
 2. [Sock Shop](sock-shop.md)
 3. [Wordpress with MySQL](wordpress-mysql.md)
+4. [KubeArmor self-protection](kubearmor-self-protection/README.md) — zero-trust policies for KubeArmor infrastructure workloads (#2066)

--- a/examples/kubearmor-self-protection/README.md
+++ b/examples/kubearmor-self-protection/README.md
@@ -1,0 +1,150 @@
+# KubeArmor Self-Protection Policies
+
+Zero-trust `KubeArmorPolicy` examples for KubeArmor's own production workloads. Closes [issue #2066](https://github.com/kubearmor/KubeArmor/issues/2066).
+
+## Prerequisites
+
+1. **PR1 merged** — [self-protection opt-in plumbing](https://github.com/kubearmor/KubeArmor/pulls) must be deployed. Block enforcement requires:
+   - `kubearmor.io/self-protection: enabled` on infrastructure pod templates
+   - `kubearmor-policy: enabled` (not `audited`)
+
+2. **Enable self-protection** before block phase:
+
+   **Direct Helm:**
+   ```bash
+   helm upgrade --install kubearmor ../../deployments/helm/KubeArmor \
+     -n kubearmor --create-namespace \
+     --set selfProtection.enabled=true
+   ```
+
+   **Operator (`KubeArmorConfig`):**
+   ```yaml
+   spec:
+     selfProtectionEnabled: true
+   ```
+
+3. **karmor CLI** (optional, for discovery): [kubearmor-client](https://github.com/kubearmor/kubearmor-client)
+
+## Two-phase workflow
+
+| Phase | Namespace posture | Policies | Enforcement |
+|-------|-------------------|----------|-------------|
+| **Audit (dry-run)** | `namespace-posture-audit.yaml` | `audit/` | Violations logged; pods stay `audited` or opt-in with audit posture |
+| **Block (zero-trust)** | `namespace-posture-block.yaml` | `block/` | Requires `selfProtection.enabled=true` |
+
+Audit-phase policies are **intentionally permissive** (`dir: /` recursive allow) so you can observe real behavior via `karmor log` before tightening.
+
+## Apply order
+
+### Phase 1 — Audit
+
+```bash
+kubectl apply -f namespace-posture-audit.yaml
+kubectl apply -f audit/
+karmor log --namespace kubearmor
+```
+
+Restart workloads and watch logs during normal operation:
+
+```bash
+kubectl -n kubearmor rollout restart ds/kubearmor
+kubectl -n kubearmor rollout restart deploy/kubearmor-relay
+kubectl -n kubearmor rollout restart deploy/kubearmor-controller
+```
+
+Refine block-phase allow-lists from observed telemetry before phase 2.
+
+### Phase 2 — Block
+
+```bash
+# Enable self-protection opt-in (requires PR1 merged)
+
+# If installed via direct Helm chart:
+helm upgrade --install kubearmor ../../deployments/helm/KubeArmor \
+  -n kubearmor --create-namespace \
+  --set selfProtection.enabled=true
+
+# If installed via operator (no Helm release named "kubearmor"):
+kubectl patch kubearmorconfig kubearmor-default -n kubearmor --type=merge \
+  -p '{"spec":{"selfProtectionEnabled":true}}'
+# Or edit KubeArmorConfig: spec.selfProtectionEnabled: true
+
+kubectl apply -f namespace-posture-block.yaml
+kubectl apply -f block/
+```
+
+Verify block enforcement:
+
+```bash
+POD=$(kubectl -n kubearmor get pod -l kubearmor-app=kubearmor -o name | head -1)
+kubectl -n kubearmor exec -it "$POD" -c kubearmor -- /bin/bash -c 'echo test' || echo "blocked as expected"
+karmor log --namespace kubearmor
+```
+
+Expect `Action: Block` (not `Audit (Block)`) when opt-in is active.
+
+## Policy layout
+
+This directory contains **13 YAML files**:
+
+| Count | Files |
+|-------|-------|
+| 2 | `namespace-posture-audit.yaml`, `namespace-posture-block.yaml` |
+| 5 | `audit/ksp-*.yaml` |
+| 6 | `block/ksp-*.yaml` (includes admin-tools block for daemon main) |
+
+**CRD note:** `matchDirectories[].dir` values must end with `/` (e.g. `/tmp/` not `/tmp`). Socket and single-file mounts use `file.matchPaths` instead.
+
+## Policy index
+
+| File | Target | Container filter |
+|------|--------|------------------|
+| `audit/ksp-kubearmor-daemon-main.yaml` | DaemonSet `kubearmor` | `[kubearmor]` |
+| `audit/ksp-kubearmor-daemon-init.yaml` | DaemonSet init | `[init]` |
+| `audit/ksp-kubearmor-relay.yaml` | Deployment `kubearmor-relay` | — |
+| `audit/ksp-kubearmor-controller.yaml` | Deployment `kubearmor-controller` | — |
+| `audit/ksp-kubearmor-operator.yaml` | Deployment `kubearmor-operator` | — |
+| `block/ksp-kubearmor-daemon-main.yaml` | Daemon main allow-list | `[kubearmor]` |
+| `block/ksp-kubearmor-daemon-init.yaml` | Init BPF compile allow-list | `[init]` |
+| `block/ksp-kubearmor-daemon-admin-tools.yaml` | Block curl/bash in main only | `[kubearmor]` |
+| `block/ksp-kubearmor-relay.yaml` | Relay allow-list | — |
+| `block/ksp-kubearmor-controller.yaml` | Controller allow-list | — |
+| `block/ksp-kubearmor-operator.yaml` | Operator allow-list | — |
+
+## Container selector syntax
+
+Use bracket syntax for per-container policies (KubeArmor policy convention, not a Kubernetes pod label):
+
+```yaml
+kubearmor.io/container.name: "[kubearmor]"
+kubearmor.io/container.name: "[init]"
+```
+
+Plain `kubearmor` without brackets is parsed incorrectly.
+
+## Environment notes
+
+- **Runtime sockets:** Block policies include common CRI paths (`containerd`, `docker`, `crio`). Trim unused paths for your environment.
+- **Network:** Block posture keeps `kubearmor-network-posture: audit` because the daemon uses `hostNetwork: true`.
+- **Capabilities:** Daemon block policy allows required capabilities before `kubearmor-capabilities-posture: block`.
+- **Out of scope:** `kubearmor-snitch` Job, BPF updater, kured — ephemeral or optional helpers.
+
+## Rollback
+
+```bash
+kubectl delete -f block/ --ignore-not-found
+kubectl delete -f audit/ --ignore-not-found
+kubectl annotate namespace kubearmor \
+  kubearmor-file-posture- \
+  kubearmor-network-posture- \
+  kubearmor-capabilities-posture- --overwrite
+
+helm upgrade kubearmor ../../deployments/helm/KubeArmor \
+  -n kubearmor --reuse-values --set selfProtection.enabled=false
+```
+
+## References
+
+- [Least permissive access / zero trust](../getting-started/least_permissive_access.md)
+- [Default posture](../getting-started/default_posture.md)
+- [Security policy examples](../getting-started/security_policy_examples.md)

--- a/examples/kubearmor-self-protection/audit/ksp-kubearmor-controller.yaml
+++ b/examples/kubearmor-self-protection/audit/ksp-kubearmor-controller.yaml
@@ -1,0 +1,25 @@
+apiVersion: security.kubearmor.com/v1
+kind: KubeArmorPolicy
+metadata:
+  name: ksp-kubearmor-controller-audit
+  namespace: kubearmor
+spec:
+  severity: 5
+  message: "KubeArmor controller self-protection (audit phase — intentionally permissive)"
+  tags:
+  - KubeArmor-SelfProtection
+  - ZeroTrust
+  - AuditPhase
+  selector:
+    matchLabels:
+      kubearmor-app: kubearmor-controller
+  file:
+    matchDirectories:
+    - dir: /
+      recursive: true
+      action: Allow
+  process:
+    matchPaths:
+    - path: /manager
+      action: Allow
+  action: Allow

--- a/examples/kubearmor-self-protection/audit/ksp-kubearmor-daemon-init.yaml
+++ b/examples/kubearmor-self-protection/audit/ksp-kubearmor-daemon-init.yaml
@@ -1,0 +1,26 @@
+apiVersion: security.kubearmor.com/v1
+kind: KubeArmorPolicy
+metadata:
+  name: ksp-kubearmor-daemon-init-audit
+  namespace: kubearmor
+spec:
+  severity: 5
+  message: "KubeArmor init self-protection (audit phase — intentionally permissive)"
+  tags:
+  - KubeArmor-SelfProtection
+  - ZeroTrust
+  - AuditPhase
+  selector:
+    matchLabels:
+      kubearmor-app: kubearmor
+      kubearmor.io/container.name: "[init]"
+  file:
+    matchDirectories:
+    - dir: /
+      recursive: true
+      action: Allow
+  process:
+    matchPaths:
+    - path: /KubeArmor/compile.sh
+      action: Allow
+  action: Allow

--- a/examples/kubearmor-self-protection/audit/ksp-kubearmor-daemon-main.yaml
+++ b/examples/kubearmor-self-protection/audit/ksp-kubearmor-daemon-main.yaml
@@ -1,0 +1,26 @@
+apiVersion: security.kubearmor.com/v1
+kind: KubeArmorPolicy
+metadata:
+  name: ksp-kubearmor-daemon-main-audit
+  namespace: kubearmor
+spec:
+  severity: 5
+  message: "KubeArmor daemon self-protection (audit phase — intentionally permissive)"
+  tags:
+  - KubeArmor-SelfProtection
+  - ZeroTrust
+  - AuditPhase
+  selector:
+    matchLabels:
+      kubearmor-app: kubearmor
+      kubearmor.io/container.name: "[kubearmor]"
+  file:
+    matchDirectories:
+    - dir: /
+      recursive: true
+      action: Allow
+  process:
+    matchPaths:
+    - path: /KubeArmor/kubearmor
+      action: Allow
+  action: Allow

--- a/examples/kubearmor-self-protection/audit/ksp-kubearmor-operator.yaml
+++ b/examples/kubearmor-self-protection/audit/ksp-kubearmor-operator.yaml
@@ -1,0 +1,25 @@
+apiVersion: security.kubearmor.com/v1
+kind: KubeArmorPolicy
+metadata:
+  name: ksp-kubearmor-operator-audit
+  namespace: kubearmor
+spec:
+  severity: 5
+  message: "KubeArmor operator self-protection (audit phase — intentionally permissive)"
+  tags:
+  - KubeArmor-SelfProtection
+  - ZeroTrust
+  - AuditPhase
+  selector:
+    matchLabels:
+      kubearmor-app: kubearmor-operator
+  file:
+    matchDirectories:
+    - dir: /
+      recursive: true
+      action: Allow
+  process:
+    matchPaths:
+    - path: /operator
+      action: Allow
+  action: Allow

--- a/examples/kubearmor-self-protection/audit/ksp-kubearmor-relay.yaml
+++ b/examples/kubearmor-self-protection/audit/ksp-kubearmor-relay.yaml
@@ -1,0 +1,21 @@
+apiVersion: security.kubearmor.com/v1
+kind: KubeArmorPolicy
+metadata:
+  name: ksp-kubearmor-relay-audit
+  namespace: kubearmor
+spec:
+  severity: 5
+  message: "KubeArmor relay self-protection (audit phase — intentionally permissive)"
+  tags:
+  - KubeArmor-SelfProtection
+  - ZeroTrust
+  - AuditPhase
+  selector:
+    matchLabels:
+      kubearmor-app: kubearmor-relay
+  file:
+    matchDirectories:
+    - dir: /
+      recursive: true
+      action: Allow
+  action: Allow

--- a/examples/kubearmor-self-protection/block/ksp-kubearmor-controller.yaml
+++ b/examples/kubearmor-self-protection/block/ksp-kubearmor-controller.yaml
@@ -1,0 +1,28 @@
+apiVersion: security.kubearmor.com/v1
+kind: KubeArmorPolicy
+metadata:
+  name: ksp-kubearmor-controller-block
+  namespace: kubearmor
+spec:
+  severity: 5
+  message: "KubeArmor controller zero-trust allow-list"
+  tags:
+  - KubeArmor-SelfProtection
+  - ZeroTrust
+  - BlockPhase
+  selector:
+    matchLabels:
+      kubearmor-app: kubearmor-controller
+  process:
+    matchPaths:
+    - path: /manager
+      action: Allow
+  file:
+    matchDirectories:
+    - dir: /tmp/k8s-webhook-server/serving-certs/
+      recursive: true
+      action: Allow
+    - dir: /sys/kernel/security/
+      recursive: true
+      action: Allow
+  action: Allow

--- a/examples/kubearmor-self-protection/block/ksp-kubearmor-daemon-admin-tools.yaml
+++ b/examples/kubearmor-self-protection/block/ksp-kubearmor-daemon-admin-tools.yaml
@@ -1,0 +1,23 @@
+apiVersion: security.kubearmor.com/v1
+kind: KubeArmorPolicy
+metadata:
+  name: ksp-kubearmor-daemon-admin-tools-block
+  namespace: kubearmor
+spec:
+  severity: 5
+  message: "Block common admin tools in KubeArmor daemon main container"
+  tags:
+  - KubeArmor-SelfProtection
+  - ZeroTrust
+  - BlockPhase
+  selector:
+    matchLabels:
+      kubearmor-app: kubearmor
+      kubearmor.io/container.name: "[kubearmor]"
+  process:
+    matchPaths:
+    - path: /usr/bin/curl
+    - path: /usr/bin/wget
+    - path: /bin/bash
+    - path: /usr/bin/bash
+  action: Block

--- a/examples/kubearmor-self-protection/block/ksp-kubearmor-daemon-init.yaml
+++ b/examples/kubearmor-self-protection/block/ksp-kubearmor-daemon-init.yaml
@@ -1,0 +1,85 @@
+apiVersion: security.kubearmor.com/v1
+kind: KubeArmorPolicy
+metadata:
+  name: ksp-kubearmor-daemon-init-block
+  namespace: kubearmor
+spec:
+  severity: 5
+  message: "KubeArmor init container zero-trust allow-list for BPF compilation"
+  tags:
+  - KubeArmor-SelfProtection
+  - ZeroTrust
+  - BlockPhase
+  selector:
+    matchLabels:
+      kubearmor-app: kubearmor
+      kubearmor.io/container.name: "[init]"
+  process:
+    matchPaths:
+    - path: /KubeArmor/compile.sh
+      action: Allow
+    matchDirectories:
+    - dir: /usr/bin/
+      recursive: true
+      action: Allow
+    - dir: /bin/
+      recursive: true
+      action: Allow
+  file:
+    matchPaths:
+    - path: /media/root/etc/os-release
+      action: Allow
+    - path: /var/run/containerd/containerd.sock
+      action: Allow
+    - path: /var/run/docker.sock
+      action: Allow
+    - path: /var/run/crio/crio.sock
+      action: Allow
+    matchDirectories:
+    - dir: /opt/kubearmor/BPF/
+      recursive: true
+      action: Allow
+    - dir: /lib/modules/
+      recursive: true
+      action: Allow
+    - dir: /sys/kernel/security/
+      recursive: true
+      action: Allow
+    - dir: /sys/kernel/debug/
+      recursive: true
+      action: Allow
+    - dir: /etc/apparmor.d/
+      recursive: true
+      action: Allow
+    - dir: /usr/src/
+      recursive: true
+      action: Allow
+    - dir: /var/run/containerd/
+      recursive: true
+      action: Allow
+    - dir: /var/run/crio/
+      recursive: true
+      action: Allow
+  capabilities:
+    matchCapabilities:
+    - capability: sys_admin
+      action: Allow
+    - capability: sys_ptrace
+      action: Allow
+    - capability: mac_admin
+      action: Allow
+    - capability: sys_resource
+      action: Allow
+    - capability: ipc_lock
+      action: Allow
+    - capability: dac_override
+      action: Allow
+    - capability: dac_read_search
+      action: Allow
+    - capability: setuid
+      action: Allow
+    - capability: setgid
+      action: Allow
+    - capability: setpcap
+      action: Allow
+  action: Allow

--- a/examples/kubearmor-self-protection/block/ksp-kubearmor-daemon-main.yaml
+++ b/examples/kubearmor-self-protection/block/ksp-kubearmor-daemon-main.yaml
@@ -1,0 +1,89 @@
+apiVersion: security.kubearmor.com/v1
+kind: KubeArmorPolicy
+metadata:
+  name: ksp-kubearmor-daemon-main-block
+  namespace: kubearmor
+spec:
+  severity: 5
+  message: "KubeArmor daemon main container zero-trust allow-list"
+  tags:
+  - KubeArmor-SelfProtection
+  - ZeroTrust
+  - BlockPhase
+  selector:
+    matchLabels:
+      kubearmor-app: kubearmor
+      kubearmor.io/container.name: "[kubearmor]"
+  process:
+    matchPaths:
+    - path: /KubeArmor/kubearmor
+      action: Allow
+  file:
+    matchPaths:
+    - path: /media/root/etc/os-release
+      action: Allow
+    - path: /var/run/containerd/containerd.sock
+      action: Allow
+    - path: /var/run/docker.sock
+      action: Allow
+    - path: /var/run/crio/crio.sock
+      action: Allow
+    matchDirectories:
+    - dir: /opt/kubearmor/BPF/
+      recursive: true
+      action: Allow
+    - dir: /lib/modules/
+      recursive: true
+      action: Allow
+    - dir: /sys/kernel/security/
+      recursive: true
+      action: Allow
+    - dir: /sys/kernel/debug/
+      recursive: true
+      action: Allow
+    - dir: /etc/apparmor.d/
+      recursive: true
+      action: Allow
+    - dir: /usr/src/
+      recursive: true
+      action: Allow
+    - dir: /var/run/containerd/
+      recursive: true
+      action: Allow
+    - dir: /var/run/crio/
+      recursive: true
+      action: Allow
+    - dir: /KubeArmor/templates/
+      recursive: true
+      action: Allow
+    - dir: /var/lib/kubearmor/tls/
+      recursive: true
+      action: Allow
+    - dir: /host/procfs/
+      recursive: true
+      action: Allow
+  capabilities:
+    matchCapabilities:
+    - capability: sys_admin
+      action: Allow
+    - capability: sys_ptrace
+      action: Allow
+    - capability: mac_admin
+      action: Allow
+    - capability: net_admin
+      action: Allow
+    - capability: sys_resource
+      action: Allow
+    - capability: ipc_lock
+      action: Allow
+    - capability: dac_override
+      action: Allow
+    - capability: dac_read_search
+      action: Allow
+    - capability: setuid
+      action: Allow
+    - capability: setgid
+      action: Allow
+    - capability: setpcap
+      action: Allow
+  action: Allow

--- a/examples/kubearmor-self-protection/block/ksp-kubearmor-operator.yaml
+++ b/examples/kubearmor-self-protection/block/ksp-kubearmor-operator.yaml
@@ -1,0 +1,25 @@
+apiVersion: security.kubearmor.com/v1
+kind: KubeArmorPolicy
+metadata:
+  name: ksp-kubearmor-operator-block
+  namespace: kubearmor
+spec:
+  severity: 5
+  message: "KubeArmor operator zero-trust allow-list"
+  tags:
+  - KubeArmor-SelfProtection
+  - ZeroTrust
+  - BlockPhase
+  selector:
+    matchLabels:
+      kubearmor-app: kubearmor-operator
+  process:
+    matchPaths:
+    - path: /operator
+      action: Allow
+  file:
+    matchDirectories:
+    - dir: /tmp/
+      recursive: true
+      action: Allow
+  action: Allow

--- a/examples/kubearmor-self-protection/block/ksp-kubearmor-relay.yaml
+++ b/examples/kubearmor-self-protection/block/ksp-kubearmor-relay.yaml
@@ -1,0 +1,24 @@
+apiVersion: security.kubearmor.com/v1
+kind: KubeArmorPolicy
+metadata:
+  name: ksp-kubearmor-relay-block
+  namespace: kubearmor
+spec:
+  severity: 5
+  message: "KubeArmor relay zero-trust allow-list"
+  tags:
+  - KubeArmor-SelfProtection
+  - ZeroTrust
+  - BlockPhase
+  selector:
+    matchLabels:
+      kubearmor-app: kubearmor-relay
+  file:
+    matchDirectories:
+    - dir: /var/lib/kubearmor/tls/
+      recursive: true
+      action: Allow
+    - dir: /tmp/
+      recursive: true
+      action: Allow
+  action: Allow

--- a/examples/kubearmor-self-protection/namespace-posture-audit.yaml
+++ b/examples/kubearmor-self-protection/namespace-posture-audit.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kubearmor
+  annotations:
+    kubearmor-file-posture: audit
+    kubearmor-network-posture: audit
+    kubearmor-capabilities-posture: audit

--- a/examples/kubearmor-self-protection/namespace-posture-block.yaml
+++ b/examples/kubearmor-self-protection/namespace-posture-block.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kubearmor
+  annotations:
+    kubearmor-file-posture: block
+    kubearmor-network-posture: audit
+    kubearmor-capabilities-posture: block

--- a/getting-started/hardening_guide.md
+++ b/getting-started/hardening_guide.md
@@ -10,6 +10,8 @@ Additionally, KubeArmor presents these hardening policies in the context of your
 
 Overall, KubeArmor is a powerful tool for securing your Kubernetes workloads, and its out-of-the-box hardening policies based on industry-leading compliance and attack frameworks make it easy to get started and ensure that your system is as secure as possible.
 
+For hardening **KubeArmor's own infrastructure pods**, see [self-protection policy examples](../examples/kubearmor-self-protection/README.md) (issue #2066).
+
 ## What is the source of these hardening policies?
 
 Hardening policies are derived from industry leading compliance standards and attack frameworks such as CIS, MITRE, NIST, STIGs, and several others.

--- a/getting-started/kubearmor-security-enhancements.md
+++ b/getting-started/kubearmor-security-enhancements.md
@@ -1,5 +1,11 @@
 # Security Enhancements for KubeArmor
 
+KubeArmor infrastructure can be hardened at multiple layers:
+
+1. **Seccomp** (syscall restriction) — below
+2. **TLS/mTLS** (gRPC communication) — below
+3. **Runtime self-protection policies** — [zero-trust KubeArmorPolicy examples](../examples/kubearmor-self-protection/README.md) for daemon, relay, controller, and operator (#2066). Requires self-protection opt-in via `selfProtection.enabled` (Helm) or `selfProtectionEnabled` (`KubeArmorConfig`).
+
 ## 1. Secure Kubearmor with Seccomp
 
 To further enhance the security of KubeArmor itself, it is crucial to protect it using seccomp (secure computing mode), a Linux kernel feature that restricts the system calls (syscalls) a process can make, thereby reducing the attack surface.

--- a/getting-started/security_policy_examples.md
+++ b/getting-started/security_policy_examples.md
@@ -435,3 +435,26 @@ Here, we demonstrate how to define security policies using our example microserv
 ```
 
 </details>
+
+## Self-protection policies for KubeArmor workloads
+
+KubeArmor can enforce zero-trust policies on its own infrastructure pods (daemon, relay, controller, operator). This requires the self-protection opt-in (`kubearmor.io/self-protection: enabled`) plus the example policies under [`examples/kubearmor-self-protection/`](../examples/kubearmor-self-protection/).
+
+**Apply audit phase (dry-run):**
+
+```bash
+kubectl apply -f examples/kubearmor-self-protection/namespace-posture-audit.yaml
+kubectl apply -f examples/kubearmor-self-protection/audit/
+karmor log --namespace kubearmor
+```
+
+**Apply block phase (after opt-in and log validation):**
+
+```bash
+helm upgrade kubearmor deployments/helm/KubeArmor -n kubearmor \
+  --reuse-values --set selfProtection.enabled=true
+kubectl apply -f examples/kubearmor-self-protection/namespace-posture-block.yaml
+kubectl apply -f examples/kubearmor-self-protection/block/
+```
+
+See the [self-protection README](../examples/kubearmor-self-protection/README.md) for the full two-phase workflow, container selector syntax, and rollback steps.

--- a/tests/k8s_env/kubearmor_self_protection/res/ksp-kubearmor-daemon-admin-tools-block.yaml
+++ b/tests/k8s_env/kubearmor_self_protection/res/ksp-kubearmor-daemon-admin-tools-block.yaml
@@ -1,0 +1,23 @@
+apiVersion: security.kubearmor.com/v1
+kind: KubeArmorPolicy
+metadata:
+  name: ksp-kubearmor-daemon-admin-tools-block
+  namespace: kubearmor
+spec:
+  severity: 5
+  message: "Block common admin tools in KubeArmor daemon main container"
+  tags:
+  - KubeArmor-SelfProtection
+  - ZeroTrust
+  - BlockPhase
+  selector:
+    matchLabels:
+      kubearmor-app: kubearmor
+      kubearmor.io/container.name: "[kubearmor]"
+  process:
+    matchPaths:
+    - path: /usr/bin/curl
+    - path: /usr/bin/wget
+    - path: /bin/bash
+    - path: /usr/bin/bash
+  action: Block

--- a/tests/k8s_env/kubearmor_self_protection/res/ksp-kubearmor-daemon-init-audit.yaml
+++ b/tests/k8s_env/kubearmor_self_protection/res/ksp-kubearmor-daemon-init-audit.yaml
@@ -1,0 +1,26 @@
+apiVersion: security.kubearmor.com/v1
+kind: KubeArmorPolicy
+metadata:
+  name: ksp-kubearmor-daemon-init-audit
+  namespace: kubearmor
+spec:
+  severity: 5
+  message: "KubeArmor init self-protection (audit phase — intentionally permissive)"
+  tags:
+  - KubeArmor-SelfProtection
+  - ZeroTrust
+  - AuditPhase
+  selector:
+    matchLabels:
+      kubearmor-app: kubearmor
+      kubearmor.io/container.name: "[init]"
+  file:
+    matchDirectories:
+    - dir: /
+      recursive: true
+      action: Allow
+  process:
+    matchPaths:
+    - path: /KubeArmor/compile.sh
+      action: Allow
+  action: Allow

--- a/tests/k8s_env/kubearmor_self_protection/res/ksp-kubearmor-daemon-init-block.yaml
+++ b/tests/k8s_env/kubearmor_self_protection/res/ksp-kubearmor-daemon-init-block.yaml
@@ -1,0 +1,85 @@
+apiVersion: security.kubearmor.com/v1
+kind: KubeArmorPolicy
+metadata:
+  name: ksp-kubearmor-daemon-init-block
+  namespace: kubearmor
+spec:
+  severity: 5
+  message: "KubeArmor init container zero-trust allow-list for BPF compilation"
+  tags:
+  - KubeArmor-SelfProtection
+  - ZeroTrust
+  - BlockPhase
+  selector:
+    matchLabels:
+      kubearmor-app: kubearmor
+      kubearmor.io/container.name: "[init]"
+  process:
+    matchPaths:
+    - path: /KubeArmor/compile.sh
+      action: Allow
+    matchDirectories:
+    - dir: /usr/bin/
+      recursive: true
+      action: Allow
+    - dir: /bin/
+      recursive: true
+      action: Allow
+  file:
+    matchPaths:
+    - path: /media/root/etc/os-release
+      action: Allow
+    - path: /var/run/containerd/containerd.sock
+      action: Allow
+    - path: /var/run/docker.sock
+      action: Allow
+    - path: /var/run/crio/crio.sock
+      action: Allow
+    matchDirectories:
+    - dir: /opt/kubearmor/BPF/
+      recursive: true
+      action: Allow
+    - dir: /lib/modules/
+      recursive: true
+      action: Allow
+    - dir: /sys/kernel/security/
+      recursive: true
+      action: Allow
+    - dir: /sys/kernel/debug/
+      recursive: true
+      action: Allow
+    - dir: /etc/apparmor.d/
+      recursive: true
+      action: Allow
+    - dir: /usr/src/
+      recursive: true
+      action: Allow
+    - dir: /var/run/containerd/
+      recursive: true
+      action: Allow
+    - dir: /var/run/crio/
+      recursive: true
+      action: Allow
+  capabilities:
+    matchCapabilities:
+    - capability: sys_admin
+      action: Allow
+    - capability: sys_ptrace
+      action: Allow
+    - capability: mac_admin
+      action: Allow
+    - capability: sys_resource
+      action: Allow
+    - capability: ipc_lock
+      action: Allow
+    - capability: dac_override
+      action: Allow
+    - capability: dac_read_search
+      action: Allow
+    - capability: setuid
+      action: Allow
+    - capability: setgid
+      action: Allow
+    - capability: setpcap
+      action: Allow
+  action: Allow

--- a/tests/k8s_env/kubearmor_self_protection/res/ksp-kubearmor-daemon-main-audit.yaml
+++ b/tests/k8s_env/kubearmor_self_protection/res/ksp-kubearmor-daemon-main-audit.yaml
@@ -1,0 +1,26 @@
+apiVersion: security.kubearmor.com/v1
+kind: KubeArmorPolicy
+metadata:
+  name: ksp-kubearmor-daemon-main-audit
+  namespace: kubearmor
+spec:
+  severity: 5
+  message: "KubeArmor daemon self-protection (audit phase — intentionally permissive)"
+  tags:
+  - KubeArmor-SelfProtection
+  - ZeroTrust
+  - AuditPhase
+  selector:
+    matchLabels:
+      kubearmor-app: kubearmor
+      kubearmor.io/container.name: "[kubearmor]"
+  file:
+    matchDirectories:
+    - dir: /
+      recursive: true
+      action: Allow
+  process:
+    matchPaths:
+    - path: /KubeArmor/kubearmor
+      action: Allow
+  action: Allow

--- a/tests/k8s_env/kubearmor_self_protection/res/ksp-kubearmor-daemon-main-block.yaml
+++ b/tests/k8s_env/kubearmor_self_protection/res/ksp-kubearmor-daemon-main-block.yaml
@@ -1,0 +1,89 @@
+apiVersion: security.kubearmor.com/v1
+kind: KubeArmorPolicy
+metadata:
+  name: ksp-kubearmor-daemon-main-block
+  namespace: kubearmor
+spec:
+  severity: 5
+  message: "KubeArmor daemon main container zero-trust allow-list"
+  tags:
+  - KubeArmor-SelfProtection
+  - ZeroTrust
+  - BlockPhase
+  selector:
+    matchLabels:
+      kubearmor-app: kubearmor
+      kubearmor.io/container.name: "[kubearmor]"
+  process:
+    matchPaths:
+    - path: /KubeArmor/kubearmor
+      action: Allow
+  file:
+    matchPaths:
+    - path: /media/root/etc/os-release
+      action: Allow
+    - path: /var/run/containerd/containerd.sock
+      action: Allow
+    - path: /var/run/docker.sock
+      action: Allow
+    - path: /var/run/crio/crio.sock
+      action: Allow
+    matchDirectories:
+    - dir: /opt/kubearmor/BPF/
+      recursive: true
+      action: Allow
+    - dir: /lib/modules/
+      recursive: true
+      action: Allow
+    - dir: /sys/kernel/security/
+      recursive: true
+      action: Allow
+    - dir: /sys/kernel/debug/
+      recursive: true
+      action: Allow
+    - dir: /etc/apparmor.d/
+      recursive: true
+      action: Allow
+    - dir: /usr/src/
+      recursive: true
+      action: Allow
+    - dir: /var/run/containerd/
+      recursive: true
+      action: Allow
+    - dir: /var/run/crio/
+      recursive: true
+      action: Allow
+    - dir: /KubeArmor/templates/
+      recursive: true
+      action: Allow
+    - dir: /var/lib/kubearmor/tls/
+      recursive: true
+      action: Allow
+    - dir: /host/procfs/
+      recursive: true
+      action: Allow
+  capabilities:
+    matchCapabilities:
+    - capability: sys_admin
+      action: Allow
+    - capability: sys_ptrace
+      action: Allow
+    - capability: mac_admin
+      action: Allow
+    - capability: net_admin
+      action: Allow
+    - capability: sys_resource
+      action: Allow
+    - capability: ipc_lock
+      action: Allow
+    - capability: dac_override
+      action: Allow
+    - capability: dac_read_search
+      action: Allow
+    - capability: setuid
+      action: Allow
+    - capability: setgid
+      action: Allow
+    - capability: setpcap
+      action: Allow
+  action: Allow

--- a/tests/k8s_env/kubearmor_self_protection/res/namespace-posture-audit.yaml
+++ b/tests/k8s_env/kubearmor_self_protection/res/namespace-posture-audit.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kubearmor
+  annotations:
+    kubearmor-file-posture: audit
+    kubearmor-network-posture: audit
+    kubearmor-capabilities-posture: audit

--- a/tests/k8s_env/kubearmor_self_protection/res/namespace-posture-block.yaml
+++ b/tests/k8s_env/kubearmor_self_protection/res/namespace-posture-block.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kubearmor
+  annotations:
+    kubearmor-file-posture: block
+    kubearmor-network-posture: audit
+    kubearmor-capabilities-posture: block

--- a/tests/k8s_env/kubearmor_self_protection/self_protection_suite_test.go
+++ b/tests/k8s_env/kubearmor_self_protection/self_protection_suite_test.go
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Authors of KubeArmor
+
+package kubearmor_self_protection_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestKubeArmorSelfProtection(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "KubeArmor Self-Protection Suite")
+}

--- a/tests/k8s_env/kubearmor_self_protection/self_protection_test.go
+++ b/tests/k8s_env/kubearmor_self_protection/self_protection_test.go
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Authors of KubeArmor
+
+package kubearmor_self_protection_test
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	. "github.com/kubearmor/KubeArmor/tests/util"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+const kubearmorNS = "kubearmor"
+
+var auditPolicyFiles = []string{
+	"res/namespace-posture-audit.yaml",
+	"res/ksp-kubearmor-daemon-main-audit.yaml",
+	"res/ksp-kubearmor-daemon-init-audit.yaml",
+}
+
+func kubearmorInstalled() bool {
+	out, err := Kubectl(fmt.Sprintf("get ns %s", kubearmorNS))
+	return err == nil && strings.Contains(out, kubearmorNS)
+}
+
+func kubearmorDaemonRunning() bool {
+	pods, err := K8sGetPods("kubearmor", kubearmorNS, []string{"kubearmor-app=kubearmor"}, 0)
+	return err == nil && len(pods) > 0
+}
+
+var _ = Describe("KubeArmor self-protection policies", func() {
+
+	BeforeEach(func() {
+		if !kubearmorInstalled() {
+			Skip("kubearmor namespace not found — install KubeArmor before running this suite")
+		}
+	})
+
+	AfterEach(func() {
+		for i := len(auditPolicyFiles) - 1; i >= 0; i-- {
+			_, _ = Kubectl(fmt.Sprintf("delete -f %s --ignore-not-found", auditPolicyFiles[i]))
+		}
+	})
+
+	It("applies audit-phase policy manifests successfully", func() {
+		for _, f := range auditPolicyFiles {
+			err := K8sApplyFile(f)
+			Expect(err).To(BeNil())
+		}
+	})
+
+	It("keeps kubearmor daemon pods healthy after audit policies are applied", func() {
+		if !kubearmorDaemonRunning() {
+			Skip("no KubeArmor daemon pods in namespace kubearmor — deploy KubeArmor before running pod health checks")
+		}
+
+		for _, f := range auditPolicyFiles {
+			err := K8sApplyFile(f)
+			Expect(err).To(BeNil())
+		}
+
+		time.Sleep(30 * time.Second)
+
+		pods, err := K8sGetPods("kubearmor", kubearmorNS, []string{"kubearmor-app=kubearmor"}, 120)
+		Expect(err).To(BeNil())
+		Expect(len(pods)).To(BeNumerically(">", 0))
+	})
+
+	It("applies block policies when KUBEARMOR_SELF_PROTECTION_BLOCK_TEST=1", func() {
+		if os.Getenv("KUBEARMOR_SELF_PROTECTION_BLOCK_TEST") != "1" {
+			Skip("set KUBEARMOR_SELF_PROTECTION_BLOCK_TEST=1 with PR1 merged and selfProtection.enabled=true")
+		}
+		if !kubearmorDaemonRunning() {
+			Skip("no KubeArmor daemon pods in namespace kubearmor — deploy KubeArmor before running block enforcement checks")
+		}
+
+		blockFiles := []string{
+			"res/namespace-posture-block.yaml",
+			"res/ksp-kubearmor-daemon-main-block.yaml",
+			"res/ksp-kubearmor-daemon-init-block.yaml",
+			"res/ksp-kubearmor-daemon-admin-tools-block.yaml",
+		}
+
+		for _, f := range blockFiles {
+			err := K8sApplyFile(f)
+			Expect(err).To(BeNil())
+		}
+
+		time.Sleep(30 * time.Second)
+
+		pods, err := K8sGetPods("kubearmor", kubearmorNS, []string{"kubearmor-app=kubearmor"}, 120)
+		Expect(err).To(BeNil())
+		Expect(len(pods)).To(BeNumerically(">", 0))
+
+		for _, f := range blockFiles {
+			_, _ = Kubectl(fmt.Sprintf("delete -f %s --ignore-not-found", f))
+		}
+	})
+})


### PR DESCRIPTION
Ship audit and block `KubeArmorPolicy` manifests for KubeArmor daemon, relay, controller, and operator with namespace posture manifests, documentation, and k8s smoke tests. Requires PR1 self-protection opt-in for block enforcement. Closes #2066.

**Purpose of PR?**:

Adds zero-trust self-protection policies for KubeArmor's own infrastructure workloads (daemon, relay, controller, operator) as described in #2066. Delivers a two-phase rollout — audit (observe) then block (enforce) — with namespace posture manifests, example policies, docs, and a Ginkgo smoke suite.

Fixes #2066

**Does this PR introduce a breaking change?**

No. Policies are opt-in examples under `examples/kubearmor-self-protection/`. Block enforcement only takes effect when operators explicitly enable self-protection (`selfProtection.enabled` / `selfProtectionEnabled`) **and** apply block-phase policies after PR1 is merged.

**If the changes in this PR are manually verified, list down the scenarios covered:**

### Static checks (Screenshot 1)

<img width="1471" height="916" alt="Screenshot From 2026-06-24 22-18-38" src="https://github.com/user-attachments/assets/df42b09e-ec15-4753-8ce9-936b5f7368e6" />


- Smoke test package compiles (`go test -c ./k8s_env/kubearmor_self_protection/`)
- All 5 audit policies pass `kubectl apply --dry-run=client`
- All 6 block policies pass `kubectl apply --dry-run=client`
- 13 YAML manifests present under `examples/kubearmor-self-protection/` (2 namespace posture + 5 audit + 6 block)

### Cluster smoke suite (Screenshot 2)
<img width="1908" height="972" alt="Screenshot From 2026-06-24 22-25-47" src="https://github.com/user-attachments/assets/62dc0ae7-bf9d-476b-b861-3979ef38b73e" />

With KubeArmor installed via operator (`helm upgrade --install kubearmor-operator` + `sample-config.yml`):

```bash
cd tests && go run github.com/onsi/ginkgo/v2/ginkgo -v ./k8s_env/kubearmor_self_protection/

