### PR TITLE
nominating two maintainers for KubeArmor

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -19,7 +19,7 @@ The list is sorted alphabetically.
 | Anurag Kumar | [@kranurag7](https://github.com/kranurag7) | Independent |
 | Aryan Bakliwal | [@AryanBakliwal](https://github.com/AryanBakliwal) | AccuKnox |
 | Aryan Sharma | [@Aryan-sharma11](https://github.com/Aryan-sharma11) | AccuKnox |
-| Barun Acharya | [@daemon1024](https://github.com/daemon1024) | AccuKnox |
+| Barun Acharya | [@daemon1024](https://github.com/daemon1024) | Odigos |
 | Jaehyun Nam | [@nam-jaehyun](https://github.com/nam-jaehyun) | Dankook University |
 | Rahul Jadhav | [@nyrahul](https://github.com/nyrahul) | AccuKnox |
 | Ramakant Sharma | [@rksharma95](https://github.com/rksharma95) | AccuKnox |

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -22,7 +22,7 @@ The list is sorted alphabetically.
 | Barun Acharya | [@daemon1024](https://github.com/daemon1024) | Odigos |
 | Jaehyun Nam | [@nam-jaehyun](https://github.com/nam-jaehyun) | Dankook University |
 | Rahul Jadhav | [@nyrahul](https://github.com/nyrahul) | AccuKnox |
-| Ramakant Sharma | [@rksharma95](https://github.com/rksharma95) | AccuKnox |
+| Ramakant Sharma | [@rksharma95](https://github.com/rksharma95) | StepSecurity |
 | Rudraksh Pareek | [@DelusionalOptimist](https://github.com/DelusionalOptimist) | CERN |
 
 ## Reviewers

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -17,6 +17,8 @@ The list is sorted alphabetically.
 | Achref Ben Saad | [@achrefbensaad](https://github.com/achrefbensaad) | AccuKnox |
 | Ankur Kothiwal | [@Ankurk99](https://github.com/Ankurk99) | CERN |
 | Anurag Kumar | [@kranurag7](https://github.com/kranurag7) | Independent |
+| Aryan Bakliwal | [@AryanBakliwal](https://github.com/AryanBakliwal) | AccuKnox |
+| Aryan Sharma | [@Aryan-sharma11](https://github.com/Aryan-sharma11) | AccuKnox |
 | Barun Acharya | [@daemon1024](https://github.com/daemon1024) | AccuKnox |
 | Jaehyun Nam | [@nam-jaehyun](https://github.com/nam-jaehyun) | Dankook University |
 | Rahul Jadhav | [@nyrahul](https://github.com/nyrahul) | AccuKnox |


### PR DESCRIPTION
Sponsoring two maintainers to be added to KubeArmor.
This sponsorship does not follow the Governance rules as we are still in a transition phase and will need to review the maintainers list before adhering 100% to the rules