### PR TITLE
fix(ci): fix ci-merge-coverage workflow failing with git rev-parse error

### DIFF
--- a/.github/workflows/ci-merge-coverage.yaml
+++ b/.github/workflows/ci-merge-coverage.yaml
@@ -17,16 +17,27 @@ jobs:
       actions: read
       contents: read
     steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          submodules: true
+
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        with:
+          go-version-file: "KubeArmor/go.mod"
+
       - name: Check if all required workflows completed successfully
         id: check-workflows
         run: |
           workflows=("ci-test-ginkgo")
           all_completed=true
 
-          commit_sha=$(git rev-parse HEAD)
+          commit_sha="${{ github.event.workflow_run.head_sha }}"
 
           for workflow in "${workflows[@]}"; do
-              conclusion=$(gh run list --workflow=$workflow --json conclusion,headSha,event,headBranch | jq -r --arg sha "$commit_sha" --arg event "pull_request" '.[] | select(.headSha == $sha and .event == $event) | .conclusion')
+              safe_name="${workflow//-/_}"
+              conclusion=$(gh run list --workflow=${workflow}.yml --json conclusion,headSha \
+                | jq -r --arg sha "$commit_sha" \
+                '.[] | select(.headSha == $sha) | .conclusion' | head -1)
 
               if [[ -z "$conclusion" ]]; then
                   conclusion="pending"
@@ -36,7 +47,7 @@ jobs:
                   all_completed=false
               fi
 
-              echo "${workflow}_status=$conclusion" >> $GITHUB_ENV
+              echo "${safe_name}_status=$conclusion" >> $GITHUB_ENV
           done
 
           if [[ "$all_completed" == "true" ]]; then
@@ -47,18 +58,10 @@ jobs:
               exit 1
           fi
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-        with:
-          submodules: true
-
-      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
-        with:
-          go-version-file: "KubeArmor/go.mod"
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Download k8s coverage files from ci-test-ginkgo
-        if: ${{ env.ci-test-ginkgo_status == 'success' }}
+        if: ${{ env.ci_test_ginkgo_status == 'success' }}
         uses: dawidd6/action-download-artifact@bf251b5aa9c2f7eeb574a96ee720e24f801b7c11 # v6
         with:
           workflow: ci-test-ginkgo.yml


### PR DESCRIPTION
## Summary
- `ci-merge-coverage` was failing on every run on `main` (e.g. run for 106f8de) with `fatal: not a git repository (or any of the parent directories): .git` and exit code 128.
- Root cause: the "Check if all required workflows completed successfully" step calls `git rev-parse HEAD` before the `actions/checkout` step has run, so no git repo exists yet in the runner workspace.
- Fix: move `actions/checkout` and `actions/setup-go` before the check step, and use `github.event.workflow_run.head_sha` instead of `git rev-parse HEAD` (this workflow is triggered by `workflow_run`, so that's the correct commit reference anyway).
- Also sanitized the per-workflow status env var name (`ci-test-ginkgo_status` -> `ci_test_ginkgo_status`, since hyphenated env context keys are unreliable) and switched to `GH_TOKEN` for `gh` CLI auth.

## Test plan
- [x] Reviewed the failing run logs on `main` confirming `git rev-parse HEAD` fails pre-checkout
- [x] YAML validated locally
- [ ] Verify `ci-merge-coverage` passes on the next `ci-test-ginkgo` completion after merge