### PR TITLE
fix(controller): target pod refresher reconcile

### DIFF
--- a/pkg/KubeArmorController/internal/controller/podrefresh_controller.go
+++ b/pkg/KubeArmorController/internal/controller/podrefresh_controller.go
@@ -24,7 +24,7 @@ type PodRefresherReconciler struct {
 	client.Client
 	Scheme           *runtime.Scheme
 	Cluster          *types.Cluster
-	ClientSet        *kubernetes.Clientset
+	ClientSet        kubernetes.Interface
 	AnnotateExisting bool
 }
 type ResourceInfo struct {
@@ -37,122 +37,113 @@ type ResourceInfo struct {
 func (r *PodRefresherReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 
 	log := log.FromContext(ctx)
-	var podList corev1.PodList
+	var pod corev1.Pod
 
-	if err := r.List(ctx, &podList); err != nil {
-		log.Error(err, "Unable to list pods")
+	if err := r.Get(ctx, req.NamespacedName, &pod); err != nil {
+		log.Error(err, "Unable to get pod")
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
 	log.Info("Watching for blocked pods")
-	poddeleted := false
 	deploymentMap := make(map[string]ResourceInfo)
-	for _, pod := range podList.Items {
-		if pod.DeletionTimestamp != nil {
-			continue
+	if pod.DeletionTimestamp != nil {
+		return ctrl.Result{}, nil
+	}
+	if pod.Spec.NodeName == "" {
+		return ctrl.Result{}, nil
+	}
+	r.Cluster.ClusterLock.RLock()
+	if _, exist := r.Cluster.Nodes[pod.Spec.NodeName]; exist {
+		if !r.Cluster.Nodes[pod.Spec.NodeName].KubeArmorActive {
+			log.Info(fmt.Sprintf("skip annotating pod as kubearmor not present on node %s", pod.Spec.NodeName))
+			r.Cluster.ClusterLock.RUnlock()
+			return ctrl.Result{}, nil
 		}
-		if pod.Spec.NodeName == "" {
-			continue
-		}
-		r.Cluster.ClusterLock.RLock()
-		if _, exist := r.Cluster.Nodes[pod.Spec.NodeName]; exist {
-			if !r.Cluster.Nodes[pod.Spec.NodeName].KubeArmorActive {
-				log.Info(fmt.Sprintf("skip annotating pod as kubearmor not present on node %s", pod.Spec.NodeName))
-				r.Cluster.ClusterLock.RUnlock()
-				continue
+	}
+	enforcer := ""
+	if _, ok := r.Cluster.Nodes[pod.Spec.NodeName]; ok {
+		enforcer = "apparmor"
+	} else {
+		enforcer = "bpf"
+	}
+	r.Cluster.ClusterLock.RUnlock()
+
+	if _, ok := pod.Annotations["kubearmor-policy"]; !ok {
+		orginalPod := pod.DeepCopy()
+		common.AddCommonAnnotations(&pod.ObjectMeta)
+		patch := client.MergeFrom(orginalPod)
+		err := r.Patch(ctx, &pod, patch)
+		if err != nil {
+			if !errors.IsNotFound(err) {
+				log.Info(fmt.Sprintf("Failed to patch pod annotations: %s", err.Error()))
 			}
 		}
-		enforcer := ""
-		if _, ok := r.Cluster.Nodes[pod.Spec.NodeName]; ok {
-			enforcer = "apparmor"
-		} else {
-			enforcer = "bpf"
-		}
-		r.Cluster.ClusterLock.RUnlock()
+	}
 
-		if _, ok := pod.Annotations["kubearmor-policy"]; !ok {
-			orginalPod := pod.DeepCopy()
-			common.AddCommonAnnotations(&pod.ObjectMeta)
-			patch := client.MergeFrom(orginalPod)
-			err := r.Patch(ctx, &pod, patch)
-			if err != nil {
-				if !errors.IsNotFound(err) {
-					log.Info(fmt.Sprintf("Failed to patch pod annotations: %s", err.Error()))
-				}
-			}
-		}
+	// restart not required for special pods and already annotated pods
 
-		// restart not required for special pods and already annotated pods
+	restartPod := requireRestart(pod, enforcer)
+	if restartPod {
+		// for annotating pre-existing pods on apparmor-nodes
+		// the pod is managed by a controller (e.g: replicaset)
+		if pod.OwnerReferences != nil && len(pod.OwnerReferences) != 0 {
+			// log.Info("Deleting pod " + pod.Name + "in namespace " + pod.Namespace + " as it is managed")
+			for _, ref := range pod.OwnerReferences {
 
-		restartPod := requireRestart(pod, enforcer)
-		if restartPod {
-			// for annotating pre-existing pods on apparmor-nodes
-			// the pod is managed by a controller (e.g: replicaset)
-			if pod.OwnerReferences != nil && len(pod.OwnerReferences) != 0 {
-				// log.Info("Deleting pod " + pod.Name + "in namespace " + pod.Namespace + " as it is managed")
-				for _, ref := range pod.OwnerReferences {
-
-					if *ref.Controller {
-						if ref.Kind == "ReplicaSet" {
-							replicaSet, err := r.ClientSet.AppsV1().ReplicaSets(pod.Namespace).Get(ctx, ref.Name, metav1.GetOptions{})
-							if err != nil {
-								log.Error(err, fmt.Sprintf("Failed to get ReplicaSet %s:", ref.Name))
-								continue
-							}
-							// Check if the ReplicaSet is managed by a Deployment
-							for _, rsOwnerRef := range replicaSet.OwnerReferences {
-								if rsOwnerRef.Kind == "Deployment" {
-									deploymentName := rsOwnerRef.Name
-									deploymentMap[deploymentName] = ResourceInfo{
-										kind:          rsOwnerRef.Kind,
-										namespaceName: pod.Namespace,
-									}
+				if *ref.Controller {
+					if ref.Kind == "ReplicaSet" {
+						replicaSet, err := r.ClientSet.AppsV1().ReplicaSets(pod.Namespace).Get(ctx, ref.Name, metav1.GetOptions{})
+						if err != nil {
+							log.Error(err, fmt.Sprintf("Failed to get ReplicaSet %s:", ref.Name))
+							continue
+						}
+						// Check if the ReplicaSet is managed by a Deployment
+						for _, rsOwnerRef := range replicaSet.OwnerReferences {
+							if rsOwnerRef.Kind == "Deployment" {
+								deploymentName := rsOwnerRef.Name
+								deploymentMap[deploymentName] = ResourceInfo{
+									kind:          rsOwnerRef.Kind,
+									namespaceName: pod.Namespace,
 								}
 							}
-						} else {
-							deploymentMap[ref.Name] = ResourceInfo{
-								namespaceName: pod.Namespace,
-								kind:          ref.Kind,
-							}
+						}
+					} else {
+						deploymentMap[ref.Name] = ResourceInfo{
+							namespaceName: pod.Namespace,
+							kind:          ref.Kind,
 						}
 					}
 				}
-
-				// find out deployment--- patch it
-				// if err := r.Delete(ctx, &pod); err != nil {
-				// 	if !errors.IsNotFound(err) {
-				// 		log.Error(err, "Could not delete pod "+pod.Name+" in namespace "+pod.Namespace)
-				// 	}
-			} else {
-				// single pods
-				// mimic kubectl replace --force
-				// delete the pod --force ==> grace period equals zero
-				log.Info("Deleting single pod " + pod.Name + " in namespace " + pod.Namespace)
-				if err := r.Delete(ctx, &pod, client.GracePeriodSeconds(0)); err != nil {
-					if !errors.IsNotFound(err) {
-						log.Error(err, "Couldn't delete pod "+pod.Name+" in namespace "+pod.Namespace)
-					}
-				}
-
-				// clean the pre-polutated attributes
-				pod.ResourceVersion = ""
-
-				// re-create the pod
-				if err := r.Create(ctx, &pod); err != nil {
-					log.Error(err, "Could not create pod "+pod.Name+" in namespace "+pod.Namespace)
-				}
-				poddeleted = true
 			}
 
+			// find out deployment--- patch it
+			// if err := r.Delete(ctx, &pod); err != nil {
+			// 	if !errors.IsNotFound(err) {
+			// 		log.Error(err, "Could not delete pod "+pod.Name+" in namespace "+pod.Namespace)
+			// 	}
+		} else {
+			// single pods
+			// mimic kubectl replace --force
+			// delete the pod --force ==> grace period equals zero
+			log.Info("Deleting single pod " + pod.Name + " in namespace " + pod.Namespace)
+			if err := r.Delete(ctx, &pod, client.GracePeriodSeconds(0)); err != nil {
+				if !errors.IsNotFound(err) {
+					log.Error(err, "Couldn't delete pod "+pod.Name+" in namespace "+pod.Namespace)
+				}
+			}
+
+			// clean the pre-polutated attributes
+			pod.ResourceVersion = ""
+
+			// re-create the pod
+			if err := r.Create(ctx, &pod); err != nil {
+				log.Error(err, "Could not create pod "+pod.Name+" in namespace "+pod.Namespace)
+			}
 		}
+
 	}
 
 	restartResources(deploymentMap, r.ClientSet)
-
-	// give time for pods to be deleted
-	if poddeleted {
-		time.Sleep(10 * time.Second)
-	}
 
 	return ctrl.Result{}, nil
 }
@@ -182,7 +173,7 @@ func requireRestart(pod corev1.Pod, enforcer string) bool {
 
 	return false
 }
-func restartResources(resourcesMap map[string]ResourceInfo, corev1 *kubernetes.Clientset) error {
+func restartResources(resourcesMap map[string]ResourceInfo, corev1 kubernetes.Interface) error {
 
 	ctx := context.Background()
 	log := log.FromContext(ctx)
@@ -241,8 +232,6 @@ func restartResources(resourcesMap map[string]ResourceInfo, corev1 *kubernetes.C
 				log.Error(err, fmt.Sprintf("error updating daemonset %s in namespace %s", name, resInfo.namespaceName))
 			}
 		}
-		// wait for few seconds after updating every resource
-		time.Sleep(5 * time.Second)
 	}
 
 	return nil

--- a/pkg/KubeArmorController/internal/controller/podrefresh_controller_test.go
+++ b/pkg/KubeArmorController/internal/controller/podrefresh_controller_test.go
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Authors of KubeArmor
+
+package controllers
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/kubearmor/KubeArmor/pkg/KubeArmorController/types"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	ctrlfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+)
+
+const appArmorTestAnnotation = "container.apparmor.security.beta.kubernetes.io/app"
+
+func TestPodRefresherReconcileTargetsRequestedPod(t *testing.T) {
+	ctx := context.Background()
+	scheme := podRefreshTestScheme(t)
+	pods := podRefreshPods(1000)
+
+	listCalled := false
+	k8sClient := ctrlfake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(pods...).
+		WithInterceptorFuncs(interceptor.Funcs{
+			List: func(ctx context.Context, c client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
+				listCalled = true
+				return c.List(ctx, list, opts...)
+			},
+		}).
+		Build()
+	reconciler := podRefreshTestReconciler(k8sClient)
+
+	if _, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: client.ObjectKey{
+		Namespace: "default",
+		Name:      "target",
+	}}); err != nil {
+		t.Fatalf("Reconcile returned error: %v", err)
+	}
+	if listCalled {
+		t.Fatal("Reconcile listed all pods instead of fetching the requested pod")
+	}
+
+	var target corev1.Pod
+	if err := k8sClient.Get(ctx, client.ObjectKey{Namespace: "default", Name: "target"}, &target); err != nil {
+		t.Fatalf("get target pod: %v", err)
+	}
+	if got := target.Annotations["kubearmor-policy"]; got != "enabled" {
+		t.Fatalf("target kubearmor-policy annotation = %q, want enabled", got)
+	}
+
+	var other corev1.Pod
+	if err := k8sClient.Get(ctx, client.ObjectKey{Namespace: "default", Name: "pod-999"}, &other); err != nil {
+		t.Fatalf("get unrelated pod: %v", err)
+	}
+	if _, ok := other.Annotations["kubearmor-policy"]; ok {
+		t.Fatal("unrelated pod was annotated during targeted reconcile")
+	}
+}
+
+func BenchmarkPodRefresherReconcileScale(b *testing.B) {
+	for _, podCount := range []int{10, 1000} {
+		b.Run(fmt.Sprintf("pods_%d", podCount), func(b *testing.B) {
+			ctx := context.Background()
+			scheme := podRefreshTestScheme(b)
+			for i := 0; i < b.N; i++ {
+				b.StopTimer()
+				k8sClient := ctrlfake.NewClientBuilder().
+					WithScheme(scheme).
+					WithObjects(podRefreshPods(podCount)...).
+					Build()
+				reconciler := podRefreshTestReconciler(k8sClient)
+				req := ctrl.Request{NamespacedName: client.ObjectKey{
+					Namespace: "default",
+					Name:      "target",
+				}}
+				b.StartTimer()
+
+				if _, err := reconciler.Reconcile(ctx, req); err != nil {
+					b.Fatalf("Reconcile returned error: %v", err)
+				}
+			}
+		})
+	}
+}
+
+func podRefreshTestScheme(t testing.TB) *runtime.Scheme {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add corev1 to scheme: %v", err)
+	}
+	return scheme
+}
+
+func podRefreshTestReconciler(k8sClient client.Client) *PodRefresherReconciler {
+	return &PodRefresherReconciler{
+		Client:    k8sClient,
+		ClientSet: fake.NewSimpleClientset(),
+		Cluster: &types.Cluster{
+			Nodes: map[string]*types.NodeInfo{
+				"node-a": {
+					KubeArmorActive: true,
+				},
+			},
+			ClusterLock: &sync.RWMutex{},
+		},
+	}
+}
+
+func podRefreshPods(count int) []client.Object {
+	pods := make([]client.Object, 0, count+1)
+	pods = append(pods, &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "target",
+			Annotations: map[string]string{
+				appArmorTestAnnotation: "localhost/profile",
+			},
+		},
+		Spec: corev1.PodSpec{
+			NodeName:   "node-a",
+			Containers: []corev1.Container{{Name: "app", Image: "nginx"}},
+		},
+	})
+	for i := 0; i < count; i++ {
+		pods = append(pods, &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "default",
+				Name:      fmt.Sprintf("pod-%d", i),
+			},
+			Spec: corev1.PodSpec{
+				NodeName:   "node-a",
+				Containers: []corev1.Container{{Name: "app", Image: "nginx"}},
+			},
+		})
+	}
+	return pods
+}

--- a/pkg/KubeArmorController/internal/controller/suite_test.go
+++ b/pkg/KubeArmorController/internal/controller/suite_test.go
@@ -6,6 +6,7 @@ package controllers
 import (
 	"path/filepath"
 	"testing"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -33,7 +34,7 @@ func TestAPIs(t *testing.T) {
 	RunSpecs(t, "Controller Suite")
 }
 
-var _ = BeforeSuite(func() {
+var _ = BeforeSuite(func(ctx SpecContext) {
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 
 	By("bootstrapping test environment")
@@ -57,7 +58,7 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 	Expect(k8sClient).NotTo(BeNil())
 
-}, 60)
+}, NodeTimeout(60*time.Second))
 
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")


### PR DESCRIPTION
**Purpose of PR?**:

Fixes #2800

**Does this PR introduce a breaking change?**

No.

**If the changes in this PR are manually verified, list down the scenarios covered:**:

- Verified with a focused controller unit test that pod refresher reconciliation fetches only the requested pod and does not list all pods.
- Verified with a focused benchmark that reconcile timing remains effectively flat between 10 and 1000 seeded pods.
- Verified the controller package test suite after updating its Ginkgo timeout decorator for the currently vendored Ginkgo API.

**Additional information for reviewer?** :

This is a scoped controller performance fix. The local checkout had unrelated work in the original worktree, so this change was implemented in a separate clean worktree based on `upstream/main`.

**Checklist:**
- [x] Bug fix. Fixes #2800
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [x] Commit has unit tests
- [ ] Commit has integration tests

## Summary
- Target `PodRefresherReconciler` to the requested pod instead of listing and iterating over every pod on each reconcile.
- Remove fixed sleeps from the pod refresh hot path and workload restart helper.
- Add focused regression and benchmark coverage for targeted reconcile behavior.
- Update the controller Ginkgo suite timeout decorator so package-wide tests run with the current Ginkgo dependency.

## Linked Issue
Fixes #2800

## What Changed
- Replaced the reconcile-wide pod list with a direct `Get` for `req.NamespacedName`.
- Kept existing annotation and restart behavior scoped to the requested pod.
- Changed the Kubernetes clientset field/helper type to `kubernetes.Interface` so controller tests can use a fake clientset.
- Added a focused unit test that fails if reconcile calls `List` and verifies unrelated pods are not annotated.
- Added a benchmark at 10 and 1000 seeded pods to cover representative pod counts.
- Changed the controller test suite from the old raw timeout argument to `NodeTimeout(60*time.Second)` with an interruptible `SpecContext` callback.

## Verification
- `git diff --check` — passed
- `go test -count=1 -v ./internal/controller/podrefresh_controller.go ./internal/controller/podrefresh_controller_test.go` in `pkg/KubeArmorController` — passed
- `go test -run '^$' -bench BenchmarkPodRefresherReconcileScale -benchtime=10x ./internal/controller/podrefresh_controller.go ./internal/controller/podrefresh_controller_test.go` in `pkg/KubeArmorController` — passed (`pods_10` 212442 ns/op, `pods_1000` 205408 ns/op)
- `make fmt` in `pkg/KubeArmorController` — passed
- `make vet` in `pkg/KubeArmorController` — passed
- `make build` in `pkg/KubeArmorController` — passed
- `go test ./...` in `pkg/KubeArmorController` — passed
- `ENVTEST_K8S_VERSION=1.36.2 make test` in `pkg/KubeArmorController` — passed after installing `setup-envtest` and caching Darwin arm64 envtest binaries locally
- `kubectl version --client=true` — passed after installing Homebrew `kubernetes-cli` (`Client Version: v1.36.3`)
- `docker buildx version` — passed after installing Homebrew `docker-buildx` (`v0.35.0`)
- `DOCKER_BUILDKIT=1 make docker-build TAG=latest` in `pkg/KubeArmorController` — not completed: BuildKit reached the in-image `go build -a -o manager cmd/main.go` step, remained there for an extended period under the local 2 CPU / 4 GiB Colima VM while other unrelated containers were running, and was interrupted
- `kubectl cluster-info` — failed: no local cluster/API server was reachable (`localhost:8080` refused)
- Controller/operator deployment steps from `contribution/testing_operator_controller_guide.md` — not run: no local Kubernetes cluster/API server was reachable, and the local controller Docker image build did not complete

## Scope
- Source changes are limited to `pkg/KubeArmorController/internal/controller/podrefresh_controller.go`, `pkg/KubeArmorController/internal/controller/podrefresh_controller_test.go`, and the controller test-suite timeout compatibility fix in `pkg/KubeArmorController/internal/controller/suite_test.go`.
- Generated CRD churn from `make test` was reviewed and intentionally not included.
