### PR TITLE
fix(controller): run scratch-based controller image as non-root UID 1000

### DIFF
--- a/pkg/KubeArmorController/Dockerfile
+++ b/pkg/KubeArmorController/Dockerfile
@@ -28,6 +28,7 @@ RUN CGO_ENABLED=0 GO111MODULE=on go build -a -o manager cmd/main.go
 FROM scratch AS controller
 WORKDIR /
 COPY --from=builder /workspace/manager .
+USER 1000
 ENTRYPOINT ["/manager"]
 
 # Build controller with ubi as base image


### PR DESCRIPTION
**Purpose of PR?**:
Fixes #2772

kubearmor-controller images since v1.7.1 run as root because the scratch-based `controller` build stage in `pkg/KubeArmorController/Dockerfile` has no `USER` directive. The chart's controller Deployment hardcodes `runAsNonRoot: true`, so a default helm install fails with `CreateContainerConfigError`.

This PR adds `USER 1000` to the scratch stage, matching the UID already used in the `controller-ubi` stage, so both image variants behave consistently and the chart's non-root assertion passes again.

**Does this PR introduce a breaking change?**

No. This restores the pre-v1.7.1 behavior, the controller ran as UID 1000 up to and including v1.7.0. No API, config, or chart changes.

**If the changes in this PR are manually verified, list down the scenarios covered:**:

- Built the patched image locally and confirmed the image config now declares a non-root user: `docker inspect kubearmor-controller-test:local --format '{{.Config.User}}'` returns `1000`.
 
<img width="1760" height="805" alt="Screenshot from 2026-07-14 20-07-05" src="https://github.com/user-attachments/assets/6e84dd7e-a054-46a4-b5ac-598a3898e82c" />

- Reproduced the exact repro steps from the issue on a local kind cluster with the patched image. Controller pod starts successfully instead of hitting `CreateContainerConfigError`.

<img width="1606" height="94" alt="Screenshot from 2026-07-14 20-06-26" src="https://github.com/user-attachments/assets/6e0bdb11-e19c-4b21-94b1-57b47a66787e" />

- Confirmed the pod-level `securityContext` still enforces `runAsNonRoot: true` and the container starts successfully under that constraint.

<img width="1595" height="40" alt="Screenshot from 2026-07-14 20-06-13" src="https://github.com/user-attachments/assets/0b8c4d11-af26-490c-9256-6aceb298d870" />

- Verified the binary itself runs correctly as UID 1000 with no filesystem permission issues. `--help` output and normal startup both behave as expected, the only error is the expected "no in-cluster kubeconfig" message when run standalone outside a cluster.

**Additional information for reviewer?** :

Scoped to only the root-user regression described in this issue. The separate arm64 binary mismatch (#2767) has a different root cause and is being tracked independently. I will follow up with a separate PR for that.

**Checklist:**
- [x] Bug fix. Fixes #2772
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Commit has unit tests
- [ ] Commit has integration tests