### PR TITLE
fix(common): reject relative root paths and volume roots in isUnsafePathToRemove

### DIFF
--- a/KubeArmor/common/common.go
+++ b/KubeArmor/common/common.go
@@ -744,17 +744,21 @@ func NormalizeIP(ipStr string) string {
 // errUnsafePathToRemove error
 var errUnsafePathToRemove = errors.New("unsafe path to remove")
 
-// isUnsafePathToRemove checks if path is empty or absolute root "/"
+// isUnsafePathToRemove checks if path is empty, relative root (., ..), or absolute root "/"
 // return true to mark the path unsafe to remove
 func isUnsafePathToRemove(path string) bool {
-	if path == "" {
+	trimmed := strings.TrimSpace(path)
+	if trimmed == "" {
 		return true
 	}
 
-	clean := filepath.Clean(path)
+	clean := filepath.Clean(trimmed)
 
-	// root /
-	if clean == string(filepath.Separator) {
+	if clean == "." || clean == ".." || clean == string(filepath.Separator) || clean == "/" {
+		return true
+	}
+
+	if vol := filepath.VolumeName(clean); vol != "" && (clean == vol || clean == vol+string(filepath.Separator)) {
 		return true
 	}
 

--- a/KubeArmor/common/common_test.go
+++ b/KubeArmor/common/common_test.go
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Authors of KubeArmor
+
+package common
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestIsUnsafePathToRemove(t *testing.T) {
+	unsafePaths := []string{
+		"",
+		"   ",
+		".",
+		"..",
+		"/",
+		string(filepath.Separator),
+	}
+
+	vol := filepath.VolumeName(os.Getenv("SystemDrive"))
+	if vol != "" {
+		unsafePaths = append(unsafePaths, vol, vol+string(filepath.Separator))
+	}
+
+	for _, p := range unsafePaths {
+		if !isUnsafePathToRemove(p) {
+			t.Errorf("expected path %q to be marked unsafe, but got safe", p)
+		}
+		if err := RemoveSafe(p); err != errUnsafePathToRemove {
+			t.Errorf("expected RemoveSafe(%q) to fail with errUnsafePathToRemove, got: %v", p, err)
+		}
+		if err := RemoveAllSafe(p); err != errUnsafePathToRemove {
+			t.Errorf("expected RemoveAllSafe(%q) to fail with errUnsafePathToRemove, got: %v", p, err)
+		}
+	}
+}
+
+func TestRemoveSafe_ValidFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	testFile := filepath.Join(tmpDir, "test.txt")
+
+	if err := os.WriteFile(testFile, []byte("hello"), 0644); err != nil {
+		t.Fatalf("failed to create temp test file: %v", err)
+	}
+
+	if err := RemoveSafe(testFile); err != nil {
+		t.Errorf("expected RemoveSafe to succeed on valid file, got: %v", err)
+	}
+
+	if _, err := os.Stat(testFile); !os.IsNotExist(err) {
+		t.Errorf("expected test file to be removed")
+	}
+}
+
+func TestRemoveAllSafe_ValidDir(t *testing.T) {
+	tmpDir := t.TempDir()
+	subDir := filepath.Join(tmpDir, "subdir")
+
+	if err := os.Mkdir(subDir, 0755); err != nil {
+		t.Fatalf("failed to create temp subdir: %v", err)
+	}
+
+	if err := RemoveAllSafe(subDir); err != nil {
+		t.Errorf("expected RemoveAllSafe to succeed on valid directory, got: %v", err)
+	}
+
+	if _, err := os.Stat(subDir); !os.IsNotExist(err) {
+		t.Errorf("expected subdir to be removed")
+	}
+}


### PR DESCRIPTION
**Purpose of PR?**:

The helper function `isUnsafePathToRemove` (used by `RemoveSafe` and `RemoveAllSafe` in `KubeArmor/common/common.go`) guards against unsafe or destructive file removal operations.

Previously, `isUnsafePathToRemove` only checked if `filepath.Clean(path)` matched the separator (`/` or `\`). Relative root paths like `.` and `..` clean to `.` and `..`, which bypassed the check and allowed `RemoveAllSafe(".")` to proceed with deleting the current working directory tree. Volume roots (e.g. `C:\`) and whitespace-only inputs were also not handled.

This PR updates `isUnsafePathToRemove` to explicitly classify relative root paths (`.` and `..`), volume roots, and whitespace-only inputs as unsafe, returning `errUnsafePathToRemove`.

Fixes #2822

**Does this PR introduce a breaking change?**

No

**If the changes in this PR are manually verified, list down the scenarios covered:**:

1. `isUnsafePathToRemove("")`, `isUnsafePathToRemove("  ")`, `isUnsafePathToRemove(".")`, `isUnsafePathToRemove("..")`, `isUnsafePathToRemove("/")` return `true` (unsafe).
2. `RemoveSafe` and `RemoveAllSafe` return `errUnsafePathToRemove` when called with relative or absolute root paths.
3. Added unit tests in `KubeArmor/common/common_test.go` covering `RemoveSafe`, `RemoveAllSafe`, and path safety checks.

**Checklist:**
- [x] Bug fix. Fixes #2822
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] PR Title follows the convention of `<type>(<scope>): <subject>`
- [x] Commit has unit tests
- [ ] Commit has integration tests
