### PR TITLE
fix(controller): secure metrics ServiceMonitor TLS

### DIFF
--- a/pkg/KubeArmorController/config/certmanager/certificate-metrics.yaml
+++ b/pkg/KubeArmorController/config/certmanager/certificate-metrics.yaml
@@ -1,0 +1,20 @@
+# The following manifests contain a self-signed issuer CR and a metrics certificate CR.
+# More information can be found at https://docs.cert-manager.io
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  labels:
+    app.kubernetes.io/name: kubearmor-controller
+    app.kubernetes.io/managed-by: kustomize
+  name: metrics-certs
+  namespace: system
+spec:
+  # SERVICE_NAME and SERVICE_NAMESPACE will be substituted by kustomize
+  # replacements in the config/default/kustomization.yaml file.
+  dnsNames:
+  - SERVICE_NAME.SERVICE_NAMESPACE.svc
+  - SERVICE_NAME.SERVICE_NAMESPACE.svc.cluster.local
+  issuerRef:
+    kind: Issuer
+    name: selfsigned-issuer
+  secretName: metrics-server-cert

--- a/pkg/KubeArmorController/config/certmanager/certificate-webhook.yaml
+++ b/pkg/KubeArmorController/config/certmanager/certificate-webhook.yaml
@@ -1,0 +1,20 @@
+# The following manifests contain a self-signed issuer CR and a webhook certificate CR.
+# More information can be found at https://docs.cert-manager.io
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  labels:
+    app.kubernetes.io/name: kubearmor-controller
+    app.kubernetes.io/managed-by: kustomize
+  name: serving-cert
+  namespace: system
+spec:
+  # SERVICE_NAME and SERVICE_NAMESPACE will be substituted by kustomize
+  # replacements in the config/default/kustomization.yaml file.
+  dnsNames:
+  - SERVICE_NAME.SERVICE_NAMESPACE.svc
+  - SERVICE_NAME.SERVICE_NAMESPACE.svc.cluster.local
+  issuerRef:
+    kind: Issuer
+    name: selfsigned-issuer
+  secretName: webhook-server-cert

--- a/pkg/KubeArmorController/config/certmanager/issuer.yaml
+++ b/pkg/KubeArmorController/config/certmanager/issuer.yaml
@@ -1,0 +1,12 @@
+# The following manifest contains a self-signed issuer CR.
+# More information can be found at https://docs.cert-manager.io
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  labels:
+    app.kubernetes.io/name: kubearmor-controller
+    app.kubernetes.io/managed-by: kustomize
+  name: selfsigned-issuer
+  namespace: system
+spec:
+  selfSigned: {}

--- a/pkg/KubeArmorController/config/certmanager/kustomization.yaml
+++ b/pkg/KubeArmorController/config/certmanager/kustomization.yaml
@@ -1,0 +1,7 @@
+resources:
+- issuer.yaml
+- certificate-webhook.yaml
+- certificate-metrics.yaml
+
+configurations:
+- kustomizeconfig.yaml

--- a/pkg/KubeArmorController/config/certmanager/kustomizeconfig.yaml
+++ b/pkg/KubeArmorController/config/certmanager/kustomizeconfig.yaml
@@ -1,0 +1,8 @@
+# This configuration is for teaching kustomize how to update name ref substitution.
+nameReference:
+- kind: Issuer
+  group: cert-manager.io
+  fieldSpecs:
+  - kind: Certificate
+    group: cert-manager.io
+    path: spec/issuerRef/name

--- a/pkg/KubeArmorController/config/default/cert_metrics_manager_patch.yaml
+++ b/pkg/KubeArmorController/config/default/cert_metrics_manager_patch.yaml
@@ -1,0 +1,21 @@
+# This patch mounts cert-manager managed certificates at the controller-runtime
+# metrics server default certificate directory.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+  namespace: system
+spec:
+  template:
+    spec:
+      containers:
+      - name: manager
+        volumeMounts:
+        - mountPath: /tmp/k8s-metrics-server/serving-certs
+          name: metrics-certs
+          readOnly: true
+      volumes:
+      - name: metrics-certs
+        secret:
+          defaultMode: 420
+          secretName: metrics-server-cert

