### PR TITLE
fix(presets): remove duplicate go:generate in filelessexec

### DIFF
--- a/KubeArmor/presets/filelessexec/preset.go
+++ b/KubeArmor/presets/filelessexec/preset.go
@@ -28,8 +28,6 @@ import (
 	tp "github.com/kubearmor/KubeArmor/KubeArmor/types"
 )
 
-//go:generate go run github.com/cilium/ebpf/cmd/bpf2go -cc clang filelessexec  ../../BPF/filelessexec.bpf.c -type event -no-global-types -- -I/usr/include/ -O2 -g -Wno-missing-declarations
-
 var (
 	_ base.PresetInterface = (*Preset)(nil)
 )


### PR DESCRIPTION
**Purpose of PR?**:

Remove a duplicated `//go:generate` bpf2go directive from `filelessexec` so `go generate` runs code generation once, consistent with the other preset packages.

Fixes #2792 

**Does this PR introduce a breaking change?**

No.

**If the changes in this PR are manually verified, list down the scenarios covered:**

- Single remaining `//go:generate` in `KubeArmor/presets/filelessexec/preset.go`
- `go generate -n ./presets/filelessexec` prints bpf2go only once
- No runtime or generated-object changes

**Additional information for reviewer?** :

Small tooling cleanup only. Not part of a design; no functional change.

**Checklist:**
- [x] Bug fix. Fixes #2792
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] PR Title follows the convention of `<type>(<scope>): <subject>`
- [ ] Commit has unit tests
- [ ] Commit has integration tests