### PR TITLE
fix(core): guard strings.Split index in AppArmor annotation parsing

### DIFF
--- a/KubeArmor/core/kubeUpdate.go
+++ b/KubeArmor/core/kubeUpdate.go
@@ -604,6 +604,43 @@ func (dm *KubeArmorDaemon) HandleUnknownNamespaceNsMap(container *tp.Container) 
 	dm.SystemMonitor.NsMapLock.Unlock()
 }
 
+// parseAppArmorAnnotations extracts container-to-profile mappings from a pod's
+// "container.apparmor.security.beta.kubernetes.io/*" annotations. Malformed
+// annotation keys (missing the "/<containerName>" suffix) or values (missing
+// the "localhost/<profile>" form) are skipped and reported back as warnings
+// instead of causing an index-out-of-range panic.
+func parseAppArmorAnnotations(annotations map[string]string) (map[string]string, []string) {
+	result := map[string]string{}
+	var warnings []string
+
+	for k, v := range annotations {
+		if !strings.HasPrefix(k, "container.apparmor.security.beta.kubernetes.io") {
+			continue
+		}
+
+		keyParts := strings.Split(k, "/")
+		if len(keyParts) != 2 {
+			warnings = append(warnings, fmt.Sprintf("Skipping malformed AppArmor annotation key (%s)", k))
+			continue
+		}
+		containerName := keyParts[1]
+
+		if v == "unconfined" {
+			result[containerName] = v
+			continue
+		}
+
+		valueParts := strings.Split(v, "/")
+		if len(valueParts) != 2 {
+			warnings = append(warnings, fmt.Sprintf("Skipping malformed AppArmor annotation value (%s: %s)", k, v))
+			continue
+		}
+		result[containerName] = valueParts[1]
+	}
+
+	return result, warnings
+}
+
 func (dm *KubeArmorDaemon) handlePodEvent(event string, obj *corev1.Pod) {
 	if event != addEvent && event != updateEvent && event != deleteEvent {
 		return
@@ -840,16 +877,12 @@ func (dm *KubeArmorDaemon) handlePodEvent(event string, obj *corev1.Pod) {
 		}
 		dm.OwnerInfoLock.RUnlock()
 
-		for k, v := range pod.Annotations {
-			if strings.HasPrefix(k, "container.apparmor.security.beta.kubernetes.io") {
-				if v == "unconfined" {
-					containerName := strings.Split(k, "/")[1]
-					appArmorAnnotations[containerName] = v
-				} else {
-					containerName := strings.Split(k, "/")[1]
-					appArmorAnnotations[containerName] = strings.Split(v, "/")[1]
-				}
-			}
+		parsedAnnotations, warnings := parseAppArmorAnnotations(pod.Annotations)
+		for containerName, profile := range parsedAnnotations {
+			appArmorAnnotations[containerName] = profile
+		}
+		for _, warning := range warnings {
+			dm.Logger.Warn(warning)
 		}
 
 		for _, container := range obj.Spec.Containers {

--- a/KubeArmor/core/kubeUpdate_apparmor_test.go
+++ b/KubeArmor/core/kubeUpdate_apparmor_test.go
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Authors of KubeArmor
+
+package core
+
+import (
+	"reflect"
+	"testing"
+)
+
+// TestParseAppArmorAnnotations verifies that malformed AppArmor annotations
+// (a bare prefix key with no container suffix, or a value without a
+// "localhost/<profile>" separator) are skipped with a warning instead of
+// causing an index-out-of-range panic.
+func TestParseAppArmorAnnotations(t *testing.T) {
+	tests := []struct {
+		name         string
+		annotations  map[string]string
+		wantProfiles map[string]string
+		wantWarnings int
+	}{
+		{
+			name: "well-formed unconfined annotation",
+			annotations: map[string]string{
+				"container.apparmor.security.beta.kubernetes.io/nginx": "unconfined",
+			},
+			wantProfiles: map[string]string{"nginx": "unconfined"},
+			wantWarnings: 0,
+		},
+		{
+			name: "well-formed localhost profile annotation",
+			annotations: map[string]string{
+				"container.apparmor.security.beta.kubernetes.io/nginx": "localhost/my-profile",
+			},
+			wantProfiles: map[string]string{"nginx": "my-profile"},
+			wantWarnings: 0,
+		},
+		{
+			name: "malformed key without container suffix",
+			annotations: map[string]string{
+				"container.apparmor.security.beta.kubernetes.io": "unconfined",
+			},
+			wantProfiles: map[string]string{},
+			wantWarnings: 1,
+		},
+		{
+			name: "malformed value without separator",
+			annotations: map[string]string{
+				"container.apparmor.security.beta.kubernetes.io/nginx": "not-a-valid-profile-string",
+			},
+			wantProfiles: map[string]string{},
+			wantWarnings: 1,
+		},
+		{
+			name: "unrelated annotations are ignored",
+			annotations: map[string]string{
+				"some-other-annotation": "value",
+			},
+			wantProfiles: map[string]string{},
+			wantWarnings: 0,
+		},
+		{
+			name:         "nil annotations",
+			annotations:  nil,
+			wantProfiles: map[string]string{},
+			wantWarnings: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotProfiles, gotWarnings := parseAppArmorAnnotations(tt.annotations)
+			if !reflect.DeepEqual(gotProfiles, tt.wantProfiles) {
+				t.Errorf("parseAppArmorAnnotations() profiles = %v, want %v", gotProfiles, tt.wantProfiles)
+			}
+			if len(gotWarnings) != tt.wantWarnings {
+				t.Errorf("parseAppArmorAnnotations() warnings = %v, want %d warnings", gotWarnings, tt.wantWarnings)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**Purpose of PR?**:

`UpdateContainer`'s AppArmor annotation loop indexed into `strings.Split(k, "/")[1]` and `strings.Split(v, "/")[1]` without checking the length of the returned slice. Any pod annotation key without a `/`-separated container name, or a non-`unconfined` value without a `/`-separated profile, made `strings.Split` return a 1-element slice and panicked the goroutine handling pod updates.

This pulls the parsing logic into `parseAppArmorAnnotations`, guards both splits with a length check, and skips + logs a warning for a malformed annotation instead of indexing out of range.

Fixes #2813

**Does this PR introduce a breaking change?**

No.

**If the changes in this PR are manually verified, list down the scenarios covered:**:

- Added `TestParseAppArmorAnnotations` covering: well-formed `unconfined` annotation, well-formed `localhost/<profile>` annotation, a bare annotation key with no container suffix, a value without a `/` separator, unrelated annotations, and nil annotations.
- `go build ./...` and `go test ./...` pass locally.

**Additional information for reviewer?** :

**Checklist:**
- [x] Bug fix. Fixes #2813
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [x] Commit has unit tests
- [ ] Commit has integration tests