### PR TITLE
fix(feeder): add map key existence guards for DefaultPostures lookups

### DIFF
--- a/KubeArmor/feeder/policyMatcher.go
+++ b/KubeArmor/feeder/policyMatcher.go
@@ -1448,9 +1448,9 @@ func (fd *Feeder) UpdateMatchedPolicy(log tp.Log) tp.Log {
 					existUSBDeviceAllowPolicy = true
 				} else if secPolicy.Operation == "NetworkFirewall" {
 					existNetworkFirewallAllowPolicy = true
-				}
+		}
 
-				if fd.DefaultPostures[log.NamespaceName].FileAction == "allow" {
+				if posture, ok := fd.DefaultPostures[log.NamespaceName]; ok && posture.FileAction == "allow" {
 					continue
 				}
 			}
@@ -1650,11 +1650,13 @@ func (fd *Feeder) UpdateMatchedPolicy(log tp.Log) tp.Log {
 
 						log.Enforcer = "eBPF Monitor"
 
-						if fd.DefaultPostures[log.NamespaceName].FileAction == "block" {
+					if posture, ok := fd.DefaultPostures[log.NamespaceName]; ok {
+						if posture.FileAction == "block" {
 							log.Action = "Audit (Block)"
-						} else { // fd.DefaultPostures[log.NamespaceName].FileAction == "audit"
+						} else { // posture.FileAction == "audit"
 							log.Action = "Audit"
 						}
+					}
 
 						continue
 					}
@@ -1662,7 +1664,7 @@ func (fd *Feeder) UpdateMatchedPolicy(log tp.Log) tp.Log {
 
 				// apply the default postures when log.type isn't yet known
 
-				if fd.DefaultPostures[log.NamespaceName].FileAction == "block" && secPolicy.Action == "Audit (Allow)" && log.Result == "Passed" && log.Type == "" {
+				if posture, ok := fd.DefaultPostures[log.NamespaceName]; ok && posture.FileAction == "block" && secPolicy.Action == "Audit (Allow)" && log.Result == "Passed" && log.Type == "" {
 					// defaultPosture = block + audit mode
 					log.Type = "MatchedPolicy"
 
@@ -1677,7 +1679,7 @@ func (fd *Feeder) UpdateMatchedPolicy(log tp.Log) tp.Log {
 					log.Action = "Audit (Block)"
 				}
 
-				if fd.DefaultPostures[log.NamespaceName].FileAction == "audit" && (secPolicy.Action == "Allow" || secPolicy.Action == "Audit (Allow)") && log.Result == "Passed" && log.Type == "" {
+				if posture, ok := fd.DefaultPostures[log.NamespaceName]; ok && posture.FileAction == "audit" && (secPolicy.Action == "Allow" || secPolicy.Action == "Audit (Allow)") && log.Result == "Passed" && log.Type == "" {
 					// defaultPosture = audit
 					log.Type = "MatchedPolicy"
 
@@ -1875,17 +1877,19 @@ func (fd *Feeder) UpdateMatchedPolicy(log tp.Log) tp.Log {
 
 						log.Enforcer = "eBPF Monitor"
 
-						if fd.DefaultPostures[log.NamespaceName].NetworkAction == "block" {
+					if posture, ok := fd.DefaultPostures[log.NamespaceName]; ok {
+						if posture.NetworkAction == "block" {
 							log.Action = "Audit (Block)"
-						} else { // fd.DefaultPostures[log.NamespaceName].NetworkAction == "audit"
+						} else { // posture.NetworkAction == "audit"
 							log.Action = "Audit"
 						}
+					}
 
 						continue
 					}
 				}
 
-				if fd.DefaultPostures[log.NamespaceName].NetworkAction == "block" && secPolicy.Action == "Audit (Allow)" && log.Result == "Passed" {
+				if posture, ok := fd.DefaultPostures[log.NamespaceName]; ok && posture.NetworkAction == "block" && secPolicy.Action == "Audit (Allow)" && log.Result == "Passed" {
 					// defaultPosture = block + audit mode
 
 					log.Type = "MatchedPolicy"
@@ -1900,7 +1904,7 @@ func (fd *Feeder) UpdateMatchedPolicy(log tp.Log) tp.Log {
 					log.Action = "Audit (Block)"
 				}
 
-				if fd.DefaultPostures[log.NamespaceName].NetworkAction == "audit" && (secPolicy.Action == "Allow" || secPolicy.Action == "Audit (Allow)") && log.Result == "Passed" {
+				if posture, ok := fd.DefaultPostures[log.NamespaceName]; ok && posture.NetworkAction == "audit" && (secPolicy.Action == "Allow" || secPolicy.Action == "Audit (Allow)") && log.Result == "Passed" {
 					// defaultPosture = audit
 
 					log.Type = "MatchedPolicy"
@@ -2191,17 +2195,19 @@ func (fd *Feeder) UpdateMatchedPolicy(log tp.Log) tp.Log {
 
 						log.Enforcer = "eBPF Monitor"
 
-						if fd.DefaultPostures[log.NamespaceName].CapabilitiesAction == "block" {
+					if posture, ok := fd.DefaultPostures[log.NamespaceName]; ok {
+						if posture.CapabilitiesAction == "block" {
 							log.Action = "Audit (Block)"
-						} else { // fd.DefaultPostures[log.NamespaceName].CapabilitiesAction == "audit"
+						} else { // posture.CapabilitiesAction == "audit"
 							log.Action = "Audit"
 						}
+					}
 
 						continue
 					}
 				}
 
-				if fd.DefaultPostures[log.NamespaceName].CapabilitiesAction == "block" && secPolicy.Action == "Audit (Allow)" && log.Result == "Passed" {
+				if posture, ok := fd.DefaultPostures[log.NamespaceName]; ok && posture.CapabilitiesAction == "block" && secPolicy.Action == "Audit (Allow)" && log.Result == "Passed" {
 					// defaultPosture = block + audit mode
 
 					log.Type = "MatchedPolicy"
@@ -2216,7 +2222,7 @@ func (fd *Feeder) UpdateMatchedPolicy(log tp.Log) tp.Log {
 					log.Action = "Audit (Block)"
 				}
 
-				if fd.DefaultPostures[log.NamespaceName].CapabilitiesAction == "audit" && (secPolicy.Action == "Allow" || secPolicy.Action == "Audit (Allow)") && log.Result == "Passed" {
+				if posture, ok := fd.DefaultPostures[log.NamespaceName]; ok && posture.CapabilitiesAction == "audit" && (secPolicy.Action == "Allow" || secPolicy.Action == "Audit (Allow)") && log.Result == "Passed" {
 					// defaultPosture = audit
 
 					log.Type = "MatchedPolicy"


### PR DESCRIPTION
**Purpose of PR?**:

Fixes a bug where namespace default postures were accessed without checking for key existence in `DefaultPostures`. When a namespace was not present in the map, Go returned a zero-value struct, causing policy decisions to silently skip both `block` and `audit` enforcement. This change adds explicit existence checks before using the map value, preventing silent policy enforcement gaps.

Fixes #

---

**Does this PR introduce a breaking change?**

No.

---

**If the changes in this PR are manually verified, list down the scenarios covered:**

* Verified the project builds successfully after the change.
* Confirmed policy enforcement behavior remains unchanged for namespaces with configured default postures.
* Reviewed the code paths to ensure missing namespace entries are explicitly handled instead of relying on zero-value map lookups.
* Verified that namespaces without configured default postures no longer silently bypass policy enforcement due to missing map keys.

---

**Additional information for reviewer?**

This is a targeted bug fix that adds explicit map key existence checks at the affected locations. It does not change behavior for valid configurations but prevents silent enforcement gaps caused by implicit zero-value map lookups.

---

**Checklist:**

* [x] Bug fix. 
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] This change requires a documentation update
* [x] PR Title follows the convention of `<type>(<scope>): <subject>`
* [ ] Commit has unit tests
* [ ] Commit has integration tests
