### PR TITLE
fix(common): add build tags to Linux-only files so go test works on macOS

### DIFF
--- a/KubeArmor/common/boottime_linux.go
+++ b/KubeArmor/common/boottime_linux.go
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Authors of KubeArmor
+
+//go:build linux
+
+package common
+
+import (
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+// GetBootTime returns the system boot time as a UTC string.
+// credits: https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/util/boottime_util_linux.go
+func GetBootTime() string {
+	currentTime := time.Now()
+
+	var info unix.Sysinfo_t
+	if err := unix.Sysinfo(&info); err != nil {
+		return ""
+	}
+
+	return currentTime.Add(-time.Duration(info.Uptime) * time.Second).Truncate(time.Second).UTC().String()
+}

--- a/KubeArmor/common/boottime_unsupported.go
+++ b/KubeArmor/common/boottime_unsupported.go
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Authors of KubeArmor
+
+//go:build !linux
+
+package common
+
+// GetBootTime is not supported on non-Linux platforms and always returns an empty string.
+func GetBootTime() string {
+	return ""
+}

--- a/KubeArmor/common/bpffs.go
+++ b/KubeArmor/common/bpffs.go
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2026 Authors of KubeArmor
 
+//go:build linux
+
 package common
 
 // This implementation for automounting bpffs has been inspired from

--- a/KubeArmor/common/common.go
+++ b/KubeArmor/common/common.go
@@ -25,7 +25,6 @@ import (
 	kc "github.com/kubearmor/KubeArmor/KubeArmor/config"
 	kg "github.com/kubearmor/KubeArmor/KubeArmor/log"
 	tp "github.com/kubearmor/KubeArmor/KubeArmor/types"
-	"golang.org/x/sys/unix"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -677,19 +676,6 @@ func HandleGRPCErrors(err error) error {
 	}
 
 	return nil
-}
-
-// get boot time
-// credits: https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/util/boottime_util_linux.go
-func GetBootTime() string {
-	currentTime := time.Now()
-
-	var info unix.Sysinfo_t
-	if err := unix.Sysinfo(&info); err != nil {
-		return ""
-	}
-
-	return currentTime.Add(-time.Duration(info.Uptime) * time.Second).Truncate(time.Second).UTC().String()
 }
 
 func GetLabelsFromString(labelString string) (map[string]string, []string) {

--- a/KubeArmor/utils/bpflsmprobe/probe.go
+++ b/KubeArmor/utils/bpflsmprobe/probe.go
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2026 Authors of KubeArmor
 
+//go:build linux
+
 // Package probe checks whether the probed LSM support is available.
 package probe
 


### PR DESCRIPTION
**Purpose of PR?**:

Fixes #2757

`bpffs.go`, `probe.go`, and `GetBootTime()` in `common.go` all use Linux-specific syscalls (`unix.Mount`, `unix.MemfdCreate`, `unix.Sysinfo`) that are unavailable on macOS and other non-Linux platforms. Without `//go:build linux` constraints, `go test` fails at compile time on `darwin/arm64` before any tests run.

This blocked non-Linux contributors from running unit tests in `./policy`, `./networkPolicyEnforcer`, `./feeder`, and `./core`.

**Does this PR introduce a breaking change?**

No. Linux CI behavior is unchanged. Non-Linux builds now compile correctly using stubs.

**If the changes in this PR are manually verified, list down the scenarios covered:**

- `GOOS=linux go build ./common/... ./utils/bpflsmprobe/...` — succeeds (real implementations)
- `GOOS=darwin go build ./common/... ./utils/bpflsmprobe/...` — succeeds (stub for GetBootTime, probe package skipped)
- Verified locally on `darwin/arm64` that the build errors from the issue no longer occur

**Additional information for reviewer?**

Changes:
- Added `//go:build linux` to `KubeArmor/common/bpffs.go` (entirely Linux-specific)
- Added `//go:build linux` to `KubeArmor/utils/bpflsmprobe/probe.go` (entirely Linux-specific)
- Moved `GetBootTime()` from `common.go` into new `boottime_linux.go` (with `//go:build linux`) and added a `boottime_unsupported.go` stub returning `""` for non-Linux
- Removed the now-unnecessary `golang.org/x/sys/unix` import from `common.go`

**Checklist:**
- [x] Bug fix. Fixes #2757
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] PR Title follows the convention of `<type>(<scope>): <subject>`
- [ ] Commit has unit tests
- [ ] Commit has integration tests