### PR TITLE
fix: accept boolean OCI hooks values

### DIFF
--- a/pkg/KubeArmorOperator/common/defaults.go
+++ b/pkg/KubeArmorOperator/common/defaults.go
@@ -603,9 +603,9 @@ func GetOCIHooks() bool {
 	val := os.Getenv("KUBEARMOR_OCI_HOOKS")
 	if val != "" {
 		switch val {
-		case "yes":
+		case "yes", "true":
 			return true
-		case "no":
+		case "no", "false":
 			return false
 		default:
 			return false

--- a/pkg/KubeArmorOperator/common/defaults_test.go
+++ b/pkg/KubeArmorOperator/common/defaults_test.go
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Authors of KubeArmor
+
+package common
+
+import "testing"
+
+func TestGetOCIHooks(t *testing.T) {
+	tests := []struct {
+		name     string
+		value    string
+		expected bool
+	}{
+		{name: "operator", value: "yes", expected: true},
+		{name: "snitch", value: "true", expected: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("KUBEARMOR_OCI_HOOKS", tt.value)
+
+			if got := GetOCIHooks(); got != tt.expected {
+				t.Errorf("GetOCIHooks() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**Purpose of PR?**:

Fixes #2828

Allow `GetOCIHooks()` to accept both `yes`/`no` and `true`/`false` values for `KUBEARMOR_OCI_HOOKS`.

This ensures that Snitch Jobs generated with `KUBEARMOR_OCI_HOOKS=true` correctly enable OCI hooks instead of treating the value as disabled.

**Does this PR introduce a breaking change?**

No.

**If the changes in this PR are manually verified, list down the scenarios covered:**:

Live-cluster manual verification was not performed.

The following scenarios are covered by unit tests:

- `KUBEARMOR_OCI_HOOKS=yes` enables OCI hooks
- `KUBEARMOR_OCI_HOOKS=true` enables OCI hooks
- `KUBEARMOR_OCI_HOOKS=no` disables OCI hooks
- `KUBEARMOR_OCI_HOOKS=false` disables OCI hooks
- Invalid or unset values remain disabled

**Checklist:**
- [x] Bug fix. Fixes #2828
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] PR Title follows the convention of `<type>(<scope>): <subject>`
- [x] Commit has unit tests
- [ ] Commit has integration tests