### PR TITLE
fix(controller): sanitize standalone pod recreation

### DIFF
--- a/pkg/KubeArmorController/internal/controller/podrefresh_controller.go
+++ b/pkg/KubeArmorController/internal/controller/podrefresh_controller.go
@@ -6,6 +6,8 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"maps"
+	"slices"
 	"time"
 
 	"github.com/kubearmor/KubeArmor/pkg/KubeArmorController/common"
@@ -134,11 +136,9 @@ func (r *PodRefresherReconciler) Reconcile(ctx context.Context, req ctrl.Request
 					}
 				}
 
-				// clean the pre-polutated attributes
-				pod.ResourceVersion = ""
-
 				// re-create the pod
-				if err := r.Create(ctx, &pod); err != nil {
+				podToCreate := podForRecreate(&pod)
+				if err := r.Create(ctx, podToCreate); err != nil {
 					log.Error(err, "Could not create pod "+pod.Name+" in namespace "+pod.Namespace)
 				}
 				poddeleted = true
@@ -182,6 +182,21 @@ func requireRestart(pod corev1.Pod, enforcer string) bool {
 
 	return false
 }
+
+func podForRecreate(pod *corev1.Pod) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:         pod.Name,
+			GenerateName: pod.GenerateName,
+			Namespace:    pod.Namespace,
+			Labels:       maps.Clone(pod.Labels),
+			Annotations:  maps.Clone(pod.Annotations),
+			Finalizers:   slices.Clone(pod.Finalizers),
+		},
+		Spec: *pod.Spec.DeepCopy(),
+	}
+}
+
 func restartResources(resourcesMap map[string]ResourceInfo, corev1 *kubernetes.Clientset) error {
 
 	ctx := context.Background()

--- a/pkg/KubeArmorController/internal/controller/podrefresh_controller_test.go
+++ b/pkg/KubeArmorController/internal/controller/podrefresh_controller_test.go
@@ -1,0 +1,126 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Authors of KubeArmor
+
+package controllers
+
+import (
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func TestPodForRecreateClearsServerPopulatedFields(t *testing.T) {
+	deletionTime := metav1.NewTime(time.Now())
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "standalone",
+			Namespace:         "default",
+			UID:               types.UID("server-uid"),
+			ResourceVersion:   "12345",
+			Generation:        2,
+			CreationTimestamp: metav1.NewTime(time.Now()),
+			DeletionTimestamp: &deletionTime,
+			ManagedFields: []metav1.ManagedFieldsEntry{
+				{Manager: "kube-apiserver"},
+			},
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+		},
+	}
+
+	recreated := podForRecreate(pod)
+
+	if recreated.UID != "" {
+		t.Fatalf("expected UID to be cleared, got %q", recreated.UID)
+	}
+	if recreated.ResourceVersion != "" {
+		t.Fatalf("expected resource version to be cleared, got %q", recreated.ResourceVersion)
+	}
+	if recreated.Generation != 0 {
+		t.Fatalf("expected generation to be cleared, got %d", recreated.Generation)
+	}
+	if !recreated.CreationTimestamp.IsZero() {
+		t.Fatalf("expected creation timestamp to be cleared, got %s", recreated.CreationTimestamp)
+	}
+	if recreated.DeletionTimestamp != nil {
+		t.Fatalf("expected deletion timestamp to be cleared, got %s", recreated.DeletionTimestamp)
+	}
+	if len(recreated.ManagedFields) != 0 {
+		t.Fatalf("expected managed fields to be cleared, got %v", recreated.ManagedFields)
+	}
+	if recreated.Status.Phase != "" {
+		t.Fatalf("expected status to be cleared, got %q", recreated.Status.Phase)
+	}
+}
+
+func TestPodForRecreatePreservesUserSettableFields(t *testing.T) {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:         "standalone",
+			GenerateName: "standalone-",
+			Namespace:    "default",
+			Labels: map[string]string{
+				"app": "demo",
+			},
+			Annotations: map[string]string{
+				"kubearmor-policy": "enabled",
+			},
+			Finalizers: []string{"example.com/finalizer"},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name:  "app",
+					Image: "nginx:latest",
+				},
+			},
+			RestartPolicy: corev1.RestartPolicyAlways,
+		},
+	}
+
+	recreated := podForRecreate(pod)
+
+	if recreated.Name != pod.Name {
+		t.Fatalf("expected name %q, got %q", pod.Name, recreated.Name)
+	}
+	if recreated.GenerateName != pod.GenerateName {
+		t.Fatalf("expected generate name %q, got %q", pod.GenerateName, recreated.GenerateName)
+	}
+	if recreated.Namespace != pod.Namespace {
+		t.Fatalf("expected namespace %q, got %q", pod.Namespace, recreated.Namespace)
+	}
+	if recreated.Labels["app"] != "demo" {
+		t.Fatalf("expected labels to be preserved, got %v", recreated.Labels)
+	}
+	if recreated.Annotations["kubearmor-policy"] != "enabled" {
+		t.Fatalf("expected annotations to be preserved, got %v", recreated.Annotations)
+	}
+	if len(recreated.Finalizers) != 1 || recreated.Finalizers[0] != "example.com/finalizer" {
+		t.Fatalf("expected finalizers to be preserved, got %v", recreated.Finalizers)
+	}
+	if len(recreated.Spec.Containers) != 1 || recreated.Spec.Containers[0].Name != "app" {
+		t.Fatalf("expected pod spec to be preserved, got %v", recreated.Spec)
+	}
+
+	pod.Labels["app"] = "changed"
+	pod.Annotations["kubearmor-policy"] = "changed"
+	pod.Finalizers[0] = "changed"
+	pod.Spec.Containers[0].Name = "changed"
+
+	if recreated.Labels["app"] != "demo" {
+		t.Fatalf("expected labels to be copied, got %v", recreated.Labels)
+	}
+	if recreated.Annotations["kubearmor-policy"] != "enabled" {
+		t.Fatalf("expected annotations to be copied, got %v", recreated.Annotations)
+	}
+	if recreated.Finalizers[0] != "example.com/finalizer" {
+		t.Fatalf("expected finalizers to be copied, got %v", recreated.Finalizers)
+	}
+	if recreated.Spec.Containers[0].Name != "app" {
+		t.Fatalf("expected pod spec to be copied, got %v", recreated.Spec.Containers)
+	}
+}