--- a/pkg/KubeArmorController/config/default/kustomization.yaml
+++ b/pkg/KubeArmorController/config/default/kustomization.yaml
@@ -21,9 +21,11 @@ resources:
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
 # crd/kustomization.yaml
 - ../webhook
-# [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'. 'WEBHOOK' components are required.
+# [CERTMANAGER] To enable cert-manager managed certificates for the webhook and metrics endpoints,
+# uncomment the following resource.
 #- ../certmanager
-# [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
+# [PROMETHEUS] To enable the controller ServiceMonitor, also enable the CERTMANAGER sections below
+# so Prometheus can verify the metrics server certificate instead of skipping TLS verification.
 #- ../prometheus
 # [METRICS] Expose the controller manager metrics service.
 - metrics_service.yaml
@@ -40,6 +42,11 @@ patches:
 - path: manager_metrics_patch.yaml
   target:
     kind: Deployment
+# [METRICS-WITH-CERTS] To enable cert-manager managed certificates for the metrics server,
+# uncomment the following patch after enabling ../certmanager.
+# - path: cert_metrics_manager_patch.yaml
+#   target:
+#     kind: Deployment
 
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
 # crd/kustomization.yaml
@@ -48,8 +55,67 @@ patches:
     kind: Deployment
 
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER' prefix.
-# Uncomment the following replacements to add the cert-manager CA injection annotations
+# Uncomment the following replacements to wire webhook and metrics certificate DNS names and
+# ServiceMonitor serverName values to the rendered Service names.
 #replacements:
+# - source: # Uncomment the following block to enable certificates for metrics
+#     kind: Service
+#     version: v1
+#     name: controller-manager-metrics-service
+#     fieldPath: .metadata.name
+#   targets:
+#     - select:
+#         kind: Certificate
+#         group: cert-manager.io
+#         version: v1
+#         name: metrics-certs
+#       fieldPaths:
+#         - .spec.dnsNames.0
+#         - .spec.dnsNames.1
+#       options:
+#         delimiter: '.'
+#         index: 0
+#         create: true
+#     - select:
+#         kind: ServiceMonitor
+#         group: monitoring.coreos.com
+#         version: v1
+#         name: controller-manager-metrics-monitor
+#       fieldPaths:
+#         - .spec.endpoints.0.tlsConfig.serverName
+#       options:
+#         delimiter: '.'
+#         index: 0
+#         create: true
+# - source:
+#     kind: Service
+#     version: v1
+#     name: controller-manager-metrics-service
+#     fieldPath: .metadata.namespace
+#   targets:
+#     - select:
+#         kind: Certificate
+#         group: cert-manager.io
+#         version: v1
+#         name: metrics-certs
+#       fieldPaths:
+#         - .spec.dnsNames.0
+#         - .spec.dnsNames.1
+#       options:
+#         delimiter: '.'
+#         index: 1
+#         create: true
+#     - select:
+#         kind: ServiceMonitor
+#         group: monitoring.coreos.com
+#         version: v1
+#         name: controller-manager-metrics-monitor
+#       fieldPaths:
+#         - .spec.endpoints.0.tlsConfig.serverName
+#       options:
+#         delimiter: '.'
+#         index: 1
+#         create: true
 # - source: # Uncomment the following block if you have any webhook
 #     kind: Service
 #     version: v1

--- a/pkg/KubeArmorController/config/prometheus/monitor.yaml
+++ b/pkg/KubeArmorController/config/prometheus/monitor.yaml
@@ -13,16 +13,23 @@ spec:
       scheme: https
       bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
       tlsConfig:
