### PR TITLE
fix(feeder): rate-limit drop logs to prevent memory spikes

### DIFF
--- a/KubeArmor/feeder/feeder.go
+++ b/KubeArmor/feeder/feeder.go
@@ -219,6 +219,9 @@ type BaseFeeder struct {
 	// True if feeder and its workers are working
 	Running bool
 
+	// Number of dropped logs
+	DroppedLogs uint64
+
 	// LogServer //
 
 	// port
@@ -923,7 +926,11 @@ func (fd *Feeder) PushLog(log tp.Log) {
 				counter++
 				if counter == lenlog {
 					// Default on the last uid in Logstuct means the log isn't pushed into Broadcast
-					kg.Printf("log channel busy, log dropped.")
+					fd.DroppedLogs++
+					if fd.DroppedLogs%10000 == 0 {
+						kg.Warnf("log channel busy, 10000 logs dropped.")
+						fd.DroppedLogs = 0
+					}
 				}
 			}
 		}


### PR DESCRIPTION
**Purpose of PR?**:
During high-event loads (e.g., thousands of events per second) where connected clients cannot consume the stream fast enough, the Feeder's internal client broadcast channels fill up. The previous implementation executed

https://github.com/kubearmor/KubeArmor/blob/27ded4a9cfa8aae52177cfc7e3a3b9e3fcb7802e/KubeArmor/feeder/feeder.go#L926

for every single dropped event.
Spamming the standard output logger thousands of times per second resulted in the KubeArmor's memory usage spike exponentially.

This PR adds a counter to track dropped logs, printing a single warning for every 10,000 dropped logs to prevent memory spikes.

Fixes #

**Does this PR introduce a breaking change?**
No

**If the changes in this PR are manually verified, list down the scenarios covered:**
<img width="1805" height="888" alt="image" src="https://github.com/user-attachments/assets/b6342cf6-f940-4a84-8f43-9bf9ef5f1ff2" />


**Additional information for reviewer?** :
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [x] Bug fix. Fixes #<issue number>
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Commit has unit tests
- [ ] Commit has integration tests

<!--

The PR title message must follow convention:
`<type>(<scope>): <subject>`.

Where: <br />
- `type` is to define what type of PR is this.
  Most common types are:
    - `feat`      - for new features, not a new feature for build script
    - `fix`       - for bug fixes or improvements, not a fix for build script
    - `chore`     - changes not related to production code
    - `docs`      - changes related to documentation
    - `style`     - formatting, missing semi colons, linting fix etc; no significant production code changes
    - `test`      - adding missing tests, refactoring tests; no production code change
    - `refactor`  - refactoring production code, eg. renaming a variable or function name, there should not be any significant production code changes

- `scope` is a single word that best describes where the changes fit.
    - feature(`monitor`,`enforcer`)
    - test(`tests`, `bdd`)
    - chore(`build`)
- `subject` is a single line brief description of the changes made in the pull request.

-->