### PR TITLE
fix(core): resolve newendpoints typo to properly track all containers…

### DIFF
--- a/KubeArmor/core/kubeUpdate.go
+++ b/KubeArmor/core/kubeUpdate.go
@@ -527,10 +527,8 @@ func (dm *KubeArmorDaemon) UpdateEndPointWithPod(action string, pod tp.K8sPod) {
 						endpoint.SecurityPolicies = append(endpoint.SecurityPolicies, secPolicy)
 					}
 				}
-
 				newendpoints = append(newendpoints, endpoint)
 			}
-			
 			endpoints = newendpoints
 			dm.EndPointsLock.Lock()
 

--- a/KubeArmor/core/kubeUpdate.go
+++ b/KubeArmor/core/kubeUpdate.go
@@ -528,9 +528,10 @@ func (dm *KubeArmorDaemon) UpdateEndPointWithPod(action string, pod tp.K8sPod) {
 					}
 				}
 
-				endpoints = append(newendpoints, endpoint)
+				newendpoints = append(newendpoints, endpoint)
 			}
-
+			
+			endpoints = newendpoints
 			dm.EndPointsLock.Lock()
 
 			for nidx := 0; nidx < len(endpoints); nidx++ {


### PR DESCRIPTION
**Purpose of PR?**:
This PR fixes a critical typo in KubeArmor/core/kubeUpdate.go inside UpdateEndPointWithPod (for action == updateEvent). The typo caused the endpoint list endpoints to be overwritten to a single-element slice on every loop iteration instead of accumulating them. As a result, only the last container in the pod spec (determined by Go's non-deterministic map iteration order) was updated in dm.EndPoints, causing other restarted containers to run completely unprotected (bypassing security policies).

Fixes # (No  issue mentioned yet, but addresses the multi-container endpoint leak/bypass bug).

**Does this PR introduce a breaking change?**
No
**If the changes in this PR are manually verified, list down the scenarios covered:**:
1. Deploying Multi-Container Workload: Deployed a deployment with two containers container-a and container-b (with container-a listed first).
2. Applying a Policy: Applied a matching policy (bug-detector-policy) to ensure enforcer rules update triggers BPF map changes.
3. Container Restarts: Simulated container crashes by forcing container restarts via crictl stop on the non-last container (container-a).
4. Endpoint Tracking Validation (Patched vs. Unpatched):
    -Before Fix: Only one of the container IDs (typically the last container in spec or whichever map randomized last) got registered in dm.EndPoints during the updateEvent cycle. The restarted container remained untracked and bypassed security.
    -After Fix: Both containers' new/active container IDs are correctly captured in endpoints and committed to dm.EndPoints during pod update cycles. Log sweeps show Updating container rules for both active CIDs consistently.

**Additional information for reviewer?** :
Root Cause Analysis
During a pod status update (such as container restarts/crashes), UpdateEndPointWithPod processes the pod's container map:

```
newendpoints := []tp.EndPoint{}
for k, v := range pod.Containers {
    endpoint := newEndPoint
    // ... setup container fields ...
    endpoints = append(newendpoints, endpoint) // ← TYPO
}
```
In Go, append(slice, element) does not modify the slice in place; it returns a new slice. Since newendpoints is declared outside the loop but never assigned to, it remains empty [] on every pass. Assigning append(newendpoints, endpoint) directly to endpoints overwrites the slice to a length of 1 containing only the current container's endpoint.

Because pod.Containers is a Go map, its iteration order is randomized and non-deterministic. Which container survived the overwrite and got updated was random. The other container(s) were discarded and remained associated with their old, dead container IDs, causing new container instances to run unprotected.

The Fix
Accumulate into newendpoints on each iteration and assign to endpoints after the loop:
```
	-			endpoints = append(newendpoints, endpoint)
	-		}

	+			newendpoints = append(newendpoints, endpoint)
	+		}

	+		endpoints = newendpoints
 			dm.EndPointsLock.Lock()
 			
```
 
_*Logs Evidence and Replication Guide*_
Replication Setup
1. Deploy a multi-container deployment:

```
apiVersion: apps/v1
kind: Deployment
metadata:
  name: bug-detector
spec:
  replicas: 1
  selector:
    matchLabels:
      app: bug-detector
  template:
    metadata:
      labels:
        app: bug-detector
    spec:
      containers:
        - name: container-a
          image: busybox
          command: ['sh', '-c', 'sleep 3600']
        - name: container-b
          image: busybox
          command: ['sh', '-c', 'sleep 3600']

```
2. Apply a policy targeting the pods.
3. Fetch the container ID of the first container (container-a):
```
OLD_CID=$(kubectl get pod -l app=bug-detector -o jsonpath='{.items[0].status.containerStatuses[?(@.name=="container-a")].containerID}' | sed 's/containerd:\/\///')
```
4. Terminate the container via the kind node runtime:
```
docker exec kubearmor-play-control-plane crictl stop "$OLD_CID"
```
5. Wait for the pod to restart and capture the new CID(containerID):
```
NEW_CID=$(kubectl get pod -l app=bug-detector -o jsonpath='{.items[0].status.containerStatuses[?(@.name=="container-a")].containerID}' | sed 's/containerd:\/\///')
```
6. Toggle or apply a policy change to force reconciliation.

_Unpatched Behavior_
On an unpatched daemon, the new CID is missing from the enforcer reconciliation logs ~50% of the time:
```
=== Checking logs for new CID ===
NOT FOUND
=== Checking logs for old CID ===
Updating container rules for 72bfde4ebe6b...
```
_(Here, the daemon keeps updating rules for the dead container ID, leaving the new container completely unmonitored.)_

_Patched Behavior_
With the patch applied, the new CID is updated and reconciled successfully:
```
=== Checking logs for new CID ===
Updating container rules for e90778a74f67...
Updating container rules for e90778a74f67...
```

**Checklist:**
- [x] Bug fix. Fixes #(Addresses multi-container restart bypass)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Commit has unit tests
- [ ] Commit has integration tests