-        # TODO(user): The option insecureSkipVerify: true is not recommended for production since it disables
-        # certificate verification. This poses a significant security risk by making the system vulnerable to
-        # man-in-the-middle attacks, where an attacker could intercept and manipulate the communication between
-        # Prometheus and the monitored services. This could lead to unauthorized access to sensitive metrics data,
-        # compromising the integrity and confidentiality of the information.
-        # Please use the following options for secure configurations:
-        # caFile: /etc/metrics-certs/ca.crt
-        # certFile: /etc/metrics-certs/tls.crt
-        # keyFile: /etc/metrics-certs/tls.key
-        insecureSkipVerify: true
+        # Enable certificate verification against the cert-manager managed secret.
+        # When this ServiceMonitor is included from config/default, the service name
+        # and namespace are rewritten by kustomize replacements to match the final
+        # rendered resource names.
+        serverName: controller-manager-metrics-service.system.svc
+        insecureSkipVerify: false
+        ca:
+          secret:
+            name: metrics-server-cert
+            key: ca.crt
+        cert:
+          secret:
+            name: metrics-server-cert
+            key: tls.crt
+        keySecret:
+          name: metrics-server-cert
+          key: tls.key
   selector:
     matchLabels:
       control-plane: controller-manager


### PR DESCRIPTION
**Purpose of PR?**:

Fixes #2746

**Does this PR introduce a breaking change?**

No.

**If the changes in this PR are manually verified, list down the scenarios covered:**:

- Rendered the standalone controller `ServiceMonitor` and confirmed it no longer uses `insecureSkipVerify: true`.
- Rendered a secure metrics overlay with cert-manager resources enabled and confirmed:
  - the `ServiceMonitor` uses `insecureSkipVerify: false`
  - the TLS `serverName` tracks the rendered metrics service name
  - the controller deployment mounts `metrics-server-cert` at the controller-runtime metrics cert path

**Additional information for reviewer?** :
This keeps the change scoped to controller manifests and secure-metrics wiring. It does not enable Prometheus or cert-manager by default in `config/default`; it documents and scaffolds the secure path that should be enabled alongside Prometheus scraping.

**Checklist:**
- [x] Bug fix. Fixes #2746
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Commit has unit tests
- [ ] Commit has integration tests

## Summary
- replace the controller `ServiceMonitor` default from insecure TLS skip-verify to cert-manager-backed certificate verification
- add the missing cert-manager certificate resources and metrics secret mount patch needed for secure scraping
- document the kustomize toggles and replacements required when enabling Prometheus scraping

## Linked Issue
Fixes #2746

## What Changed
- updated `pkg/KubeArmorController/config/prometheus/monitor.yaml` to verify TLS with `metrics-server-cert`
- added `pkg/KubeArmorController/config/certmanager/*` resources for webhook and metrics certificates
- added `pkg/KubeArmorController/config/default/cert_metrics_manager_patch.yaml`
- expanded `pkg/KubeArmorController/config/default/kustomization.yaml` guidance for secure Prometheus + cert-manager wiring

## Verification
- `make build` (in `pkg/KubeArmorController`) — passed
- `GOWORK=off go run sigs.k8s.io/kustomize/kustomize/v5@v5.5.0 build /tmp/kubearmor-controller-prometheus` — passed
- `GOWORK=off go run sigs.k8s.io/kustomize/kustomize/v5@v5.5.0 build --load-restrictor LoadRestrictionsNone /tmp/kubearmor-controller-config-build/secure` — passed
- `make test` (in `pkg/KubeArmorController`) — failed: the target stopped during envtest tool bootstrap with `tar: Error opening archive: Unrecognized archive format` before project tests executed
- `make docker-build TAG=latest` (in `pkg/KubeArmorController`) — failed: `docker` is not installed in this environment
- `make docker-build` (in `pkg/KubeArmorOperator`) — failed: `docker` is not installed in this environment
- `./KubeArmor/build/build_kubearmor.sh` — failed: `docker` is not installed in this environment

## Scope
- only controller manifest/config files required for secure metrics scraping were changed; no unrelated repository files were included
