### PR TITLE
fix(USB): increase socket buffer and handle panic

### DIFF
--- a/KubeArmor/usbDeviceHandler/usbDeviceHandler.go
+++ b/KubeArmor/usbDeviceHandler/usbDeviceHandler.go
@@ -85,6 +85,11 @@ func (de *USBDeviceHandler) monitorUSBDeviceEvents() {
 	}
 	defer unix.Close(sock)
 
+	// increase socket buffer size to 8MB to handle bursts of uevents
+	if err := unix.SetsockoptInt(sock, unix.SOL_SOCKET, unix.SO_RCVBUF, 8*1024*1024); err != nil {
+		de.Logger.Warnf("Failed to increase socket receive buffer: %v", err)
+	}
+
 	// Bind to the socket to receive all uevents (pid = 0, groups = 1)
 	sa := &unix.SockaddrNetlink{
 		Family: unix.AF_NETLINK,
@@ -100,7 +105,12 @@ func (de *USBDeviceHandler) monitorUSBDeviceEvents() {
 	for {
 		nr, _, err := unix.Recvfrom(sock, buf, 0)
 		if err != nil {
-			de.Logger.Errf("Error receiving message: %v", err)
+			if err == unix.ENOBUFS {
+				de.Logger.Warnf("Dropped USB event: Netlink socket buffer full")
+			} else {
+				de.Logger.Errf("Error receiving message: %v", err)
+			}
+			continue
 		}
 
 		msg := buf[:nr]


### PR DESCRIPTION
**Purpose of PR?**:
This PR fixes a hard crash (`slice bounds out of range [:-1]`) in the USBDeviceHandler that occurs when the kernel's Netlink event queue overflows.
<img width="1097" height="314" alt="image" src="https://github.com/user-attachments/assets/96ec5c26-7a39-4034-97a4-2e9ef61a7157" />

When the default Netlink socket receive buffer fills up, `unix.Recvfrom` returns the `ENOBUFS` (No buffer space available) error and -1 for the number of bytes read (`nr`).
Because the loop previously logged the error but did not continue to the next iteration, the code attempted to slice the buffer with the negative index, resulting in a panic.

Fixes #

**Does this PR introduce a breaking change?**
No

**If the changes in this PR are manually verified, list down the scenarios covered:**
<img width="969" height="132" alt="image" src="https://github.com/user-attachments/assets/69087506-6075-4dc1-b47a-8da1e0dd0d86" />


**Additional information for reviewer?** :
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [x] Bug fix. Fixes #<issue number>
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Commit has unit tests
- [ ] Commit has integration tests

<!--

The PR title message must follow convention:
`<type>(<scope>): <subject>`.

Where: <br />
- `type` is to define what type of PR is this.
  Most common types are:
    - `feat`      - for new features, not a new feature for build script
    - `fix`       - for bug fixes or improvements, not a fix for build script
    - `chore`     - changes not related to production code
    - `docs`      - changes related to documentation
    - `style`     - formatting, missing semi colons, linting fix etc; no significant production code changes
    - `test`      - adding missing tests, refactoring tests; no production code change
    - `refactor`  - refactoring production code, eg. renaming a variable or function name, there should not be any significant production code changes

- `scope` is a single word that best describes where the changes fit.
    - feature(`monitor`,`enforcer`)
    - test(`tests`, `bdd`)
    - chore(`build`)
- `subject` is a single line brief description of the changes made in the pull request.

-->