### PR TITLE
docs(docs): add sample policies for database protection and network p…

### DIFF
--- a/getting-started/use-cases.md
+++ b/getting-started/use-cases.md
@@ -189,7 +189,7 @@ spec:
   <summary><h2>Limit access to raw database tables in the pod</h2></summary>
 
 ### Description
-MySQL and other database systems keep their raw tables in a specific folder path. This path can either if a path in a volume mount or local to the pod. Typically, these raw tables are accessed only by certain set of processes such as `mysqld`, `mysqldump`, `mysqladmin`. Any other binary should never be allowed to read or write into this folder.
+MySQL and other database systems keep their raw tables in a specific folder path. This path can either be a path in a volume mount or local to the pod. Typically, these raw tables are accessed only by certain set of processes such as `mysqld`, `mysqldump`, `mysqladmin`. Any other binary should never be allowed to read or write into this folder.
 
 ### Attack Scenario
 Attackers will try to:
@@ -198,7 +198,28 @@ Attackers will try to:
 3. delete the tables to cause system downtime
   
 ### Sample Policy
-TODO
+```yaml
+apiVersion: security.kubearmor.com/v1
+kind: KubeArmorPolicy
+metadata:
+  name: limit-mysql-raw-table-access
+  namespace: mysql
+spec:
+  severity: 5
+  selector:
+    matchLabels:
+      app: mysql
+  file:
+    matchDirectories:
+    - dir: /var/lib/mysql/
+      recursive: true
+      fromSource:
+      - path: /usr/sbin/mysqld
+      - path: /usr/bin/mysqldump
+      - path: /usr/bin/mysqladmin
+  action:
+    Allow
+```
 </details>
 
 <details>
@@ -211,7 +232,31 @@ Typically, within a pod/container there are only specific processes that need to
 An attacker binary would try to send a beacon to its C&C (Command and Control) Server. Also the binary might use the network primitives to exfiltrate pod/container data/configuration.
   
 ### Sample Policy
-TODO
+```yaml
+apiVersion: security.kubearmor.com/v1
+kind: KubeArmorPolicy
+metadata:
+  name: restrict-network-primitives
+  namespace: default
+spec:
+  severity: 5
+  selector:
+    matchLabels:
+      app: my-app
+  network:
+    matchProtocols:
+    - protocol: tcp
+      fromSource:
+      - path: /usr/bin/curl
+    - protocol: udp
+      fromSource:
+      - path: /usr/bin/curl
+    - protocol: raw
+      fromSource:
+      - path: /bin/ping
+  action:
+    Allow
+```
 </details>
 
 ## Generic use-cases


### PR DESCRIPTION
**Purpose of PR?**:

Fixes #2730

**Does this PR introduce a breaking change?**
No

**If the changes in this PR are manually verified, list down the scenarios covered:**:
N/A (Documentation update only; YAML blocks formatted and validated).

**Additional information for reviewer?** :
This PR adds the missing sample KSP rules for the MySQL database protection and network primitives whitelisting scenarios in `getting-started/use-cases.md`. Also corrected a minor typo "can either if a path" to "can either be a path".

**Checklist:**
- [ ] Bug fix. Fixes #2730
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Commit has unit tests
- [ ] Commit has integration tests