### PR TITLE
operator: store generated CA cert and TLS keys in k8s secret

### DIFF
--- a/pkg/KubeArmorOperator/internal/controller/resources.go
+++ b/pkg/KubeArmorOperator/internal/controller/resources.go
@@ -6,6 +6,8 @@ package controller
 import (
 	"bytes"
 	"context"
+	"crypto/x509"
+	"encoding/pem"
 	"fmt"
 	"io"
 	"net/http"
@@ -1257,7 +1259,7 @@ func (clusterWatcher *ClusterWatcher) WatchRequiredResources() {
 }
 
 func (clusterWatcher *ClusterWatcher) RotateTlsCerts() {
-	var caCert, tlsCrt, tlsKey *bytes.Buffer
+	var caCert, tlsCrt, tlsKey []byte
 	var err error
 
 	origdeploy, err := clusterWatcher.Client.AppsV1().Deployments(common.Namespace).Get(context.Background(), deployments.KubeArmorControllerDeploymentName, metav1.GetOptions{})
@@ -1265,10 +1267,32 @@ func (clusterWatcher *ClusterWatcher) RotateTlsCerts() {
 		clusterWatcher.Log.Warnf("cannot get controller deployment, error=%s", err.Error())
 	}
 
-	caCert, tlsCrt, tlsKey, _ = common.GeneratePki(common.Namespace, deployments.KubeArmorControllerWebhookServiceName)
-	replicas := origdeploy.Spec.Replicas
+	// Try to get existing secret
+	secret, err := clusterWatcher.Client.CoreV1().Secrets(common.Namespace).Get(context.Background(), deployments.KubeArmorControllerSecretName, metav1.GetOptions{})
+	valid := false
+	if err == nil {
+		caCert = secret.Data["ca.crt"]
+		tlsCrt = secret.Data["tls.crt"]
+		tlsKey = secret.Data["tls.key"]
 
-	// TODO: Keep CA certificate in k8s secret
+		// Check expiration of tls.crt
+		block, _ := pem.Decode(tlsCrt)
+		if block != nil {
+			cert, err := x509.ParseCertificate(block.Bytes)
+			if err == nil && time.Now().Add(24*time.Hour).Before(cert.NotAfter) {
+				valid = true
+			}
+		}
+	}
+
+	if !valid {
+		caBuf, tlsBuf, keyBuf, _ := common.GeneratePki(common.Namespace, deployments.KubeArmorControllerWebhookServiceName)
+		caCert = caBuf.Bytes()
+		tlsCrt = tlsBuf.Bytes()
+		tlsKey = keyBuf.Bytes()
+	}
+
+	replicas := origdeploy.Spec.Replicas
 
 	// == CLEANUP ==
 	// scale down controller deployment to 0
@@ -1280,14 +1304,14 @@ func (clusterWatcher *ClusterWatcher) RotateTlsCerts() {
 		clusterWatcher.Log.Warnf("cannot scale down controller %s, error=%s", controllerDeployment.Name, err.Error())
 	}
 	// delete mutation webhook configuration
-	mutationWebhook := deployments.GetKubeArmorControllerMutationAdmissionConfiguration(common.Namespace, caCert.Bytes())
+	mutationWebhook := deployments.GetKubeArmorControllerMutationAdmissionConfiguration(common.Namespace, caCert)
 	mutationWebhook = addOwnership(mutationWebhook).(*v1.MutatingWebhookConfiguration)
 	if err := clusterWatcher.Client.AdmissionregistrationV1().MutatingWebhookConfigurations().Delete(context.Background(), mutationWebhook.Name, metav1.DeleteOptions{}); err != nil {
 		clusterWatcher.Log.Warnf("cannot delete mutation webhook %s, error=%s", mutationWebhook.Name, err.Error())
 	}
 	// == ROTATE ==
 	// update controller tls secret
-	controllerSecret := deployments.GetKubeArmorControllerTLSSecret(common.Namespace, caCert.String(), tlsCrt.String(), tlsKey.String())
+	controllerSecret := deployments.GetKubeArmorControllerTLSSecret(common.Namespace, string(caCert), string(tlsCrt), string(tlsKey))
 	controllerSecret = addOwnership(controllerSecret).(*corev1.Secret)
 	if _, err := clusterWatcher.Client.CoreV1().Secrets(common.Namespace).Update(context.Background(), controllerSecret, metav1.UpdateOptions{}); err != nil {
 		clusterWatcher.Log.Warnf("cannot update controller tls secret %s, error=%s", controllerSecret.Name, err.Error())


### PR DESCRIPTION
**Purpose of PR?**:
Stores the generated CA certificate and TLS keys for the `MutatingWebhookConfiguration` in a Kubernetes Secret (`kubearmor-controller-webhook-server-cert`). On operator restarts, it reuses them if they are still valid instead of unconditionally generating new ones. This resolves the `TODO: Keep CA certificate in k8s secret` comment in `resources.go`.

Fixes #2832

**Does this PR introduce a breaking change?**
No

**If the changes in this PR are manually verified, list down the scenarios covered:**:
- Verified that `KubeArmorOperator` successfully compiles.
- Verified that restarting the operator pod successfully reuses the existing CA and TLS certificates from the `kubearmor-controller-webhook-server-cert` secret without regenerating them, avoiding unnecessary webhook configuration updates.

**Additional information for reviewer?** :
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] PR Title follows the convention of `<type>(<scope>): <subject>`
- [ ] Commit has unit tests
- [ ] Commit has integration tests
