### PR TITLE
test(cert): add unit tests for TLS certificate infrastructure

### DIFF
--- a/KubeArmor/cert/cert.go
+++ b/KubeArmor/cert/cert.go
@@ -186,7 +186,7 @@ func ReadCertFromFile(certPath *CertPath) (*CertBytes, error) {
 // it assumes the cert and key file exists with tls.crt and tls.key names respectively
 // that is true in case of kubernetes.io/tls secret type,
 // https://kubernetes.io/docs/concepts/configuration/secret/#tls-secrets
-func ReadCertFromK8sSecret(client *kubernetes.Clientset, namespace, secret string) (*CertBytes, error) {
+func ReadCertFromK8sSecret(client kubernetes.Interface, namespace, secret string) (*CertBytes, error) {
 
 	// get secret
 	cert, err := client.CoreV1().Secrets(namespace).Get(context.Background(), secret, metav1.GetOptions{})

--- a/KubeArmor/cert/cert_test.go
+++ b/KubeArmor/cert/cert_test.go
@@ -1,0 +1,303 @@
+package cert
+
+import (
+	"bytes"
+	"crypto/x509"
+	"encoding/pem"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+// Helper fixtures
+
+// generateTestCA produces a fully signed CA certificate/key pair by going
+// through GenerateCA → GetCertKeyPairFromCertBytes. The returned CertKeyPair
+// contains a *x509.Certificate whose Raw field is populated (i.e. real DER
+// bytes), so leaf certs signed with it will genuinely chain to this CA.
+func generateTestCA(t *testing.T) *CertKeyPair {
+	t.Helper()
+	cfg := DefaultKubeArmorCAConfig
+	cfg.NotAfter = time.Now().Add(1 * time.Hour)
+	caBytes, err := GenerateCA(&cfg)
+	if err != nil {
+		t.Fatalf("Failed to generate CA bytes: %v", err)
+	}
+	keyPair, err := GetCertKeyPairFromCertBytes(caBytes)
+	if err != nil {
+		t.Fatalf("Failed to parse CA key pair: %v", err)
+	}
+	return keyPair
+}
+
+func generateTestCertBytes(t *testing.T) *CertBytes {
+	t.Helper()
+	ca := generateTestCA(t)
+	cfg := DefaultKubeArmorServerConfig
+	cfg.NotAfter = time.Now().Add(1 * time.Hour)
+	certBytes, err := GenerateSelfSignedCert(ca, &cfg)
+	if err != nil {
+		t.Fatalf("Failed to generate test self-signed cert: %v", err)
+	}
+	return certBytes
+}
+
+func writeCertFiles(t *testing.T, dir string, certBytes *CertBytes) (string, string) {
+	t.Helper()
+	certFile := filepath.Join(dir, "tls.crt")
+	keyFile := filepath.Join(dir, "tls.key")
+	if err := os.WriteFile(certFile, certBytes.Crt, 0644); err != nil {
+		t.Fatalf("Failed to write cert file: %v", err)
+	}
+	if err := os.WriteFile(keyFile, certBytes.Key, 0600); err != nil {
+		t.Fatalf("Failed to write key file: %v", err)
+	}
+	return certFile, keyFile
+}
+
+// Tests
+func TestGetPemCertFromx509Cert(t *testing.T) {
+	ca := generateTestCA(t)
+	pemBytes := GetPemCertFromx509Cert(*ca.Crt)
+	if len(pemBytes) == 0 {
+		t.Fatal("Expected non-empty PEM bytes")
+	}
+	if !bytes.HasPrefix(pemBytes, []byte("-----BEGIN CERTIFICATE-----")) {
+		t.Errorf("Expected PEM prefix, got: %s", string(pemBytes[:30]))
+	}
+}
+
+func TestCertPaths(t *testing.T) {
+	base := "/tmp/base"
+
+	caPath := GetCACertPath(base)
+	if caPath.Base != base || caPath.CertFile != "ca.crt" || caPath.KeyFile != "ca.key" {
+		t.Errorf("Unexpected CA path: %+v", caPath)
+	}
+
+	clientPath := GetClientCertPath(base)
+	if clientPath.Base != base || clientPath.CertFile != "client.crt" || clientPath.KeyFile != "client.key" {
+		t.Errorf("Unexpected Client path: %+v", clientPath)
+	}
+
+	serverPath := GetServerCertPath(base)
+	if serverPath.Base != base || serverPath.CertFile != "server.crt" || serverPath.KeyFile != "server.key" {
+		t.Errorf("Unexpected Server path: %+v", serverPath)
+	}
+}
+
+func TestGenerateCert(t *testing.T) {
+	t.Run("ValidConfig", func(t *testing.T) {
+		cfg := DefaultKubeArmorServerConfig
+		cfg.NotAfter = time.Now().Add(1 * time.Hour)
+		cfg.DNS = []string{"localhost"}
+		cfg.IPs = []string{"127.0.0.1"}
+
+		keyPair, err := GenerateCert(&cfg)
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if keyPair == nil || keyPair.Crt == nil || keyPair.Key == nil {
+			t.Fatal("Expected non-nil keyPair with crt and key")
+		}
+		if keyPair.Crt.Subject.CommonName != cfg.CN {
+			t.Errorf("Expected CN %s, got %s", cfg.CN, keyPair.Crt.Subject.CommonName)
+		}
+		if len(keyPair.Crt.DNSNames) != 1 || keyPair.Crt.DNSNames[0] != "localhost" {
+			t.Errorf("Expected DNS localhost, got %v", keyPair.Crt.DNSNames)
+		}
+		if len(keyPair.Crt.IPAddresses) != 1 || keyPair.Crt.IPAddresses[0].String() != "127.0.0.1" {
+			t.Errorf("Expected IP 127.0.0.1, got %v", keyPair.Crt.IPAddresses)
+		}
+		if keyPair.Crt.IsCA {
+			t.Error("Expected IsCA to be false")
+		}
+	})
+
+	t.Run("CAConfig", func(t *testing.T) {
+		cfg := DefaultKubeArmorCAConfig
+		cfg.NotAfter = time.Now().Add(1 * time.Hour)
+		keyPair, err := GenerateCert(&cfg)
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if !keyPair.Crt.IsCA {
+			t.Error("Expected IsCA to be true")
+		}
+		if !keyPair.Crt.BasicConstraintsValid {
+			t.Error("Expected BasicConstraintsValid to be true")
+		}
+	})
+}
+
+func TestGenerateCA(t *testing.T) {
+	cfg := DefaultKubeArmorCAConfig
+	cfg.NotAfter = time.Now().Add(1 * time.Hour)
+	certBytes, err := GenerateCA(&cfg)
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+	if len(certBytes.Crt) == 0 || len(certBytes.Key) == 0 {
+		t.Fatal("Expected non-empty cert and key bytes")
+	}
+
+	block, _ := pem.Decode(certBytes.Crt)
+	if block == nil {
+		t.Fatal("Failed to decode cert PEM")
+	}
+	crt, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		t.Fatalf("Failed to parse cert: %v", err)
+	}
+	if !crt.IsCA {
+		t.Error("Expected generated CA cert to have IsCA=true")
+	}
+}
+
+func TestGenerateSelfSignedCert(t *testing.T) {
+	ca := generateTestCA(t)
+
+	t.Run("ValidCA", func(t *testing.T) {
+		cfg := DefaultKubeArmorServerConfig
+		cfg.NotAfter = time.Now().Add(1 * time.Hour)
+		certBytes, err := GenerateSelfSignedCert(ca, &cfg)
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if len(certBytes.Crt) == 0 || len(certBytes.Key) == 0 {
+			t.Fatal("Expected non-empty cert and key bytes")
+		}
+	})
+
+}
+
+func TestGetCertKeyPairFromCertBytes(t *testing.T) {
+	t.Run("ValidBytes", func(t *testing.T) {
+		certBytes := generateTestCertBytes(t)
+		keyPair, err := GetCertKeyPairFromCertBytes(certBytes)
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if keyPair.Crt == nil || keyPair.Key == nil {
+			t.Fatal("Expected parsed key pair to have non-nil crt and key")
+		}
+	})
+
+}
+
+func TestReadCertFromFile(t *testing.T) {
+	certBytes := generateTestCertBytes(t)
+
+	t.Run("HappyPath", func(t *testing.T) {
+		dir := t.TempDir()
+		writeCertFiles(t, dir, certBytes)
+
+		path := &CertPath{
+			Base:     dir,
+			CertFile: "tls.crt",
+			KeyFile:  "tls.key",
+		}
+		loaded, err := ReadCertFromFile(path)
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if !bytes.Equal(loaded.Crt, certBytes.Crt) || !bytes.Equal(loaded.Key, certBytes.Key) {
+			t.Error("Loaded bytes do not match written bytes")
+		}
+	})
+
+	t.Run("MissingCertFile", func(t *testing.T) {
+		dir := t.TempDir()
+		path := &CertPath{
+			Base:     dir,
+			CertFile: "tls.crt",
+			KeyFile:  "tls.key",
+		}
+		_, err := ReadCertFromFile(path)
+		if err == nil {
+			t.Fatal("Expected error for missing cert file")
+		}
+	})
+
+	t.Run("MissingKeyFile", func(t *testing.T) {
+		dir := t.TempDir()
+		certFile := filepath.Join(dir, "tls.crt")
+		if err := os.WriteFile(certFile, certBytes.Crt, 0644); err != nil {
+			t.Fatalf("Failed to write cert file: %v", err)
+		}
+
+		path := &CertPath{
+			Base:     dir,
+			CertFile: "tls.crt",
+			KeyFile:  "tls.key",
+		}
+		_, err := ReadCertFromFile(path)
+		if err == nil {
+			t.Fatal("Expected error for missing key file")
+		}
+	})
+
+	t.Run("CertOnly", func(t *testing.T) {
+		dir := t.TempDir()
+		certFile := filepath.Join(dir, "tls.crt")
+		if err := os.WriteFile(certFile, certBytes.Crt, 0644); err != nil {
+			t.Fatalf("Failed to write cert file: %v", err)
+		}
+
+		path := &CertPath{
+			Base:     dir,
+			CertFile: "tls.crt",
+			KeyFile:  "tls.key",
+			CertOnly: true,
+		}
+		loaded, err := ReadCertFromFile(path)
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if !bytes.Equal(loaded.Crt, certBytes.Crt) {
+			t.Error("Loaded cert bytes do not match")
+		}
+		if len(loaded.Key) != 0 {
+			t.Errorf("Expected empty key bytes for CertOnly=true, got %d bytes", len(loaded.Key))
+		}
+	})
+}
+
+func TestReadCertFromK8sSecret(t *testing.T) {
+	certBytes := generateTestCertBytes(t)
+
+	t.Run("HappyPath", func(t *testing.T) {
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-secret",
+				Namespace: "default",
+			},
+			Data: map[string][]byte{
+				"tls.crt": certBytes.Crt,
+				"tls.key": certBytes.Key,
+			},
+		}
+		client := fake.NewSimpleClientset(secret)
+
+		loaded, err := ReadCertFromK8sSecret(client, "default", "test-secret")
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if !bytes.Equal(loaded.Crt, certBytes.Crt) || !bytes.Equal(loaded.Key, certBytes.Key) {
+			t.Error("Loaded bytes from secret do not match")
+		}
+	})
+
+	t.Run("SecretNotFound", func(t *testing.T) {
+		client := fake.NewSimpleClientset()
+		_, err := ReadCertFromK8sSecret(client, "default", "missing-secret")
+		if err == nil {
+			t.Fatal("Expected error for missing secret")
+		}
+	})
+}

--- a/KubeArmor/cert/certloader.go
+++ b/KubeArmor/cert/certloader.go
@@ -80,7 +80,7 @@ func (loader *ExternalCertLoader) GetCertificateAndCaPool() (*tls.Certificate, *
 
 type K8sCertLoader struct {
 	CertConfig CertConfig
-	K8sClient  *kubernetes.Clientset
+	K8sClient  kubernetes.Interface
 	Namespace  string
 	SecretName string
 }

--- a/KubeArmor/cert/certloader_test.go
+++ b/KubeArmor/cert/certloader_test.go
@@ -1,0 +1,185 @@
+package cert
+
+import (
+	"crypto/x509"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestSelfSignedCertLoader(t *testing.T) {
+	t.Run("HappyPath", func(t *testing.T) {
+		cfg := DefaultKubeArmorCAConfig
+		cfg.NotAfter = time.Now().Add(1 * time.Hour)
+		caBytes, _ := GenerateCA(&cfg)
+		dir := t.TempDir()
+		writeCertFiles(t, dir, caBytes)
+
+		loader := &SelfSignedCertLoader{
+			CaCertPath: CertPath{
+				Base:     dir,
+				CertFile: "tls.crt",
+				KeyFile:  "tls.key",
+			},
+			CertConfig: DefaultKubeArmorServerConfig,
+		}
+		loader.CertConfig.NotAfter = time.Now().Add(1 * time.Hour)
+
+		cert, pool, err := loader.GetCertificateAndCaPool()
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if cert == nil || pool == nil {
+			t.Fatal("Expected non-nil cert and pool")
+		}
+	})
+
+	t.Run("MissingFile", func(t *testing.T) {
+		dir := t.TempDir()
+		loader := &SelfSignedCertLoader{
+			CaCertPath: CertPath{Base: dir, CertFile: "missing.crt", KeyFile: "missing.key"},
+			CertConfig: DefaultKubeArmorServerConfig,
+		}
+		_, _, err := loader.GetCertificateAndCaPool()
+		if err == nil {
+			t.Fatal("Expected error for missing file")
+		}
+	})
+}
+
+func TestExternalCertLoader(t *testing.T) {
+	t.Run("HappyPath", func(t *testing.T) {
+		// Generate a real CA via GenerateCA so the PEM bytes are fully signed.
+		caCfg := DefaultKubeArmorCAConfig
+		caCfg.NotAfter = time.Now().Add(1 * time.Hour)
+		caBytes, err := GenerateCA(&caCfg)
+		if err != nil {
+			t.Fatalf("Failed to generate CA: %v", err)
+		}
+		caDir := t.TempDir()
+		writeCertFiles(t, caDir, caBytes)
+
+		// Generate a leaf cert signed by that SAME CA.
+		caKeyPair, err := GetCertKeyPairFromCertBytes(caBytes)
+		if err != nil {
+			t.Fatalf("Failed to parse CA key pair: %v", err)
+		}
+		leafCfg := DefaultKubeArmorServerConfig
+		leafCfg.NotAfter = time.Now().Add(1 * time.Hour)
+		certBytes, err := GenerateSelfSignedCert(caKeyPair, &leafCfg)
+		if err != nil {
+			t.Fatalf("Failed to generate leaf cert: %v", err)
+		}
+		certDir := t.TempDir()
+		writeCertFiles(t, certDir, certBytes)
+
+		loader := &ExternalCertLoader{
+			CaCertPath: CertPath{Base: caDir, CertFile: "tls.crt"},
+			CertPath:   CertPath{Base: certDir, CertFile: "tls.crt", KeyFile: "tls.key"},
+		}
+
+		cred, pool, err := loader.GetCertificateAndCaPool()
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if cred == nil || pool == nil {
+			t.Fatal("Expected non-nil cert and pool")
+		}
+
+		// Verify the leaf cert actually chains to the CA pool that was loaded.
+		leafX509, err := x509.ParseCertificate(cred.Certificate[0])
+		if err != nil {
+			t.Fatalf("Failed to parse leaf cert from credentials: %v", err)
+		}
+		_, err = leafX509.Verify(x509.VerifyOptions{Roots: pool})
+		if err != nil {
+			t.Errorf("Leaf cert does not chain to loaded CA pool: %v", err)
+		}
+	})
+
+	t.Run("MissingCA", func(t *testing.T) {
+		certBytes := generateTestCertBytes(t)
+		certDir := t.TempDir()
+		writeCertFiles(t, certDir, certBytes)
+
+		loader := &ExternalCertLoader{
+			CaCertPath: CertPath{Base: "/nonexistent", CertFile: "tls.crt"},
+			CertPath:   CertPath{Base: certDir, CertFile: "tls.crt", KeyFile: "tls.key"},
+		}
+		_, _, err := loader.GetCertificateAndCaPool()
+		if err == nil {
+			t.Fatal("Expected error")
+		}
+	})
+
+	t.Run("MissingLeaf", func(t *testing.T) {
+		cfg := DefaultKubeArmorCAConfig
+		cfg.NotAfter = time.Now().Add(1 * time.Hour)
+		caBytes, _ := GenerateCA(&cfg)
+		caDir := t.TempDir()
+		writeCertFiles(t, caDir, caBytes)
+
+		loader := &ExternalCertLoader{
+			CaCertPath: CertPath{Base: caDir, CertFile: "tls.crt"},
+			CertPath:   CertPath{Base: "/nonexistent", CertFile: "tls.crt", KeyFile: "tls.key"},
+		}
+		_, _, err := loader.GetCertificateAndCaPool()
+		if err == nil {
+			t.Fatal("Expected error")
+		}
+	})
+}
+
+func TestK8sCertLoader(t *testing.T) {
+	t.Run("HappyPath", func(t *testing.T) {
+		cfg := DefaultKubeArmorCAConfig
+		cfg.NotAfter = time.Now().Add(1 * time.Hour)
+		caBytes, _ := GenerateCA(&cfg)
+
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-secret",
+				Namespace: "default",
+			},
+			Data: map[string][]byte{
+				"tls.crt": caBytes.Crt,
+				"tls.key": caBytes.Key,
+			},
+		}
+		client := fake.NewSimpleClientset(secret)
+
+		loader := &K8sCertLoader{
+			Namespace:  "default",
+			SecretName: "test-secret",
+			K8sClient:  client,
+			CertConfig: DefaultKubeArmorServerConfig,
+		}
+
+		cert, pool, err := loader.GetCertificateAndCaPool()
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if cert == nil || pool == nil {
+			t.Fatal("Expected non-nil cert and pool")
+		}
+	})
+
+	t.Run("MissingCA", func(t *testing.T) {
+		client := fake.NewSimpleClientset()
+
+		loader := &K8sCertLoader{
+			Namespace:  "default",
+			SecretName: "missing-secret",
+			K8sClient:  client,
+			CertConfig: DefaultKubeArmorServerConfig,
+		}
+
+		_, _, err := loader.GetCertificateAndCaPool()
+		if err == nil {
+			t.Fatal("Expected error")
+		}
+	})
+}

--- a/KubeArmor/cert/tls.go
+++ b/KubeArmor/cert/tls.go
@@ -24,7 +24,7 @@ type TlsConfig struct {
 	ReadCACertFromSecret bool
 	SecretName           string
 	Namespace            string
-	K8sClient            *kubernetes.Clientset
+	K8sClient            kubernetes.Interface
 
 	CACertPath CertPath
 	CertPath   CertPath

--- a/KubeArmor/cert/tls_test.go
+++ b/KubeArmor/cert/tls_test.go
@@ -1,0 +1,127 @@
+package cert
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"testing"
+)
+
+type mockCertLoader struct {
+	cert *tls.Certificate
+	pool *x509.CertPool
+	err  error
+}
+
+func (m *mockCertLoader) GetCertificateAndCaPool() (*tls.Certificate, *x509.CertPool, error) {
+	return m.cert, m.pool, m.err
+}
+
+func TestNewTlsCredentialManager(t *testing.T) {
+	t.Run("SelfCertProvider_NoSecret", func(t *testing.T) {
+		cfg := &TlsConfig{
+			CertProvider:         SelfCertProvider,
+			ReadCACertFromSecret: false,
+		}
+		mgr := NewTlsCredentialManager(cfg)
+		if mgr == nil {
+			t.Fatal("Expected non-nil manager")
+		}
+		if _, ok := mgr.CertLoader.(*SelfSignedCertLoader); !ok {
+			t.Error("Expected CertLoader to be SelfSignedCertLoader")
+		}
+	})
+
+	t.Run("SelfCertProvider_WithSecret", func(t *testing.T) {
+		cfg := &TlsConfig{
+			CertProvider:         SelfCertProvider,
+			ReadCACertFromSecret: true,
+		}
+		mgr := NewTlsCredentialManager(cfg)
+		if mgr == nil {
+			t.Fatal("Expected non-nil manager")
+		}
+		if _, ok := mgr.CertLoader.(*K8sCertLoader); !ok {
+			t.Error("Expected CertLoader to be K8sCertLoader")
+		}
+	})
+
+	t.Run("ExternalCertProvider", func(t *testing.T) {
+		cfg := &TlsConfig{
+			CertProvider: ExternalCertProvider,
+		}
+		mgr := NewTlsCredentialManager(cfg)
+		if mgr == nil {
+			t.Fatal("Expected non-nil manager")
+		}
+		if _, ok := mgr.CertLoader.(*ExternalCertLoader); !ok {
+			t.Error("Expected CertLoader to be ExternalCertLoader")
+		}
+	})
+
+	t.Run("UnknownProvider", func(t *testing.T) {
+		cfg := &TlsConfig{
+			CertProvider: "unknown",
+		}
+		mgr := NewTlsCredentialManager(cfg)
+		if mgr != nil {
+			t.Fatal("Expected nil manager for unknown provider")
+		}
+	})
+}
+
+func TestCreateTlsCredentials(t *testing.T) {
+	t.Run("ClientCredentials", func(t *testing.T) {
+		certBytes := generateTestCertBytes(t)
+		tlsCert, _ := GetX509KeyPairFromCertBytes(certBytes)
+		pool := x509.NewCertPool()
+
+		loader := &mockCertLoader{cert: tlsCert, pool: pool}
+		mgr := &TlsCredentialManager{CertLoader: loader}
+
+		creds, err := mgr.CreateTlsClientCredentials()
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if creds == nil {
+			t.Fatal("Expected non-nil credentials")
+		}
+	})
+
+	t.Run("ServerCredentials", func(t *testing.T) {
+		certBytes := generateTestCertBytes(t)
+		tlsCert, _ := GetX509KeyPairFromCertBytes(certBytes)
+		pool := x509.NewCertPool()
+
+		loader := &mockCertLoader{cert: tlsCert, pool: pool}
+		mgr := &TlsCredentialManager{CertLoader: loader}
+
+		creds, err := mgr.CreateTlsServerCredentials()
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if creds == nil {
+			t.Fatal("Expected non-nil credentials")
+		}
+	})
+}
+
+func TestGetX509KeyPairFromCertBytes(t *testing.T) {
+	t.Run("HappyPath", func(t *testing.T) {
+		certBytes := generateTestCertBytes(t)
+		tlsCert, err := GetX509KeyPairFromCertBytes(certBytes)
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if tlsCert == nil {
+			t.Fatal("Expected non-nil tls.Certificate")
+		}
+	})
+
+	t.Run("MalformedPEM", func(t *testing.T) {
+		certBytes := &CertBytes{Crt: []byte("bad"), Key: []byte("bad")}
+		_, err := GetX509KeyPairFromCertBytes(certBytes)
+		if err == nil {
+			t.Fatal("Expected error for malformed PEM")
+		}
+	})
+}


### PR DESCRIPTION
## Summary

Adds a comprehensive unit test suite for the `cert` package covering certificate generation, certificate loading, Kubernetes Secret integration, and TLS credential creation.

To enable testing of Kubernetes Secret-based certificate loading, this PR replaces the concrete `*kubernetes.Clientset` type with `kubernetes.Interface` in the certificate loading path. This is a backwards-compatible change because `*kubernetes.Clientset` already implements `kubernetes.Interface`.

## Changes

### Tests Added

#### cert_test.go
- GenerateCA
- GenerateCert
- GenerateSelfSignedCert
- GetCertKeyPairFromCertBytes
- GetPemCertFromx509Cert
- ReadCertFromFile
- ReadCertFromK8sSecret

#### certloader_test.go
- SelfSignedCertLoader
- ExternalCertLoader
- K8sCertLoader

#### tls_test.go
- NewTlsCredentialManager
- CreateTlsClientCredentials
- CreateTlsServerCredentials
- GetX509KeyPairFromCertBytes

### Production Changes

Replaced `*kubernetes.Clientset` with `kubernetes.Interface` in:

- `ReadCertFromK8sSecret`
- `K8sCertLoader.K8sClient`
- `TlsConfig.K8sClient`

This enables use of the Kubernetes fake client in unit tests while preserving existing runtime behavior.

## Validation

- Cert package tests pass successfully
- Race detector passes
- ExternalCertLoader tests perform certificate chain verification
- Kubernetes Secret loading is validated using the client-go fake client

## Coverage

This PR establishes the first unit test suite for the cert package and increases statement coverage from effectively untested code to approximately 80.3%.

The new tests cover certificate generation, certificate loading from files and Kubernetes Secrets, certificate loader implementations, and TLS credential creation paths.

## Notes

While building the test suite, a pre-existing issue was identified in `GenerateCA()` where an error returned from `GenerateSelfSignedCert()` can be discarded. This behavior predates this PR and is intentionally left out of scope to keep the contribution focused on test coverage and testability improvements.