### PR TITLE
fix(controller): restart StatefulSets and DaemonSets in pod refresher

### DIFF
--- a/pkg/KubeArmorController/internal/controller/podrefresh_controller.go
+++ b/pkg/KubeArmorController/internal/controller/podrefresh_controller.go
@@ -24,7 +24,7 @@ type PodRefresherReconciler struct {
 	client.Client
 	Scheme           *runtime.Scheme
 	Cluster          *types.Cluster
-	ClientSet        *kubernetes.Clientset
+	ClientSet        kubernetes.Interface
 	AnnotateExisting bool
 }
 type ResourceInfo struct {
@@ -182,7 +182,7 @@ func requireRestart(pod corev1.Pod, enforcer string) bool {
 
 	return false
 }
-func restartResources(resourcesMap map[string]ResourceInfo, corev1 *kubernetes.Clientset) error {
+func restartResources(resourcesMap map[string]ResourceInfo, corev1 kubernetes.Interface) error {
 
 	ctx := context.Background()
 	log := log.FromContext(ctx)
@@ -205,7 +205,7 @@ func restartResources(resourcesMap map[string]ResourceInfo, corev1 *kubernetes.C
 			if err != nil {
 				log.Error(err, fmt.Sprintf("error updating deployment %s in namespace %s", name, resInfo.namespaceName))
 			}
-		case "Statefulset":
+		case "StatefulSet":
 			statefulSet, err := corev1.AppsV1().StatefulSets(resInfo.namespaceName).Get(ctx, name, metav1.GetOptions{})
 			if err != nil {
 				log.Error(err, fmt.Sprintf("error getting statefulset %s in namespace %s", name, resInfo.namespaceName))
@@ -223,7 +223,7 @@ func restartResources(resourcesMap map[string]ResourceInfo, corev1 *kubernetes.C
 				log.Error(err, fmt.Sprintf("error updating statefulset %s in namespace %s", name, resInfo.namespaceName))
 			}
 
-		case "Daemonset":
+		case "DaemonSet":
 			daemonSet, err := corev1.AppsV1().DaemonSets(resInfo.namespaceName).Get(ctx, name, metav1.GetOptions{})
 			if err != nil {
 				log.Error(err, fmt.Sprintf("error getting daemonset %s in namespace %s", name, resInfo.namespaceName))

--- a/pkg/KubeArmorController/internal/controller/podrefresh_controller_test.go
+++ b/pkg/KubeArmorController/internal/controller/podrefresh_controller_test.go
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Authors of KubeArmor
+
+package controllers
+
+import (
+	"context"
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/kubearmor/KubeArmor/pkg/KubeArmorController/common"
+)
+
+func TestRestartResourcesCanonicalKinds(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		kind      string
+		resource  string
+		clientset *fake.Clientset
+		verify    func(context.Context, *testing.T, *fake.Clientset)
+	}{
+		{
+			name:     "deployment",
+			kind:     "Deployment",
+			resource: "deploy",
+			clientset: fake.NewSimpleClientset(&appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{Name: "deploy", Namespace: "default"},
+				Spec:       appsv1.DeploymentSpec{Template: corev1.PodTemplateSpec{}},
+			}),
+			verify: func(ctx context.Context, t *testing.T, clientset *fake.Clientset) {
+				t.Helper()
+				deployment, err := clientset.AppsV1().Deployments("default").Get(ctx, "deploy", metav1.GetOptions{})
+				if err != nil {
+					t.Fatalf("get deployment: %v", err)
+				}
+				assertRestartAnnotation(t, deployment.Spec.Template.Annotations)
+			},
+		},
+		{
+			name:     "statefulset",
+			kind:     "StatefulSet",
+			resource: "stateful",
+			clientset: fake.NewSimpleClientset(&appsv1.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{Name: "stateful", Namespace: "default"},
+				Spec:       appsv1.StatefulSetSpec{Template: corev1.PodTemplateSpec{}},
+			}),
+			verify: func(ctx context.Context, t *testing.T, clientset *fake.Clientset) {
+				t.Helper()
+				statefulSet, err := clientset.AppsV1().StatefulSets("default").Get(ctx, "stateful", metav1.GetOptions{})
+				if err != nil {
+					t.Fatalf("get statefulset: %v", err)
+				}
+				assertRestartAnnotation(t, statefulSet.Spec.Template.Annotations)
+			},
+		},
+		{
+			name:     "daemonset",
+			kind:     "DaemonSet",
+			resource: "daemon",
+			clientset: fake.NewSimpleClientset(&appsv1.DaemonSet{
+				ObjectMeta: metav1.ObjectMeta{Name: "daemon", Namespace: "default"},
+				Spec:       appsv1.DaemonSetSpec{Template: corev1.PodTemplateSpec{}},
+			}),
+			verify: func(ctx context.Context, t *testing.T, clientset *fake.Clientset) {
+				t.Helper()
+				daemonSet, err := clientset.AppsV1().DaemonSets("default").Get(ctx, "daemon", metav1.GetOptions{})
+				if err != nil {
+					t.Fatalf("get daemonset: %v", err)
+				}
+				assertRestartAnnotation(t, daemonSet.Spec.Template.Annotations)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := restartResources(map[string]ResourceInfo{
+				tt.resource: {
+					kind:          tt.kind,
+					namespaceName: "default",
+				},
+			}, tt.clientset)
+			if err != nil {
+				t.Fatalf("restartResources returned error: %v", err)
+			}
+
+			tt.verify(context.Background(), t, tt.clientset)
+		})
+	}
+}
+
+func assertRestartAnnotation(t *testing.T, annotations map[string]string) {
+	t.Helper()
+
+	if annotations == nil {
+		t.Fatal("expected restart annotation map to be initialized")
+	}
+	if annotations[common.KubeArmorRestartedAnnotation] == "" {
+		t.Fatalf("expected %q annotation to be set", common.KubeArmorRestartedAnnotation)
+	}
+}


### PR DESCRIPTION
**Purpose of PR?**:

Fixes #2790

**Does this PR introduce a breaking change?**

No.

**If the changes in this PR are manually verified, list down the scenarios covered:**:

- Verified that `restartResources()` now handles canonical `Deployment`, `StatefulSet`, and `DaemonSet` kinds.
- Added regression coverage for the restart annotation path using a fake Kubernetes client.

**Additional information for reviewer?** :

This is a scoped controller fix only. No unrelated files were changed.

**Checklist:**
- [x] Bug fix. Fixes #2790
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [x] Commit has unit tests
- [ ] Commit has integration tests

## Summary
- fix the pod refresher switch cases for canonical `StatefulSet` and `DaemonSet` owner kinds
- make `restartResources()` accept `kubernetes.Interface` so the regression can be covered with a fake client
- add focused regression tests for Deployment, StatefulSet, and DaemonSet restart annotation updates

## Linked Issue
Fixes #2790

## What Changed
- switch `restartResources()` from `Statefulset`/`Daemonset` to `StatefulSet`/`DaemonSet`
- change the controller client field and helper signature from `*kubernetes.Clientset` to `kubernetes.Interface`
- add `podrefresh_controller_test.go` covering canonical controller kinds

## Verification
- `go test -count=1 -v ./internal/controller/podrefresh_controller.go ./internal/controller/podrefresh_controller_test.go` — passed
- `make build` — passed
- `make test` — not run successfully: envtest bootstrap fetched an unreadable archive (`tar: Error opening archive: Unrecognized archive format`)
- `go test ./internal/controller -run TestRestartResourcesCanonicalKinds -count=1 -v` — not run successfully: existing `suite_test.go` fails before tests with `Unknown Decorator` from `BeforeSuite(..., 60)`
- `make docker-build TAG=latest` — not completed: local Docker CLI hung during the final in-image `go build` step
- Controller/operator smoke deployment steps from `contribution/testing_operator_controller_guide.md` — not run: local environment does not have `kubectl` or `helm` installed

## Scope
- only `pkg/KubeArmorController/internal/controller/podrefresh_controller.go` and a new focused test file were changed; unrelated files were not modified
