### PR TITLE
fix(core): deduplicate config reload namespace updates

### DIFF
--- a/KubeArmor/core/unorchestratedUpdates.go
+++ b/KubeArmor/core/unorchestratedUpdates.go
@@ -46,6 +46,24 @@ func (dm *KubeArmorDaemon) SetContainerNSVisibility() {
 	dm.UpdateVisibility("ADDED", "container_namespace", visibility)
 }
 
+func uniqueEndpointNamespaces(endpoints []tp.EndPoint) []string {
+	namespaces := make([]string, 0, len(endpoints))
+	seen := make(map[string]struct{}, len(endpoints))
+
+	for _, ep := range endpoints {
+		if _, ok := seen[ep.NamespaceName]; ok {
+			continue
+		}
+
+		seen[ep.NamespaceName] = struct{}{}
+		namespaces = append(namespaces, ep.NamespaceName)
+	}
+
+	slices.Sort(namespaces)
+
+	return namespaces
+}
+
 // =================== //
 // == Config Update == //
 // =================== //
@@ -77,10 +95,15 @@ func (dm *KubeArmorDaemon) WatchConfigChanges() {
 		dm.UpdateGlobalPosture(globalPosture)
 
 		// Update default posture for endpoints
-		for _, ep := range dm.EndPoints {
-			dm.Logger.Printf("Updating Default Posture for endpoint %s", ep.EndPointName)
-			dm.UpdateDefaultPosture("MODIFIED", ep.NamespaceName, globalPosture, false)
-			dm.UpdateVisibility("MODIFIED", ep.NamespaceName, visibility)
+		dm.EndPointsLock.RLock()
+		endPointsCopy := make([]tp.EndPoint, len(dm.EndPoints))
+		copy(endPointsCopy, dm.EndPoints)
+		dm.EndPointsLock.RUnlock()
+
+		for _, namespace := range uniqueEndpointNamespaces(endPointsCopy) {
+			dm.Logger.Printf("Updating Default Posture for namespace %s", namespace)
+			dm.UpdateDefaultPosture("MODIFIED", namespace, globalPosture, false)
+			dm.UpdateVisibility("MODIFIED", namespace, visibility)
 		}
 
 		// Update throttling configs

--- a/KubeArmor/core/unorchestratedUpdates_race_test.go
+++ b/KubeArmor/core/unorchestratedUpdates_race_test.go
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Authors of KubeArmor
+
+package core
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	tp "github.com/kubearmor/KubeArmor/KubeArmor/types"
+)
+
+func TestConfigReloadEndpointIterationRaceCondition(t *testing.T) {
+	t.Parallel()
+
+	dm := &KubeArmorDaemon{
+		EndPoints:     []tp.EndPoint{},
+		EndPointsLock: &sync.RWMutex{},
+	}
+
+	for i := 0; i < 50; i++ {
+		dm.EndPoints = append(dm.EndPoints, tp.EndPoint{
+			NamespaceName: "test-namespace",
+			EndPointName:  fmt.Sprintf("test-endpoint-%d", i),
+		})
+	}
+
+	var wg sync.WaitGroup
+	stopCh := make(chan struct{})
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stopCh:
+				return
+			default:
+				dm.EndPointsLock.RLock()
+				endPointsCopy := make([]tp.EndPoint, len(dm.EndPoints))
+				copy(endPointsCopy, dm.EndPoints)
+				dm.EndPointsLock.RUnlock()
+
+				for _, namespace := range uniqueEndpointNamespaces(endPointsCopy) {
+					_ = namespace
+				}
+
+				time.Sleep(1 * time.Millisecond)
+			}
+		}
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		counter := 100
+		for {
+			select {
+			case <-stopCh:
+				return
+			default:
+				dm.EndPointsLock.Lock()
+				if len(dm.EndPoints) > 0 {
+					dm.EndPoints = dm.EndPoints[:len(dm.EndPoints)-1]
+				}
+				dm.EndPoints = append(dm.EndPoints, tp.EndPoint{
+					NamespaceName: "test-namespace",
+					EndPointName:  fmt.Sprintf("test-endpoint-%d", counter),
+				})
+				counter++
+				dm.EndPointsLock.Unlock()
+				time.Sleep(1 * time.Millisecond)
+			}
+		}
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+	close(stopCh)
+	wg.Wait()
+}

--- a/KubeArmor/core/unorchestratedUpdates_test.go
+++ b/KubeArmor/core/unorchestratedUpdates_test.go
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Authors of KubeArmor
+
+package core
+
+import (
+	"testing"
+
+	tp "github.com/kubearmor/KubeArmor/KubeArmor/types"
+)
+
+func TestUniqueEndpointNamespaces(t *testing.T) {
+	t.Parallel()
+
+	endpoints := []tp.EndPoint{
+		{NamespaceName: "team-b", EndPointName: "ep-1"},
+		{NamespaceName: "team-a", EndPointName: "ep-2"},
+		{NamespaceName: "team-b", EndPointName: "ep-3"},
+		{NamespaceName: "team-c", EndPointName: "ep-4"},
+		{NamespaceName: "team-a", EndPointName: "ep-5"},
+	}
+
+	namespaces := uniqueEndpointNamespaces(endpoints)
+	expected := []string{"team-a", "team-b", "team-c"}
+
+	if len(namespaces) != len(expected) {
+		t.Fatalf("expected %d namespaces, got %d (%v)", len(expected), len(namespaces), namespaces)
+	}
+
+	for idx, namespace := range expected {
+		if namespaces[idx] != namespace {
+			t.Fatalf("expected namespaces %v, got %v", expected, namespaces)
+		}
+	}
+}


### PR DESCRIPTION
**Purpose of PR?**:

## Summary
- deduplicate config-reload namespace updates so repeated endpoints in the same namespace do not replay the same posture and visibility work
- take an endpoint snapshot under `EndPointsLock` before iterating so the config-reload path reads a stable view of `dm.EndPoints`
- add focused tests for namespace deduplication and the concurrent snapshot pattern

## Linked Issue
Fixes #2762

## What Changed
- replaced per-endpoint config-reload updates with per-namespace updates derived from a deduplicated endpoint snapshot
- added `uniqueEndpointNamespaces` to centralize the namespace deduplication logic
- added focused unit and race-oriented coverage for the updated path

## Verification
- `make gofmt` — passed
- `go test ./...` — failed: Darwin host hits existing Linux-specific build errors in `common`/`utils` (`unix.Mount`, `unix.Sysinfo_t`, `unix.MemfdCreate`)
- `$(go env GOPATH)/bin/revive ./...` — failed: repository has many pre-existing lint findings unrelated to this change
- `$(go env GOPATH)/bin/gosec -exclude=G402,G115 ./...` — failed: analysis is blocked by the same Darwin/Linux type errors, though it reported `Issues: 0`
- `$(go env GOPATH)/bin/govulncheck ./...` — failed: toolchain/package resolution requires Go 1.26 while the available toolchain tops out at the Go 1.25 compatibility layer used here
- `cd tests && make` — not run: the current upstream tree does not contain `tests/Makefile`

## Scope
- only `KubeArmor/core/unorchestratedUpdates.go` and focused tests for that path were changed; unrelated files were not modified

**Does this PR introduce a breaking change?**

No.

**If the changes in this PR are manually verified, list down the scenarios covered:**:

- Not manually verified in a Linux/Kubernetes runtime in this environment.

**Additional information for reviewer?** :

- This change stays within the config-reload path and intentionally avoids broader refactoring.

**Checklist:**
- [x] Bug fix. Fixes #2762
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [x] Commit has unit tests
- [ ] Commit has integration tests
