### PR TITLE
fix(presets): stop writing ContainerMap under RLock in anonmapexec

### DIFF
--- a/KubeArmor/presets/anonmapexec/preset.go
+++ b/KubeArmor/presets/anonmapexec/preset.go
@@ -285,19 +285,20 @@ func (p *Preset) UpdateSecurityPolicies(endPoint tp.EndPoint) {
 					p.ContainerMapLock.RLock()
 					// Check if Container ID is registered in Map or not
 					ckv, ok := p.ContainerMap[cid]
+					p.ContainerMapLock.RUnlock()
 					if !ok {
 						// It maybe possible that CRI has unregistered the containers but K8s construct still has not sent this update while the policy was being applied,
 						// so the need to check if the container is present in the map before we apply policy.
-						p.ContainerMapLock.RUnlock()
 						return
 					}
 					base.UpdateMatchPolicy(&ckv, &secPolicy)
+					p.ContainerMapLock.Lock()
 					p.ContainerMap[cid] = ckv
 					err := p.AddContainerIDToMap(cid, ckv.NsKey, preset.Action)
 					if err != nil {
 						p.Logger.Warnf("Updating policy for container %s :%s ", cid, err)
 					}
-					p.ContainerMapLock.RUnlock()
+					p.ContainerMapLock.Unlock()
 				}
 			}
 		}


### PR DESCRIPTION
**Purpose of PR?**

Fix a data race in the AnonMapExec preset `UpdateSecurityPolicies` wrote `ContainerMap` while holding a read only lock.

Fixes #2796 

**Does this PR introduce a breaking change?**

No.

**If the changes in this PR are manually verified, list down the scenarios covered:**:

- Locking order now matches the other presets
- Map write only under exclusive `Lock`

**Additional information for reviewer?**

No.

**Checklist:**
- [x] Bug fix. Fixes #2796
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] PR Title follows the convention of `<type>(<scope>): <subject>`
- [ ] Commit has unit tests
- [ ] Commit has integration tests