### PR TITLE
feat(core): support regex-based label selector matching for standalone policies

### DIFF
--- a/KubeArmor/core/unorchestratedUpdates.go
+++ b/KubeArmor/core/unorchestratedUpdates.go
@@ -100,12 +100,64 @@ func (dm *KubeArmorDaemon) WatchConfigChanges() {
 // == Container Security Policy Update == //
 // ====================================== //
 
+// MatchIdentities matches endpoint selector identities (with regex support) against container labels
+func (dm *KubeArmorDaemon) MatchIdentities(ep tp.EndPoint, containerLabels map[string]string) bool {
+	if len(ep.Identities) == 0 {
+		return false
+	}
+
+	for _, identity := range ep.Identities {
+		k, v, found := strings.Cut(identity, "=")
+		if !found {
+			return false
+		}
+
+		// namespaceName is a special identity and must match exactly
+		if k == "namespaceName" {
+			if containerVal, ok := containerLabels["namespaceName"]; !ok || containerVal != v {
+				return false
+			}
+			continue
+		}
+
+		// For other labels, check if the container has the label
+		containerVal, ok := containerLabels[k]
+		if !ok {
+			return false
+		}
+
+		// Get compiled regex from ep.IdentitiesRegexp if available
+		var rx *regexp.Regexp
+		if ep.IdentitiesRegexp != nil {
+			rx = ep.IdentitiesRegexp[k]
+		}
+
+		if rx == nil {
+			var err error
+			rx, err = regexp.CompilePOSIX(v)
+			if err != nil {
+				dm.Logger.Warnf("Failed to compile regex for label %q value %q: %s", k, v, err.Error())
+				if containerVal != v {
+					return false
+				}
+				continue
+			}
+		}
+
+		if !rx.MatchString(containerVal) {
+			return false
+		}
+	}
+
+	return true
+}
+
 // MatchandUpdateContainerSecurityPolicies finds relevant endpoint for containers and updates the security policies for enforcement
 func (dm *KubeArmorDaemon) MatchandUpdateContainerSecurityPolicies(cid string) {
 	container := dm.Containers[cid]
 	for idx, ep := range dm.EndPoints {
-		_, containerIdentities := kl.GetLabelsFromString(container.Labels)
-		if ep.EndPointName == dm.Containers[cid].ContainerName || kl.MatchIdentities(ep.Identities, containerIdentities) {
+		containerLabels, _ := kl.GetLabelsFromString(container.Labels)
+		if ep.EndPointName == dm.Containers[cid].ContainerName || dm.MatchIdentities(ep, containerLabels) {
 			ep.Containers = append(ep.Containers, cid)
 			dm.EndPoints[idx] = ep
 			ctr := dm.Containers[cid]
@@ -133,8 +185,8 @@ func (dm *KubeArmorDaemon) MatchandUpdateContainerSecurityPolicies(cid string) {
 func (dm *KubeArmorDaemon) MatchandRemoveContainerFromEndpoint(cid string) {
 	container := dm.Containers[cid]
 	for idx, ep := range dm.EndPoints {
-		_, containerIdentities := kl.GetLabelsFromString(container.Labels)
-		if ep.EndPointName == container.ContainerName || kl.MatchIdentities(ep.Identities, containerIdentities) {
+		containerLabels, _ := kl.GetLabelsFromString(container.Labels)
+		if ep.EndPointName == container.ContainerName || dm.MatchIdentities(ep, containerLabels) {
 			for i, c := range ep.Containers {
 				if c != cid {
 					continue
@@ -186,6 +238,7 @@ func (dm *KubeArmorDaemon) handlePolicyEvent(eventType string, createEndPoint bo
 				// Policy already exists so modify
 				eventType = "MODIFIED"
 				newPoint.SecurityPolicies[idx] = secPolicy
+				newPoint.IdentitiesRegexp = secPolicy.Spec.Selector.IdentitiesRegexp
 			}
 		}
 	}
@@ -196,6 +249,7 @@ func (dm *KubeArmorDaemon) handlePolicyEvent(eventType string, createEndPoint bo
 		dm.RuntimeEnforcer.UpdateAppArmorProfiles(containername, "ADDED", appArmorAnnotations, privilegedProfiles)
 
 		newPoint.SecurityPolicies = append(newPoint.SecurityPolicies, secPolicy)
+		newPoint.IdentitiesRegexp = secPolicy.Spec.Selector.IdentitiesRegexp
 		if createEndPoint {
 			// Create new EndPoint - possible scenarios:
 			// policy received before container
@@ -204,6 +258,7 @@ func (dm *KubeArmorDaemon) handlePolicyEvent(eventType string, createEndPoint bo
 			newPoint.ContainerName = containername
 			newPoint.PolicyEnabled = tp.KubeArmorPolicyEnabled
 			newPoint.Identities = secPolicy.Spec.Selector.Identities
+			newPoint.IdentitiesRegexp = secPolicy.Spec.Selector.IdentitiesRegexp
 
 			newPoint.ProcessVisibilityEnabled = true
 			newPoint.FileVisibilityEnabled = true
@@ -320,16 +375,17 @@ func (dm *KubeArmorDaemon) ParseAndUpdateContainerSecurityPolicy(event tp.K8sKub
 	}
 
 	secPolicy.Spec.Selector.Identities = []string{"namespaceName=" + secPolicy.Metadata["namespaceName"]}
+	secPolicy.Spec.Selector.IdentitiesRegexp = make(map[string]*regexp.Regexp)
 	containername := ""
 	for k, v := range secPolicy.Spec.Selector.MatchLabels {
 		secPolicy.Spec.Selector.Identities = append(secPolicy.Spec.Selector.Identities, k+"="+v)
-		// TODO: regex based matching
+		expr, err := regexp.CompilePOSIX(v)
+		if err != nil {
+			dm.Logger.Warnf("Failed to parse expression for selector label %q value %q: %s", k, v, err.Error())
+			return pb.PolicyStatus_Invalid
+		}
+		secPolicy.Spec.Selector.IdentitiesRegexp[k] = expr
 		if k == "kubearmor.io/container.name" {
-			expr, err := regexp.CompilePOSIX(v)
-			if err != nil {
-				dm.Logger.Warnf("Failed to parse expression for \"kubearmor.io/container.name\": %s", err.Error())
-				return pb.PolicyStatus_Invalid
-			}
 			containername = expr.String()
 		}
 	}

--- a/KubeArmor/core/unorchestratedUpdates_test.go
+++ b/KubeArmor/core/unorchestratedUpdates_test.go
@@ -1,0 +1,170 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Authors of KubeArmor
+
+package core
+
+import (
+	"regexp"
+	"sync"
+	"testing"
+
+	fd "github.com/kubearmor/KubeArmor/KubeArmor/feeder"
+	tp "github.com/kubearmor/KubeArmor/KubeArmor/types"
+	pb "github.com/kubearmor/KubeArmor/protobuf"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestParseAndUpdateContainerSecurityPolicy_Regex(t *testing.T) {
+	node := tp.Node{}
+	nodeLock := &sync.RWMutex{}
+	logger := fd.NewFeeder(&node, &nodeLock)
+
+	dm := &KubeArmorDaemon{
+		EndPoints:            []tp.EndPoint{},
+		EndPointsLock:        &sync.RWMutex{},
+		SecurityPolicies:     []tp.SecurityPolicy{},
+		SecurityPoliciesLock: &sync.RWMutex{},
+		Containers:           map[string]tp.Container{},
+		ContainersLock:       &sync.RWMutex{},
+		Logger:               logger,
+	}
+
+	// 1. Valid regex patterns
+	validPolicyEvent := tp.K8sKubeArmorPolicyEvent{
+		Type: "ADDED",
+		Object: tp.K8sKubeArmorPolicy{
+			Metadata: metav1.ObjectMeta{
+				Name: "valid-regex-policy",
+			},
+			Spec: tp.SecuritySpec{
+				Selector: tp.SelectorType{
+					MatchLabels: map[string]string{
+						"kubearmor.io/container.name": "container-[0-9]+",
+						"custom-label":                "^val-[a-z]+$",
+					},
+				},
+			},
+		},
+	}
+
+	status := dm.ParseAndUpdateContainerSecurityPolicy(validPolicyEvent)
+	if status != pb.PolicyStatus_Applied {
+		t.Fatalf("expected PolicyStatus_Applied, got %v", status)
+	}
+
+	if len(dm.EndPoints) != 1 {
+		t.Fatalf("expected 1 endpoint to be created, got %d", len(dm.EndPoints))
+	}
+
+	ep := dm.EndPoints[0]
+	if ep.IdentitiesRegexp == nil {
+		t.Fatal("expected ep.IdentitiesRegexp to be initialized")
+	}
+
+	rxContainer, ok := ep.IdentitiesRegexp["kubearmor.io/container.name"]
+	if !ok || rxContainer == nil {
+		t.Fatal("expected compiled regex for kubearmor.io/container.name")
+	}
+
+	if !rxContainer.MatchString("container-123") {
+		t.Error("expected container-[0-9]+ to match container-123")
+	}
+
+	if rxContainer.MatchString("container-abc") {
+		t.Error("expected container-[0-9]+ to NOT match container-abc")
+	}
+
+	rxCustom, ok := ep.IdentitiesRegexp["custom-label"]
+	if !ok || rxCustom == nil {
+		t.Fatal("expected compiled regex for custom-label")
+	}
+
+	if !rxCustom.MatchString("val-xyz") {
+		t.Error("expected ^val-[a-z]+$ to match val-xyz")
+	}
+
+	if rxCustom.MatchString("val-123") {
+		t.Error("expected ^val-[a-z]+$ to NOT match val-123")
+	}
+
+	// 2. Invalid regex pattern
+	invalidPolicyEvent := tp.K8sKubeArmorPolicyEvent{
+		Type: "ADDED",
+		Object: tp.K8sKubeArmorPolicy{
+			Metadata: metav1.ObjectMeta{
+				Name: "invalid-regex-policy",
+			},
+			Spec: tp.SecuritySpec{
+				Selector: tp.SelectorType{
+					MatchLabels: map[string]string{
+						"kubearmor.io/container.name": "container-[0-9",
+					},
+				},
+			},
+		},
+	}
+
+	status = dm.ParseAndUpdateContainerSecurityPolicy(invalidPolicyEvent)
+	if status != pb.PolicyStatus_Invalid {
+		t.Fatalf("expected PolicyStatus_Invalid, got %v", status)
+	}
+}
+
+func TestMatchIdentities_Regex(t *testing.T) {
+	dm := &KubeArmorDaemon{}
+
+	// Setup compiled regexes
+	rx1 := regexp.MustCompile("prod-.*")
+	rx2 := regexp.MustCompile("^web-[0-9]+$")
+
+	ep := tp.EndPoint{
+		Identities: []string{
+			"namespaceName=container_namespace",
+			"env=prod-.*",
+			"app=^web-[0-9]+$",
+		},
+		IdentitiesRegexp: map[string]*regexp.Regexp{
+			"env": rx1,
+			"app": rx2,
+		},
+	}
+
+	// Case 1: Match succeeds
+	labels1 := map[string]string{
+		"namespaceName": "container_namespace",
+		"env":           "prod-service",
+		"app":           "web-42",
+	}
+	if !dm.MatchIdentities(ep, labels1) {
+		t.Error("expected MatchIdentities to return true for matching labels")
+	}
+
+	// Case 2: Match fails due to mismatched regex (app)
+	labels2 := map[string]string{
+		"namespaceName": "container_namespace",
+		"env":           "prod-service",
+		"app":           "web-abc",
+	}
+	if dm.MatchIdentities(ep, labels2) {
+		t.Error("expected MatchIdentities to return false due to app value mismatch")
+	}
+
+	// Case 3: Match fails due to missing label (env)
+	labels3 := map[string]string{
+		"namespaceName": "container_namespace",
+		"app":           "web-42",
+	}
+	if dm.MatchIdentities(ep, labels3) {
+		t.Error("expected MatchIdentities to return false due to missing env label")
+	}
+
+	// Case 4: Match fails due to mismatched namespaceName
+	labels4 := map[string]string{
+		"namespaceName": "different_namespace",
+		"env":           "prod-service",
+		"app":           "web-42",
+	}
+	if dm.MatchIdentities(ep, labels4) {
+		t.Error("expected MatchIdentities to return false due to namespaceName mismatch")
+	}
+}

--- a/KubeArmor/types/types.go
+++ b/KubeArmor/types/types.go
@@ -86,6 +86,8 @@ type EndPoint struct {
 	Labels     map[string]string `json:"labels"`
 	Identities []string          `json:"identities"`
 
+	IdentitiesRegexp map[string]*regexp.Regexp `json:"-"`
+
 	Containers       []string `json:"containers"`
 	PodIP            string   `json:"podIP,omitempty"`
 	AppArmorProfiles []string `json:"apparmorProfiles"`
@@ -381,6 +383,8 @@ type SelectorType struct {
 
 	// only for ksp
 	Identities []string `json:"identities,omitempty"` // set during policy update
+
+	IdentitiesRegexp map[string]*regexp.Regexp `json:"-"`
 
 	// for ksp & csp - used in matchExpression, key: label
 	MatchExpIdentities []string `json:"matchExpIdentities,omitempty"`


### PR DESCRIPTION
**Purpose of PR?**:
This PR implements POSIX regular expression matching for selector label values in standalone (unorchestrated) KubeArmor. It addresses the existing TODO to support regex-based matching for label selectors like `kubearmor.io/container.name` and other custom labels.

Fixes #2807

**Does this PR introduce a breaking change?**
No.

**If the changes in this PR are manually verified, list down the scenarios covered:**:
Unit tests have been added to verify:
1. Compiling valid regex patterns inside standalone policies during parsing and loading.
2. Handling invalid regex patterns (validating that `pb.PolicyStatus_Invalid` is returned).
3. Evaluative matching of container metadata identities against regex patterns (e.g. wildcards, character ranges).
4. Failure to match container metadata when the label value does not match the regex pattern.

These tests were compiled and run on the target OS (Linux).

**Additional information for reviewer?** :
This changes KubeArmor's standalone policy loading and parsing in `unorchestratedUpdates.go` and updates `types.go` to hold compiled regular expressions in a transient `IdentitiesRegexp` field on `SelectorType` and `EndPoint` to avoid compiling them on every match event.

**Checklist:**
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] PR Title follows the convention of  `feat(core): support regex-based label selector matching for standalone policies`
- [x] Commit has unit tests
- [ ] Commit has integration tests