### PR DESCRIPTION
**Purpose of PR?**:

Fixes #2798

**Does this PR introduce a breaking change?**

No.

**If the changes in this PR are manually verified, list down the scenarios covered:**:

- Verified the standalone pod recreate helper clears server-populated metadata before create.
- Verified it preserves user-settable metadata and pod spec fields.

**Additional information for reviewer?** :
_Mention if this PR is part of any design or a continuation of previous PRs_

Not applicable.

**Checklist:**
- [x] Bug fix. Fixes #2798
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [x] Commit has unit tests
- [ ] Commit has integration tests

## Summary
- Sanitize standalone pod recreate requests by constructing a clean pod object instead of reusing the deleted live object.
- Copy only user-settable metadata and the pod spec into the recreate object.
- Add focused unit coverage for clearing server-populated fields and preserving user-settable fields.

## Linked Issue
Fixes #2798

## What Changed
- Added `podForRecreate` for standalone pod recreation.
- Updated the standalone pod restart path to use the sanitized recreate object.
- Added regression tests for metadata cleanup and copied pod state.

## Verification
- `git diff --check` — passed
- `make fmt` in `pkg/KubeArmorController` — passed
- `make vet` in `pkg/KubeArmorController` — passed
- `go test ./internal/controller/podrefresh_controller.go ./internal/controller/podrefresh_controller_test.go` in `pkg/KubeArmorController` — passed
- `make build` in `pkg/KubeArmorController` — passed
- `go test ./...` in `pkg/KubeArmorController` — failed: existing `suite_test.go` uses a raw `60` Ginkgo decorator, which current Ginkgo rejects before selected tests run
- `make test` in `pkg/KubeArmorController` — failed: envtest asset fetch for `tools@1.19.2` downloaded an unrecognized archive before tests ran

## Scope
- Only the pod refresher implementation and focused controller unit tests were changed.