### PR TITLE
fix(core): Fix kubearmor-init image build workflow

### DIFF
--- a/KubeArmor/build/push_kubearmor.sh
+++ b/KubeArmor/build/push_kubearmor.sh
@@ -60,7 +60,7 @@ echo "[PASSED] Pushed $REPO:$VERSION"
 
 # push $REPO-init
 echo "[INFO] Pushing $REPO-init:$VERSION"
-cd $ARMOR_HOME/..; docker buildx build --metadata-file kubearmor-init.json --platform $PLATFORMS --build-arg VERSION=$VERSION -t $REPO-init:$VERSION -f Dockerfile.init $BUILD_MODE $LABEL $STABEL_LABEL .
+cd $ARMOR_HOME/..; docker buildx build --metadata-file kubearmor-init.json --platform $PLATFORMS --target kubearmor-init --build-arg VERSION=$VERSION -t $REPO-init:$VERSION -f Dockerfile.init $BUILD_MODE $LABEL $STABEL_LABEL .
 
 [[ $? -ne 0 ]] && echo "[FAILED] Failed to push $REPO-init:$VERSION" && exit 1
 echo "[PASSED] Pushed $REPO-init:$VERSION"


### PR DESCRIPTION
**Purpose of PR?**:
When KubeArmor is installed on nodes with CPUs not supporting `x86-64-v3` architecture, the following error was reported from init container

```
Fatal glibc error: CPU does not support x86-64-v3
```

KubeArmor ships two different init images
1. `kubearmor-init`: Based on Apline, uses `musl`
2. `kubearmor-init-ubi`: Based on RedHat UBI 10, uses `glibc`

The above error was seen when KubeArmor used the `kubearmor-init` image, which should never happen because Alpine based images uses `musl` and not `glibc`. This error is not possible unless the image is UBI 10 based, since UBI 10 dropped support for `x86-64-v3` CPU architecture and uses `glibc`.

The reason for this error was that in the [push_kubearmor.sh](https://github.com/kubearmor/KubeArmor/blob/main/KubeArmor/build/push_kubearmor.sh) script used to build `kubearmor` and `kubearmor-init` images, it missed the `--target kubearmor-init` flag in the following line which caused the UBI 10 based image to be built instead of the Alpine based one.

https://github.com/kubearmor/KubeArmor/blob/e89c28d30a56179aa591de7bbaa86d32f916ff42/KubeArmor/build/push_kubearmor.sh#L63


Fixes #

**Does this PR introduce a breaking change?**
No

**If the changes in this PR are manually verified, list down the scenarios covered:**:

**Additional information for reviewer?** :
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [x] Bug fix. Fixes #<issue number>
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Commit has unit tests
- [ ] Commit has integration tests

<!--

The PR title message must follow convention:
`<type>(<scope>): <subject>`.

Where: <br />
- `type` is to define what type of PR is this.
  Most common types are:
    - `feat`      - for new features, not a new feature for build script
    - `fix`       - for bug fixes or improvements, not a fix for build script
    - `chore`     - changes not related to production code
    - `docs`      - changes related to documentation
    - `style`     - formatting, missing semi colons, linting fix etc; no significant production code changes
    - `test`      - adding missing tests, refactoring tests; no production code change
    - `refactor`  - refactoring production code, eg. renaming a variable or function name, there should not be any significant production code changes

- `scope` is a single word that best describes where the changes fit.
    - feature(`monitor`,`enforcer`)
    - test(`tests`, `bdd`)
    - chore(`build`)
- `subject` is a single line brief description of the changes made in the pull request.

-->