### PR TITLE
fix(state): guard StateEventChans iteration with StateEventChansLock

### DIFF
--- a/KubeArmor/state/data.go
+++ b/KubeArmor/state/data.go
@@ -75,6 +75,9 @@ func (sa *StateAgent) PushContainerEvent(container tp.Container, event string) {
 		Object: containerBytes,
 	}
 
+	sa.StateEventChansLock.RLock()
+	defer sa.StateEventChansLock.RUnlock()
+
 	// skip sending message as no state receiver is connected
 	if sa.StateEventChans == nil {
 		return
@@ -110,6 +113,9 @@ func (sa *StateAgent) PushNodeEvent(node tp.Node, event string) {
 		Object: nodeData,
 	}
 
+	sa.StateEventChansLock.RLock()
+	defer sa.StateEventChansLock.RUnlock()
+
 	// skip sending message as no state receiver is connected
 	if sa.StateEventChans == nil {
 		return
@@ -139,6 +145,9 @@ func (sa *StateAgent) PushNamespaceEvent(namespace tp.Namespace, event string) {
 		Name:   namespace.Name,
 		Object: nsBytes,
 	}
+
+	sa.StateEventChansLock.RLock()
+	defer sa.StateEventChansLock.RUnlock()
 
 	// skip sending message as no state receiver is connected
 	if sa.StateEventChans == nil {

--- a/KubeArmor/state/data_race_test.go
+++ b/KubeArmor/state/data_race_test.go
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Authors of KubeArmor
+
+package state
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+
+	tp "github.com/kubearmor/KubeArmor/KubeArmor/types"
+)
+
+func newTestStateAgent() *StateAgent {
+	node := &tp.Node{NodeName: "test-node"}
+	return NewStateAgent(node, new(sync.RWMutex), map[string]tp.Container{}, new(sync.RWMutex))
+}
+
+// TestPushContainerEventRace demonstrates the unsynchronized read of
+// sa.StateEventChans in PushContainerEvent racing with clients
+// connecting/disconnecting (addStateEventChan/removeStateEventChan).
+// Run with -race to observe the data race.
+func TestPushContainerEventRace(t *testing.T) {
+	sa := newTestStateAgent()
+
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+
+	// simulate WatchState clients connecting and disconnecting
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; ; i++ {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			uid, conn := sa.addStateEventChan()
+			// drain a bit like WatchState would
+			select {
+			case <-conn:
+			default:
+			}
+			sa.removeStateEventChan(uid)
+			_ = i
+		}
+	}()
+
+	// simulate container events pushed by the runtime handlers
+	// (containerdHandler/dockerHandler call these via `go ...`)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 5000; i++ {
+			sa.PushContainerEvent(tp.Container{
+				ContainerID:   fmt.Sprintf("c%d", i),
+				ContainerName: "nginx",
+				NamespaceName: "default",
+			}, EventAdded)
+		}
+		close(stop)
+	}()
+
+	wg.Wait()
+}

--- a/KubeArmor/state/data_race_test.go
+++ b/KubeArmor/state/data_race_test.go
@@ -30,7 +30,7 @@ func TestPushContainerEventRace(t *testing.T) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		for i := 0; ; i++ {
+		for {
 			select {
 			case <-stop:
 				return
@@ -43,7 +43,6 @@ func TestPushContainerEventRace(t *testing.T) {
 			default:
 			}
 			sa.removeStateEventChan(uid)
-			_ = i
 		}
 	}()
 


### PR DESCRIPTION
**Purpose of PR?**:

Fixes #2774

`PushContainerEvent`, `PushNodeEvent` and `PushNamespaceEvent` in `KubeArmor/state/data.go` iterate `sa.StateEventChans` without holding `StateEventChansLock`, while `addStateEventChan`/`removeStateEventChan` mutate the map and close the channels under that lock on every `WatchState` client connect/disconnect. Since the runtime handlers push events from separate goroutines (`go dm.StateAgent.PushContainerEvent(...)`), a client disconnecting mid-broadcast crashes the daemon with `fatal error: concurrent map iteration and map write` or `panic: send on closed channel`.

This PR takes `StateEventChansLock.RLock()` around the broadcast loop in all three functions. The sends are already non-blocking (`select`/`default`), so holding the read lock during fan-out is cheap, and because `removeStateEventChan` closes channels under the write lock, the read lock also rules out the send-on-closed-channel panic.

**Does this PR introduce a breaking change?**

No.

**If the changes in this PR are manually verified, list down the scenarios covered:**:

- Added `TestPushContainerEventRace` which simulates `WatchState` clients connecting/disconnecting concurrently with container event pushes. On current `main` it fails under `go test -race` (data race between `PushContainerEvent` and `removeStateEventChan`) and also panics with `send on closed channel`. With this fix, `go test -race -count=1 -run TestPushContainerEventRace ./state/` passes.
- `go vet ./state/` clean.

**Additional information for reviewer?** :

Failure output on `main` without the fix:

```
WARNING: DATA RACE
Read at ... by goroutine 11:
  ...state.(*StateAgent).PushContainerEvent()  KubeArmor/state/data.go:85
Previous write at ... by goroutine 10:
  runtime.closechan()
  ...state.(*StateAgent).removeStateEventChan() KubeArmor/state/stateAgent.go:92
...
panic: send on closed channel
```

**Checklist:**
- [x] Bug fix. Fixes #2774
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [x] Commit has unit tests
- [ ] Commit has integration tests


