### PR TITLE
fix(types): preserve endpoint privileged containers JSON compatibility

### DIFF
--- a/KubeArmor/types/types.go
+++ b/KubeArmor/types/types.go
@@ -5,6 +5,7 @@
 package types
 
 import (
+	"encoding/json"
 	"regexp"
 	"time"
 
@@ -93,8 +94,11 @@ type EndPoint struct {
 
 	SecurityPolicies []SecurityPolicy `json:"securityPolicies"`
 
-	// only needed for unorchestrated containers
-	PrivilegedContainers map[string]struct{} `json:"privilegdContainers"`
+	// only needed for unorchestrated containers.
+	// Keep the legacy misspelled JSON key during the transition so existing
+	// consumers continue to receive the field while new consumers can rely on
+	// the corrected privilegedContainers contract.
+	PrivilegedContainers map[string]struct{} `json:"privilegedContainers"`
 
 	// == //
 
@@ -105,6 +109,43 @@ type EndPoint struct {
 	FileVisibilityEnabled         bool `json:"fileVisibilityEnabled"`
 	NetworkVisibilityEnabled      bool `json:"networkVisibilityEnabled"`
 	CapabilitiesVisibilityEnabled bool `json:"capabilitiesVisibilityEnabled"`
+}
+
+type endPointJSON EndPoint
+
+// MarshalJSON emits both the corrected and legacy JSON keys for
+// PrivilegedContainers to preserve compatibility with existing consumers.
+func (ep EndPoint) MarshalJSON() ([]byte, error) {
+	type endpointCompat struct {
+		endPointJSON
+		LegacyPrivilegedContainers map[string]struct{} `json:"privilegdContainers"`
+	}
+
+	return json.Marshal(endpointCompat{
+		endPointJSON:               endPointJSON(ep),
+		LegacyPrivilegedContainers: ep.PrivilegedContainers,
+	})
+}
+
+// UnmarshalJSON accepts both the corrected and legacy JSON keys, preferring
+// the corrected field when both are present.
+func (ep *EndPoint) UnmarshalJSON(data []byte) error {
+	type endpointCompat struct {
+		endPointJSON
+		LegacyPrivilegedContainers map[string]struct{} `json:"privilegdContainers"`
+	}
+
+	var aux endpointCompat
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+
+	*ep = EndPoint(aux.endPointJSON)
+	if ep.PrivilegedContainers == nil && aux.LegacyPrivilegedContainers != nil {
+		ep.PrivilegedContainers = aux.LegacyPrivilegedContainers
+	}
+
+	return nil
 }
 
 // Node Structure

--- a/KubeArmor/types/types_test.go
+++ b/KubeArmor/types/types_test.go
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package types
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestEndPointMarshalJSONIncludesCorrectAndLegacyPrivilegedContainersKeys(t *testing.T) {
+	endpoint := EndPoint{
+		PrivilegedContainers: map[string]struct{}{
+			"demo": {},
+		},
+	}
+
+	data, err := json.Marshal(endpoint)
+	if err != nil {
+		t.Fatalf("marshal endpoint: %v", err)
+	}
+
+	var decoded map[string]any
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("unmarshal marshaled endpoint: %v", err)
+	}
+
+	for _, key := range []string{"privilegedContainers", "privilegdContainers"} {
+		value, ok := decoded[key]
+		if !ok {
+			t.Fatalf("expected JSON key %q in marshaled endpoint", key)
+		}
+		containers, ok := value.(map[string]any)
+		if !ok {
+			t.Fatalf("expected JSON key %q to contain an object", key)
+		}
+		if _, ok := containers["demo"]; !ok {
+			t.Fatalf("expected container name under JSON key %q", key)
+		}
+	}
+}
+
+func TestEndPointUnmarshalJSONAcceptsLegacyPrivilegedContainersKey(t *testing.T) {
+	var endpoint EndPoint
+
+	err := json.Unmarshal([]byte(`{"privilegdContainers":{"legacy":{}}}`), &endpoint)
+	if err != nil {
+		t.Fatalf("unmarshal endpoint with legacy key: %v", err)
+	}
+
+	if _, ok := endpoint.PrivilegedContainers["legacy"]; !ok {
+		t.Fatalf("expected legacy privileged container key to populate field")
+	}
+}
+
+func TestEndPointUnmarshalJSONPrefersCorrectPrivilegedContainersKey(t *testing.T) {
+	var endpoint EndPoint
+
+	err := json.Unmarshal([]byte(`{
+		"privilegedContainers":{"correct":{}},
+		"privilegdContainers":{"legacy":{}}
+	}`), &endpoint)
+	if err != nil {
+		t.Fatalf("unmarshal endpoint with both keys: %v", err)
+	}
+
+	if _, ok := endpoint.PrivilegedContainers["correct"]; !ok {
+		t.Fatalf("expected corrected key to populate field")
+	}
+	if _, ok := endpoint.PrivilegedContainers["legacy"]; ok {
+		t.Fatalf("expected corrected key to take precedence over legacy key")
+	}
+}


### PR DESCRIPTION
## Summary
- correct the canonical `EndPoint.PrivilegedContainers` JSON field name to `privilegedContainers`
- preserve the legacy `privilegdContainers` key during marshaling for downstream compatibility
- accept both keys during unmarshaling and add focused regression coverage in `KubeArmor/types`

## Linked Issue
Fixes #2768

## What Changed
- added custom `MarshalJSON` and `UnmarshalJSON` logic for `types.EndPoint`
- documented the compatibility behavior at the field definition
- added regression tests for corrected-key output, legacy-key input, and precedence when both keys are present

## Verification
- `cd KubeArmor && go test ./types` — passed
- `cd KubeArmor && make gofmt` — passed
- `cd KubeArmor && go test ./...` — failed: repository-wide build fails on this Darwin host in existing Linux-specific code paths (`unix.Mount`, `unix.Sysinfo`, `unix.MemfdCreate`) outside this change
- `cd tests && go test ./...` — failed: suite requires `kubectl` and a live local Kubernetes API/proxy; this environment has neither
- `cd KubeArmor && make` — failed: same existing Darwin/Linux build incompatibilities outside this change
- `cd KubeArmor && make gosec` — failed: target could not invoke `gosec` after tool installation attempt in this environment
- `cd KubeArmor && make scan` — failed: target could not invoke `govulncheck` after tool installation attempt in this environment

## Scope
- Only `KubeArmor/types/types.go` and `KubeArmor/types/types_test.go` were changed; unrelated files were not modified.

**Purpose of PR?**:
Fixes #2768

**Does this PR introduce a breaking change?**
No. The corrected key is added while the legacy misspelled key remains available during marshaling for compatibility.

**If the changes in this PR are manually verified, list down the scenarios covered:**:
- Marshaling an endpoint includes both `privilegedContainers` and `privilegdContainers`
- Unmarshaling accepts the legacy key
- When both keys are present, the corrected key wins

**Additional information for reviewer?** :
- Full repository build and integration checks are currently blocked on this macOS environment because the repo expects Linux-specific syscalls and a live Kubernetes test setup.

**Checklist:**
- [x] Bug fix. Fixes #2768
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [x] Commit has unit tests
- [ ] Commit has integration tests
