### PR TITLE
fix(core): guard WatchConfigChanges endpoint iteration with EndPointsLock

### DIFF
--- a/KubeArmor/core/unorchestratedUpdates.go
+++ b/KubeArmor/core/unorchestratedUpdates.go
@@ -77,7 +77,13 @@ func (dm *KubeArmorDaemon) WatchConfigChanges() {
 		dm.UpdateGlobalPosture(globalPosture)
 
 		// Update default posture for endpoints
-		for _, ep := range dm.EndPoints {
+		// Copy endpoints under lock to avoid racing with concurrent endpoint updates
+		dm.EndPointsLock.RLock()
+		endPointsCopy := make([]tp.EndPoint, len(dm.EndPoints))
+		copy(endPointsCopy, dm.EndPoints)
+		dm.EndPointsLock.RUnlock()
+
+		for _, ep := range endPointsCopy {
 			dm.Logger.Printf("Updating Default Posture for endpoint %s", ep.EndPointName)
 			dm.UpdateDefaultPosture("MODIFIED", ep.NamespaceName, globalPosture, false)
 			dm.UpdateVisibility("MODIFIED", ep.NamespaceName, visibility)

--- a/KubeArmor/core/unorchestratedUpdates_race_test.go
+++ b/KubeArmor/core/unorchestratedUpdates_race_test.go
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Authors of KubeArmor
+
+package core
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	tp "github.com/kubearmor/KubeArmor/KubeArmor/types"
+)
+
+// TestConfigReloadEndpointIterationRaceCondition ensures that iterating over
+// dm.EndPoints during a config reload (the WatchConfigChanges callback in
+// unorchestratedUpdates.go) does not race with concurrent endpoint mutations
+// performed elsewhere in the daemon (e.g. container handlers), which take
+// EndPointsLock while adding/removing endpoints.
+func TestConfigReloadEndpointIterationRaceCondition(t *testing.T) {
+	dm := &KubeArmorDaemon{
+		EndPoints:     []tp.EndPoint{},
+		EndPointsLock: &sync.RWMutex{},
+	}
+
+	for i := 0; i < 50; i++ {
+		dm.EndPoints = append(dm.EndPoints, tp.EndPoint{
+			NamespaceName: "test-namespace",
+			EndPointName:  fmt.Sprintf("test-endpoint-%d", i),
+		})
+	}
+
+	var wg sync.WaitGroup
+	stopCh := make(chan struct{})
+
+	// Goroutine 1: mirrors the fixed WatchConfigChanges code path - copy
+	// endpoints under the read lock, then range over the snapshot.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stopCh:
+				return
+			default:
+				dm.EndPointsLock.RLock()
+				endPointsCopy := make([]tp.EndPoint, len(dm.EndPoints))
+				copy(endPointsCopy, dm.EndPoints)
+				dm.EndPointsLock.RUnlock()
+
+				for _, ep := range endPointsCopy {
+					_ = ep.NamespaceName
+				}
+				time.Sleep(1 * time.Millisecond)
+			}
+		}
+	}()
+
+	// Goroutine 2: concurrently mutates the endpoint slice under
+	// EndPointsLock, matching how container handlers update dm.EndPoints.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		counter := 100
+		for {
+			select {
+			case <-stopCh:
+				return
+			default:
+				dm.EndPointsLock.Lock()
+				if len(dm.EndPoints) > 0 {
+					dm.EndPoints = dm.EndPoints[:len(dm.EndPoints)-1]
+				}
+				dm.EndPoints = append(dm.EndPoints, tp.EndPoint{
+					NamespaceName: "test-namespace",
+					EndPointName:  fmt.Sprintf("test-endpoint-%d", counter),
+				})
+				counter++
+				dm.EndPointsLock.Unlock()
+				time.Sleep(1 * time.Millisecond)
+			}
+		}
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+	close(stopCh)
+	wg.Wait()
+
+	t.Log("config reload endpoint iteration race condition test completed without races")
+}


### PR DESCRIPTION
## Summary
- `WatchConfigChanges()` in `KubeArmor/core/unorchestratedUpdates.go` iterated `dm.EndPoints` directly on config reload without holding `dm.EndPointsLock`, unlike every other access to that slice in the daemon (e.g. `kubeUpdate.go`).
- This is an unsynchronized concurrent-access surface between config reload and endpoint-mutating operations (container add/remove, policy update).

## Linked Issue
Fixes #2759

## What Changed
- Take `dm.EndPointsLock.RLock()` to copy `dm.EndPoints` into a local snapshot, release the lock, then iterate the snapshot to perform per-endpoint posture/visibility updates.
- Added `KubeArmor/core/unorchestratedUpdates_race_test.go`, a targeted `-race` test that runs the fixed snapshot-and-iterate pattern concurrently against goroutines mutating `dm.EndPoints` under the same lock.

## Verification
- `gofmt -l` on changed files — passed (no output)
- `GOOS=linux GOARCH=amd64 go build ./core/...` — passed
- `GOOS=linux GOARCH=amd64 go vet ./core/...` — passed
- `go test ./core/... -run TestConfigReloadEndpointIterationRaceCondition -race` — not run: this repo's `core` package (via `KubeArmor/common` and `KubeArmor/utils/bpflsmprobe`) only compiles on Linux (uses Linux-only `golang.org/x/sys/unix` APIs), and no Linux toolchain/Docker was available in this environment; verified via Linux cross-compilation (build+vet above) instead
- `make gofmt` / `go-lint` (Revive) / `go-sec` / `go-vuln` / `go test ./...` (repo CI, `ci-test-go.yml`) — not run locally: these require a Linux runner and/or tools (Revive, Gosec, govulncheck) not installed in this environment; will run in upstream CI on this PR

## Scope
- Only `KubeArmor/core/unorchestratedUpdates.go` and the new test file were changed; no unrelated files were touched.