### PR TITLE
fix(helm): fail validation when helm is unavailable

### DIFF
--- a/.github/workflows/helm-validate-values-test.sh
+++ b/.github/workflows/helm-validate-values-test.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Authors of KubeArmor
+
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "$script_dir/../.." && pwd)"
+script="$repo_root/.github/workflows/helm-validate-values.sh"
+bash_bin="$(command -v bash)"
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+assert_contains() {
+	local haystack="$1"
+	local needle="$2"
+
+	if [[ "$haystack" != *"$needle"* ]]; then
+		echo "expected output to contain: $needle" >&2
+		echo "$haystack" >&2
+		exit 1
+	fi
+}
+
+run_missing_helm_test() {
+	local bindir="$tmpdir/missing/bin"
+	mkdir -p "$bindir"
+	ln -s "$(command -v rm)" "$bindir/rm"
+
+	set +e
+	local output
+	output="$(PATH="$bindir" "$bash_bin" "$script" 2>&1)"
+	local status=$?
+	set -e
+
+	if [[ $status -eq 0 ]]; then
+		echo "expected missing-helm test to fail" >&2
+		exit 1
+	fi
+
+	assert_contains "$output" "helm is required to validate environment specific templates."
+}
+
+run_failed_helm_test() {
+	local bindir="$tmpdir/failing/bin"
+	mkdir -p "$bindir"
+	ln -s "$(command -v rm)" "$bindir/rm"
+	cat > "$bindir/helm" <<EOF
+#!$bash_bin
+echo "simulated helm failure" >&2
+exit 2
+EOF
+	chmod +x "$bindir/helm"
+
+	set +e
+	local output
+	output="$(PATH="$bindir" "$bash_bin" "$script" 2>&1)"
+	local status=$?
+	set -e
+
+	if [[ $status -eq 0 ]]; then
+		echo "expected failing-helm test to fail" >&2
+		exit 1
+	fi
+
+	assert_contains "$output" "Generating templates for docker..."
+	assert_contains "$output" "simulated helm failure"
+}
+
+run_success_test() {
+	local bindir="$tmpdir/success/bin"
+	mkdir -p "$bindir"
+	ln -s "$(command -v rm)" "$bindir/rm"
+	cat > "$bindir/helm" <<EOF
+#!$bash_bin
+printf 'kind: ConfigMap\nmetadata:\n  name: rendered\n'
+EOF
+	chmod +x "$bindir/helm"
+
+	local output
+	output="$(cd "$repo_root" && PATH="$bindir" "$bash_bin" "$script" 2>&1)"
+
+	assert_contains "$output" "Validated environment specific templates!"
+
+	for env in docker crio k3s microk8s minikube GKE BottleRocket EKS generic; do
+		if [[ -e "$repo_root/$env.yml" ]]; then
+			echo "expected $env.yml to be removed" >&2
+			exit 1
+		fi
+	done
+}
+
+run_missing_helm_test
+run_failed_helm_test
+run_success_test

--- a/.github/workflows/helm-validate-values.sh
+++ b/.github/workflows/helm-validate-values.sh
@@ -1,19 +1,22 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2026 Authors of KubeArmor
 
+set -euo pipefail
+
 envs=("docker" "crio" "k3s" "microk8s" "minikube" "GKE" "BottleRocket" "EKS" "generic")
 
+if ! command -v helm >/dev/null 2>&1; then
+	echo "helm is required to validate environment specific templates." >&2
+	exit 1
+fi
+
 echo "Testing environment specific helm templates..."
-for env in ${envs[@]}; do
+for env in "${envs[@]}"; do
 	echo "Generating templates for $env..."
-	helm template kubearmor ./deployments/helm/KubeArmor --set environment.name=$env > $env.yml
-	if [[ "$?" -eq 1 ]]
-	then
-		echo "Failed to generate template for $env!"
-		exit 1
-	fi
-	rm -rf $env.yml
+	output_file="${env}.yml"
+	helm template kubearmor ./deployments/helm/KubeArmor --set "environment.name=$env" > "$output_file"
+	rm -f "$output_file"
 done
 
 echo "Validated environment specific templates!"


### PR DESCRIPTION
## Summary
- make `.github/workflows/helm-validate-values.sh` fail fast when `helm` is unavailable
- rely on strict shell error handling so any failed `helm template` invocation stops validation
- add a focused bash regression test covering missing-helm, non-zero helm exit, and success cases

## Linked Issue
Fixes #2750

## What Changed
- added `set -euo pipefail` and a `command -v helm` preflight to the validation script
- quoted the environment loop and file handling for safer shell behavior
- added `.github/workflows/helm-validate-values-test.sh` to exercise the script locally without a real Helm install

## Verification
- `bash -n .github/workflows/helm-validate-values.sh .github/workflows/helm-validate-values-test.sh` — passed
- `bash .github/workflows/helm-validate-values-test.sh` — passed
- `bash -c 'if bash .github/workflows/helm-validate-values.sh >/tmp/helm-script.out 2>/tmp/helm-script.err; then exit 1; fi; grep -q "helm is required to validate environment specific templates." /tmp/helm-script.err'` — passed
- `helm lint ./deployments/helm/KubeArmor` — not run: `helm` is not installed in the local environment
- `helm lint ./deployments/helm/KubeArmorOperator` — not run: `helm` is not installed in the local environment

## Scope
- Only `.github/workflows/helm-validate-values.sh` and its focused regression test were changed.

**Purpose of PR?**:

Fixes #2750

**Does this PR introduce a breaking change?**

No.

**If the changes in this PR are manually verified, list down the scenarios covered:**:

- Missing `helm` now fails immediately with a clear error.
- Any non-zero `helm` exit stops validation.
- Successful rendering still reaches the success message and cleans up generated files.

**Additional information for reviewer?** :
_Scope is intentionally limited to the validation script and its regression coverage._


**Checklist:**
- [x] Bug fix. Fixes #2750
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [x] Commit has unit tests
- [ ] Commit has integration tests
