### PR TITLE
fix(operator): handle ignored PKI generation error in TLS cert rotation

### DIFF
--- a/pkg/KubeArmorOperator/internal/controller/resources.go
+++ b/pkg/KubeArmorOperator/internal/controller/resources.go
@@ -1265,7 +1265,11 @@ func (clusterWatcher *ClusterWatcher) RotateTlsCerts() {
 		clusterWatcher.Log.Warnf("cannot get controller deployment, error=%s", err.Error())
 	}
 
-	caCert, tlsCrt, tlsKey, _ = common.GeneratePki(common.Namespace, deployments.KubeArmorControllerWebhookServiceName)
+	caCert, tlsCrt, tlsKey, err = common.GeneratePki(common.Namespace, deployments.KubeArmorControllerWebhookServiceName)
+	if err != nil {
+		clusterWatcher.Log.Warnf("cannot generate PKI, error=%s", err.Error())
+		return
+	}
 	replicas := origdeploy.Spec.Replicas
 
 	// TODO: Keep CA certificate in k8s secret


### PR DESCRIPTION
**Purpose of PR?**:

Fixes an issue where errors returned from `common.GeneratePki(...)` during TLS certificate generation were silently ignored. The controller now checks and propagates the error instead of continuing with invalid or nil certificates, preventing misconfigured admission webhooks when PKI generation fails.

Fixes #

---

**Does this PR introduce a breaking change?**

No.

---

**If the changes in this PR are manually verified, list down the scenarios covered:**

* Verified the project builds successfully after the change.
* Confirmed successful PKI generation continues to follow the existing code path.
* Reviewed the failure path to ensure errors from `common.GeneratePki(...)` are returned instead of being silently discarded.
* Verified that invalid or nil certificates are no longer propagated to webhook configuration when PKI generation fails.

---

**Additional information for reviewer?**

This is a small, targeted bug fix with no functional changes to the successful execution path. It improves error handling in a security-critical code path by preventing silent failures during TLS certificate generation.

---

**Checklist:**

* [x] Bug fix. Fixes #<issue number>
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] This change requires a documentation update
* [x] PR Title follows the convention of `<type>(<scope>): <subject>`
* [ ] Commit has unit tests
* [ ] Commit has integration tests
