### PR TITLE
feat(ci): open a tracking issue when the Trivy scan finds vulnerabilities

### DIFF
--- a/.github/workflows/ci-trivy-scan-ubi.yaml
+++ b/.github/workflows/ci-trivy-scan-ubi.yaml
@@ -1,4 +1,4 @@
-name: ci-trivy-scan
+name: ci-trivy-scan-ubi
 
 on:
   push: 
@@ -26,6 +26,9 @@ jobs:
     permissions:
       id-token: write
     timeout-minutes: 150
+    outputs:
+      vulnerable: ${{ steps.summary.outputs.vulnerable }}
+      failed_components: ${{ steps.summary.outputs.failed_components }}
     steps:
       - name: Checkout code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -102,12 +105,16 @@ jobs:
             docker save -o kubearmor-controller.tar kubearmor/kubearmor-controller-ubi:latest
           fi
 
+      - name: Prepare Trivy report directory
+        run: mkdir -p trivy-reports
+
       - name: Run Trivy vulnerability scanner on kubearmor-init
         id: scan_init
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           input: kubearmor-init.tar
           format: 'table'
+          output: 'trivy-reports/kubearmor-init.txt'
           exit-code: '1'
           ignore-unfixed: true
           vuln-type: 'os,library'
@@ -120,6 +127,7 @@ jobs:
         with:
           input: kubearmor.tar
           format: 'table'
+          output: 'trivy-reports/kubearmor.txt'
           exit-code: '1'
           ignore-unfixed: true
           vuln-type: 'os,library'
@@ -133,6 +141,7 @@ jobs:
         with:
           input: kubearmor-controller.tar
           format: 'table'
+          output: 'trivy-reports/kubearmor-controller.txt'
           exit-code: '1'
           ignore-unfixed: true
           vuln-type: 'os,library'
@@ -146,6 +155,7 @@ jobs:
         with:
           input: kubearmor-operator.tar
           format: 'table'
+          output: 'trivy-reports/kubearmor-operator.txt'
           exit-code: '1'
           ignore-unfixed: true
           vuln-type: 'os,library'
@@ -153,51 +163,62 @@ jobs:
         continue-on-error: true 
 
 
-      - name: Report Trivy Scan Results
+      - name: Summarize Trivy scan results
+        id: summary
+        env:
+          TRIVY_COMPONENTS: |
+            kubearmor-init|kubearmor/kubearmor-init-ubi:latest|${{ steps.scan_init.outcome }}|true
+            kubearmor|kubearmor/kubearmor-ubi:latest|${{ steps.scan_main.outcome }}|true
+            kubearmor-controller|kubearmor/kubearmor-controller-ubi:latest|${{ steps.scan_controller.outcome }}|${{ steps.filter.outputs.controller }}
+            kubearmor-operator|kubearmor/kubearmor-operator-ubi:latest|${{ steps.scan_operator.outcome }}|${{ steps.filter.outputs.operator }}
+        run: ./.github/workflows/trivy-summarize.sh
+
+      - name: Upload Trivy reports
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: trivy-reports-ubi
+          path: trivy-reports/
+          if-no-files-found: warn
+          retention-days: 30
+
+      - name: Fail if vulnerabilities were found
+        if: steps.summary.outputs.vulnerable == 'true'
+        env:
+          FAILED_COMPONENTS: ${{ steps.summary.outputs.failed_components }}
         run: |
-          echo "Trivy Scan Results Summary:"
-          echo "=========================="
-          any_scan_failed=false
+          echo "Trivy reported vulnerabilities in: $FAILED_COMPONENTS"
+          exit 1
 
-          if [[ "${{ steps.scan_init.outcome }}" == "failure" ]]; then
-            echo "❌ kubearmor-init: FAILED (Vulnerabilities found)"
-            any_scan_failed=true
-          else
-            echo "✅ kubearmor-init: PASSED"
-          fi
+  report-vulnerabilities:
+    name: Track Trivy findings
+    needs: build
+    if: |
+      !cancelled() &&
+      github.event_name == 'push' &&
+      github.ref == 'refs/heads/main' &&
+      needs.build.outputs.vulnerable == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-          # Check kubearmor scan result
-          if [[ "${{ steps.scan_main.outcome }}" == "failure" ]]; then
-            echo "❌ kubearmor: FAILED (Vulnerabilities found)"
-            any_scan_failed=true
-          else
-            echo "✅ kubearmor: PASSED"
-          fi
+      - name: Download Trivy reports
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: trivy-reports-ubi
+          path: trivy-reports
 
-          # Check kubearmor-controller scan result, if it ran
-          if [[ "${{ steps.filter.outputs.controller }}" == "true" ]]; then
-            if [[ "${{ steps.scan_controller.outcome }}" == "failure" ]]; then
-              echo "❌ kubearmor-controller: FAILED (Vulnerabilities found)"
-              any_scan_failed=true
-            else
-              echo "✅ kubearmor-controller: PASSED"
-            fi
-          fi
-
-          # Check kubearmor-operator scan result, if it ran
-          if [[ "${{ steps.filter.outputs.operator }}" == "true" ]]; then
-            if [[ "${{ steps.scan_operator.outcome }}" == "failure" ]]; then
-              echo "❌ kubearmor-operator: FAILED (Vulnerabilities found)"
-              any_scan_failed=true
-            else
-              echo "✅ kubearmor-operator: PASSED"
-            fi
-          fi
-
-          echo "=========================="
-          if [[ "$any_scan_failed" == "true" ]]; then
-            echo "One or more Trivy scans failed. Check logs above for details."
-            exit 1
-          else
-            echo "All Trivy scans passed."
-          fi
+      - name: Create or update the Trivy tracking issue
+        run: ./.github/workflows/trivy-report-issue.sh
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          TRIVY_ISSUE_TITLE: "[Trivy] Vulnerabilities detected in KubeArmor UBI images on main"
+          TRIVY_ARTIFACT_NAME: trivy-reports-ubi
+          TRIVY_REPORT_DIR: trivy-reports
+          TRIVY_LABELS: security,trivy
+          TRIVY_SEVERITY: CRITICAL,HIGH

--- a/.github/workflows/ci-trivy-scan.yaml
+++ b/.github/workflows/ci-trivy-scan.yaml
@@ -26,6 +26,9 @@ jobs:
     permissions:
       id-token: write
     timeout-minutes: 150
+    outputs:
+      vulnerable: ${{ steps.summary.outputs.vulnerable }}
+      failed_components: ${{ steps.summary.outputs.failed_components }}
     steps:
       - name: Checkout code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -102,12 +105,16 @@ jobs:
             docker save -o kubearmor-controller.tar kubearmor/kubearmor-controller:latest
           fi
           
+      - name: Prepare Trivy report directory
+        run: mkdir -p trivy-reports
+
       - name: Run Trivy vulnerability scanner on kubearmor-init
         id: scan_init
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           input: kubearmor-init.tar
           format: 'table'
+          output: 'trivy-reports/kubearmor-init.txt'
           exit-code: '1'
           ignore-unfixed: true
           vuln-type: 'os,library'
@@ -120,6 +127,7 @@ jobs:
         with:
           input: kubearmor.tar
           format: 'table'
+          output: 'trivy-reports/kubearmor.txt'
           exit-code: '1'
           ignore-unfixed: true
           vuln-type: 'os,library'
@@ -133,6 +141,7 @@ jobs:
         with:
           input: kubearmor-controller.tar
           format: 'table'
+          output: 'trivy-reports/kubearmor-controller.txt'
           exit-code: '1'
           ignore-unfixed: true
           vuln-type: 'os,library'
@@ -146,6 +155,7 @@ jobs:
         with:
           input: kubearmor-operator.tar
           format: 'table'
+          output: 'trivy-reports/kubearmor-operator.txt'
           exit-code: '1'
           ignore-unfixed: true
           vuln-type: 'os,library'
@@ -153,51 +163,62 @@ jobs:
         continue-on-error: true 
 
 
-      - name: Report Trivy Scan Results
+      - name: Summarize Trivy scan results
+        id: summary
+        env:
+          TRIVY_COMPONENTS: |
+            kubearmor-init|kubearmor/kubearmor-init:latest|${{ steps.scan_init.outcome }}|true
+            kubearmor|kubearmor/kubearmor:latest|${{ steps.scan_main.outcome }}|true
+            kubearmor-controller|kubearmor/kubearmor-controller:latest|${{ steps.scan_controller.outcome }}|${{ steps.filter.outputs.controller }}
+            kubearmor-operator|kubearmor/kubearmor-operator:latest|${{ steps.scan_operator.outcome }}|${{ steps.filter.outputs.operator }}
+        run: ./.github/workflows/trivy-summarize.sh
+
+      - name: Upload Trivy reports
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: trivy-reports
+          path: trivy-reports/
+          if-no-files-found: warn
+          retention-days: 30
+
+      - name: Fail if vulnerabilities were found
+        if: steps.summary.outputs.vulnerable == 'true'
+        env:
+          FAILED_COMPONENTS: ${{ steps.summary.outputs.failed_components }}
         run: |
-          echo "Trivy Scan Results Summary:"
-          echo "=========================="
-          any_scan_failed=false
+          echo "Trivy reported vulnerabilities in: $FAILED_COMPONENTS"
+          exit 1
 
-          if [[ "${{ steps.scan_init.outcome }}" == "failure" ]]; then
-            echo "❌ kubearmor-init: FAILED (Vulnerabilities found)"
-            any_scan_failed=true
-          else
-            echo "✅ kubearmor-init: PASSED"
-          fi
+  report-vulnerabilities:
+    name: Track Trivy findings
+    needs: build
+    if: |
+      !cancelled() &&
+      github.event_name == 'push' &&
+      github.ref == 'refs/heads/main' &&
+      needs.build.outputs.vulnerable == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-          # Check kubearmor scan result
-          if [[ "${{ steps.scan_main.outcome }}" == "failure" ]]; then
-            echo "❌ kubearmor: FAILED (Vulnerabilities found)"
-            any_scan_failed=true
-          else
-            echo "✅ kubearmor: PASSED"
-          fi
+      - name: Download Trivy reports
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: trivy-reports
+          path: trivy-reports
 
-          # Check kubearmor-controller scan result, if it ran
-          if [[ "${{ steps.filter.outputs.controller }}" == "true" ]]; then
-            if [[ "${{ steps.scan_controller.outcome }}" == "failure" ]]; then
-              echo "❌ kubearmor-controller: FAILED (Vulnerabilities found)"
-              any_scan_failed=true
-            else
-              echo "✅ kubearmor-controller: PASSED"
-            fi
-          fi
-
-          # Check kubearmor-operator scan result, if it ran
-          if [[ "${{ steps.filter.outputs.operator }}" == "true" ]]; then
-            if [[ "${{ steps.scan_operator.outcome }}" == "failure" ]]; then
-              echo "❌ kubearmor-operator: FAILED (Vulnerabilities found)"
-              any_scan_failed=true
-            else
-              echo "✅ kubearmor-operator: PASSED"
-            fi
-          fi
-
-          echo "=========================="
-          if [[ "$any_scan_failed" == "true" ]]; then
-            echo "One or more Trivy scans failed. Check logs above for details."
-            exit 1
-          else
-            echo "All Trivy scans passed."
-          fi
+      - name: Create or update the Trivy tracking issue
+        run: ./.github/workflows/trivy-report-issue.sh
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          TRIVY_ISSUE_TITLE: "[Trivy] Vulnerabilities detected in KubeArmor images on main"
+          TRIVY_ARTIFACT_NAME: trivy-reports
+          TRIVY_REPORT_DIR: trivy-reports
+          TRIVY_LABELS: security,trivy
+          TRIVY_SEVERITY: CRITICAL,HIGH

--- a/.github/workflows/trivy-report-issue.sh
+++ b/.github/workflows/trivy-report-issue.sh
@@ -1,0 +1,254 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Authors of KubeArmor
+
+# Opens a GitHub tracking issue when a Trivy scan reports vulnerabilities, or
+# appends a comment to the already open tracking issue so that every push to
+# main does not create a duplicate.
+#
+# Input (environment):
+#   GH_TOKEN              token with "issues: write" on the repository (used by gh)
+#   GH_REPO               "owner/repo" to operate on
+#   TRIVY_ISSUE_TITLE     exact issue title, also used as the deduplication key
+#   TRIVY_REPORT_DIR      directory with "<component>.txt" reports and
+#                         "failed-components.tsv" (default: trivy-reports)
+#   TRIVY_LABELS          comma separated labels (default: "security,trivy")
+#   TRIVY_SEVERITY        severities the scan ran with (default: "CRITICAL,HIGH")
+#   TRIVY_ARTIFACT_NAME   name of the artifact holding the full reports
+#   GITHUB_SHA, GITHUB_SERVER_URL, GITHUB_RUN_ID, GITHUB_WORKFLOW
+#                         standard GitHub Actions context, used for the links
+
+set -euo pipefail
+
+REPO="${GH_REPO:-${GITHUB_REPOSITORY:-}}"
+TITLE="${TRIVY_ISSUE_TITLE:?TRIVY_ISSUE_TITLE must be set}"
+REPORT_DIR="${TRIVY_REPORT_DIR:-trivy-reports}"
+LABELS="${TRIVY_LABELS:-security,trivy}"
+SEVERITY="${TRIVY_SEVERITY:-CRITICAL,HIGH}"
+ARTIFACT_NAME="${TRIVY_ARTIFACT_NAME:-trivy-reports}"
+SERVER_URL="${GITHUB_SERVER_URL:-https://github.com}"
+SHA="${GITHUB_SHA:-unknown}"
+RUN_ID="${GITHUB_RUN_ID:-}"
+WORKFLOW="${GITHUB_WORKFLOW:-Trivy scan}"
+
+# GitHub rejects issue bodies and comments larger than 65536 characters. Stay
+# well below that so the reports can be truncated with a readable notice.
+MAX_BODY=60000
+
+MANIFEST="$REPORT_DIR/failed-components.tsv"
+
+log() {
+  echo "[trivy-report-issue] $*" >&2
+}
+
+if [ -z "$REPO" ]; then
+  log "GH_REPO (or GITHUB_REPOSITORY) must be set"
+  exit 1
+fi
+
+if [ ! -s "$MANIFEST" ] || ! grep -q '[^[:space:]]' "$MANIFEST"; then
+  log "no failing components recorded in $MANIFEST, nothing to report"
+  exit 0
+fi
+
+if [ -n "$RUN_ID" ]; then
+  RUN_URL="$SERVER_URL/$REPO/actions/runs/$RUN_ID"
+else
+  RUN_URL=""
+fi
+
+# Creates a label when it is missing. Labels that cannot be ensured are dropped
+# from the issue instead of failing the whole run, because "gh issue create"
+# rejects labels that do not exist in the repository.
+ensure_label() {
+  local name="$1" color="$2" description="$3" output=""
+
+  if output="$(gh label create "$name" --repo "$REPO" --color "$color" \
+    --description "$description" 2>&1)"; then
+    log "created label '$name'"
+    return 0
+  fi
+
+  if printf '%s' "$output" | grep -qi "already exists"; then
+    log "label '$name' already exists"
+    return 0
+  fi
+
+  log "WARNING: could not ensure label '$name': $output"
+  return 1
+}
+
+label_description() {
+  case "$1" in
+  security) echo "Security related issue" ;;
+  trivy) echo "Reported by the Trivy image scan" ;;
+  *) echo "Created by the Trivy scan workflow" ;;
+  esac
+}
+
+label_color() {
+  case "$1" in
+  security) echo "d93f0b" ;;
+  trivy) echo "1d76db" ;;
+  *) echo "ededed" ;;
+  esac
+}
+
+# Ensure every requested label exists and keep the ones that are usable.
+usable_labels=""
+old_ifs="$IFS"
+IFS=','
+for label in $LABELS; do
+  IFS="$old_ifs"
+  [ -n "$label" ] || continue
+  if ensure_label "$label" "$(label_color "$label")" "$(label_description "$label")"; then
+    usable_labels="${usable_labels:+$usable_labels,}$label"
+  fi
+  IFS=','
+done
+IFS="$old_ifs"
+
+# Looks for an already open tracking issue with exactly this title. The label
+# filter keeps the listing small; it is dropped when no label could be ensured.
+find_open_issue() {
+  local args=(issue list --repo "$REPO" --state open --limit 100)
+  local label
+
+  if [ -n "$usable_labels" ]; then
+    old_ifs="$IFS"
+    IFS=','
+    for label in $usable_labels; do
+      IFS="$old_ifs"
+      args+=(--label "$label")
+      IFS=','
+    done
+    IFS="$old_ifs"
+  fi
+
+  # shellcheck disable=SC2054 # "number,title" is a single gh argument
+  args+=(--json number,title --template '{{range .}}{{.number}}{{"\t"}}{{.title}}{{"\n"}}{{end}}')
+
+  gh "${args[@]}" | awk -F'\t' -v title="$TITLE" '$2 == title { print $1; exit }'
+}
+
+# Prints a report, shortened to at most "$2" bytes so that the body stays within
+# the GitHub size limit.
+#
+# "head -c" caps the byte count, and "sed '\$ d'" then drops the trailing line it
+# may have cut in half. Everything that survives is therefore a whole line, which
+# keeps the Trivy table readable and, because the table is drawn with three byte
+# box characters, keeps the output valid UTF-8. Counting bytes here rather than
+# with awk's length() also avoids depending on whether the runner's awk is
+# multibyte aware.
+render_report() {
+  local file="$1" budget="$2" size
+
+  if [ ! -s "$file" ]; then
+    echo "(no report was captured for this component, the scan step may have failed before writing one)"
+    return 0
+  fi
+
+  size="$(wc -c <"$file" | tr -d ' ')"
+  if [ "$size" -le "$budget" ]; then
+    cat "$file"
+    return 0
+  fi
+
+  head -c "$budget" "$file" | sed '$ d'
+  printf '\n[... truncated at ~%s of %s bytes, download the "%s" artifact from the workflow run for the full report ...]\n' \
+    "$budget" "$size" "$ARTIFACT_NAME"
+}
+
+# Writes the issue body ("create") or the follow up comment ("comment") to "$2".
+render_body() {
+  local mode="$1" out="$2"
+  local name image count used budget
+
+  : >"$out"
+
+  if [ "$mode" = "create" ]; then
+    {
+      echo "Trivy reported \`$SEVERITY\` vulnerabilities in the images built from \`main\`."
+      echo
+      echo "This issue is maintained automatically by the \`$WORKFLOW\` workflow: every"
+      echo "later failing scan is appended as a comment instead of opening a new issue."
+      echo "Close it once the scans are green again."
+      echo
+    } >>"$out"
+  else
+    {
+      echo "### Still failing on a newer commit"
+      echo
+    } >>"$out"
+  fi
+
+  {
+    echo "| | |"
+    echo "| --- | --- |"
+    echo "| Commit | [\`${SHA:0:7}\`]($SERVER_URL/$REPO/commit/$SHA) |"
+    if [ -n "$RUN_URL" ]; then
+      echo "| Workflow run | [$WORKFLOW]($RUN_URL) |"
+    fi
+    echo "| Severities | \`$SEVERITY\` (unfixed vulnerabilities ignored) |"
+    echo
+    echo "**Affected images**"
+    echo
+  } >>"$out"
+
+  while IFS=$'\t' read -r name image; do
+    [ -n "$name" ] || continue
+    echo "- \`${image:-$name}\`" >>"$out"
+  done <"$MANIFEST"
+
+  echo >>"$out"
+
+  count="$(grep -c . "$MANIFEST" || true)"
+  [ "${count:-0}" -gt 0 ] || count=1
+  used="$(wc -c <"$out" | tr -d ' ')"
+  budget=$(((MAX_BODY - used - 2000) / count))
+  [ "$budget" -ge 1000 ] || budget=1000
+
+  while IFS=$'\t' read -r name image; do
+    [ -n "$name" ] || continue
+    {
+      printf '<details><summary>Trivy report: <code>%s</code></summary>\n\n' "${image:-$name}"
+      printf '```\n'
+      render_report "$REPORT_DIR/$name.txt" "$budget"
+      printf '```\n\n</details>\n\n'
+    } >>"$out"
+  done <"$MANIFEST"
+
+  if [ -n "$RUN_URL" ]; then
+    echo "The complete reports are attached to the [workflow run]($RUN_URL) as the \`$ARTIFACT_NAME\` artifact." >>"$out"
+  fi
+}
+
+body="$(mktemp)"
+trap 'rm -f "$body"' EXIT
+
+issue_number="$(find_open_issue)"
+
+if [ -n "$issue_number" ]; then
+  log "updating existing tracking issue #$issue_number"
+  render_body comment "$body"
+  gh issue comment "$issue_number" --repo "$REPO" --body-file "$body"
+  issue_url="$SERVER_URL/$REPO/issues/$issue_number"
+else
+  log "opening a new tracking issue"
+  render_body create "$body"
+  create_args=(issue create --repo "$REPO" --title "$TITLE" --body-file "$body")
+  if [ -n "$usable_labels" ]; then
+    create_args+=(--label "$usable_labels")
+  fi
+  issue_url="$(gh "${create_args[@]}")"
+fi
+
+log "tracking issue: $issue_url"
+
+if [ -n "${GITHUB_OUTPUT:-}" ]; then
+  echo "issue-url=$issue_url" >>"$GITHUB_OUTPUT"
+fi
+
+if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+  echo "Trivy tracking issue: $issue_url" >>"$GITHUB_STEP_SUMMARY"
+fi

--- a/.github/workflows/trivy-summarize.sh
+++ b/.github/workflows/trivy-summarize.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Authors of KubeArmor
+
+# Summarizes the per-component Trivy scan step outcomes for the ci-trivy-scan
+# and ci-trivy-scan-ubi workflows.
+#
+# Input (environment):
+#   TRIVY_COMPONENTS  newline separated records of "name|image|outcome|enabled".
+#                     "outcome" is the GitHub Actions outcome of the scan step and
+#                     "enabled" is "true" when the component was actually built.
+#   TRIVY_REPORT_DIR  directory holding the "<name>.txt" Trivy reports
+#                     (default: trivy-reports)
+#
+# Output:
+#   - a human readable summary on stdout and, when running in CI, in the job summary
+#   - the "vulnerable" and "failed_components" step outputs
+#   - "$TRIVY_REPORT_DIR/failed-components.tsv" listing "name<TAB>image" for every
+#     failing component, later consumed by trivy-report-issue.sh
+
+set -euo pipefail
+
+REPORT_DIR="${TRIVY_REPORT_DIR:-trivy-reports}"
+: "${TRIVY_COMPONENTS:?TRIVY_COMPONENTS must be set}"
+
+mkdir -p "$REPORT_DIR"
+manifest="$REPORT_DIR/failed-components.tsv"
+: >"$manifest"
+
+summary="$(mktemp)"
+trap 'rm -f "$summary"' EXIT
+
+failed_components=""
+vulnerable="false"
+
+{
+  echo "## Trivy scan results"
+  echo
+  echo "| Component | Image | Result |"
+  echo "| --- | --- | --- |"
+} >>"$summary"
+
+# Trim the surrounding whitespace that YAML block scalars leave behind.
+trim() {
+  printf '%s' "${1:-}" | tr -d '[:space:]'
+}
+
+while IFS='|' read -r name image outcome enabled; do
+  name="$(trim "${name:-}")"
+  [ -n "$name" ] || continue
+  image="$(trim "${image:-}")"
+  outcome="$(trim "${outcome:-}")"
+  enabled="$(trim "${enabled:-}")"
+
+  if [ "$enabled" != "true" ]; then
+    printf "| %s | \`%s\` | :fast_forward: skipped (not built) |\n" "$name" "$image" >>"$summary"
+    continue
+  fi
+
+  case "$outcome" in
+  failure)
+    printf "| %s | \`%s\` | :x: vulnerabilities found |\n" "$name" "$image" >>"$summary"
+    printf '%s\t%s\n' "$name" "$image" >>"$manifest"
+    failed_components="${failed_components:+$failed_components }$name"
+    vulnerable="true"
+    ;;
+  success)
+    printf "| %s | \`%s\` | :white_check_mark: passed |\n" "$name" "$image" >>"$summary"
+    ;;
+  *)
+    printf "| %s | \`%s\` | :warning: scan did not run (%s) |\n" \
+      "$name" "$image" "${outcome:-unknown}" >>"$summary"
+    ;;
+  esac
+done <<EOF
+$TRIVY_COMPONENTS
+EOF
+
+# Keep the reports visible in the job log: with "output" set, trivy-action writes
+# the tables to files instead of printing them.
+for report in "$REPORT_DIR"/*.txt; do
+  [ -f "$report" ] || continue
+  echo "=============================================================="
+  echo "Trivy report: $(basename "$report")"
+  echo "=============================================================="
+  cat "$report"
+  echo
+done
+
+cat "$summary"
+
+if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+  cat "$summary" >>"$GITHUB_STEP_SUMMARY"
+fi
+
+if [ -n "${GITHUB_OUTPUT:-}" ]; then
+  {
+    echo "vulnerable=$vulnerable"
+    echo "failed_components=$failed_components"
+  } >>"$GITHUB_OUTPUT"
+fi
+
+if [ "$vulnerable" = "true" ]; then
+  echo "Trivy found vulnerabilities in: $failed_components"
+else
+  echo "All Trivy scans passed."
+fi


### PR DESCRIPTION
Fixes #2851

## What this does

The Trivy workflows already fail the run when an image has `CRITICAL`/`HIGH` vulnerabilities, but the findings only ever lived in the job log, no alerting, nothing to track them against.

Both scan workflows now keep their reports and, **on pushes to `main`**, open a GitHub issue labelled `security` and `trivy`. If a tracking issue is already open, the next failing scan is **appended as a comment** rather than opening a duplicate on every push.

### Tasks from the issue

- [x] Update `.github/workflows/ci-trivy-scan.yaml`
- [x] Update `.github/workflows/ci-trivy-scan-ubi.yaml`
- [x] Ensure `trivy` and `security` labels exist in the repository

On the third: neither label exists in the repo today, and `gh issue create` rejects unknown labels, so the script creates them if missing (idempotent, and it degrades to filing the issue without a label rather than failing if it cannot). Pre-creating them by hand also works, the script then just no-ops.

## Approach

The reporting logic sits in two shell scripts instead of inline YAML, so the two workflows share it rather than duplicating it:

| File | Role |
| --- | --- |
| `.github/workflows/trivy-summarize.sh` | Replaces the ~48-line summary block that was copy-pasted into both workflows. Renders the per-component result table into the job summary and records which components failed. |
| `.github/workflows/trivy-report-issue.sh` | Ensures the labels exist, finds the open tracking issue, and creates it or comments on it. |

Design notes:

- **Least privilege.** Issue creation runs in a **separate job** on `ubuntu-latest`, so only that job gets `issues: write`; the build job on the self-hosted runner keeps its existing permissions. This mirrors the existing `create_issue` job in `ci-marketplace-release.yml`, except it uses `secrets.GITHUB_TOKEN`, so no new secret is needed.
- **Reports are captured.** The scans now write to files, which are uploaded as a workflow artifact *and* embedded in the issue. Because trivy tables are drawn with 3-byte box characters, reports are truncated on line boundaries to stay inside GitHub's 65536 **byte** issue-body limit, with a pointer to the artifact for the full output. The reports are still `cat`-ed into the job log, so the console output you see today is unchanged.
- **Dedup is an exact title match** against open issues carrying both labels, so the plain and UBI workflows keep separate tracking issues and a near-miss title never silently swallows a new report.
- **Scope.** Issue filing is gated to `push` on `main` only. Pushes to `v*` and `create` events behave exactly as before, and a build that fails *before* the scans (compile error, etc.) files nothing.

### Drive-by fix

`ci-trivy-scan-ubi.yaml` declared `name: ci-trivy-scan`, identical to the non-UBI workflow, which made the two indistinguishable in the Actions UI. It is now `ci-trivy-scan-ubi`.

## What the issue looks like

<details><summary>Rendered body</summary>

> Trivy reported `CRITICAL,HIGH` vulnerabilities in the images built from `main`.
>
> This issue is maintained automatically by the `ci-trivy-scan` workflow: every later failing scan is appended as a comment instead of opening a new issue. Close it once the scans are green again.
>
> | | |
> | --- | --- |
> | Commit | [`3c34671`](https://github.com/kubearmor/KubeArmor/commit/3c34671) |
> | Workflow run | [ci-trivy-scan](https://github.com/kubearmor/KubeArmor/actions) |
> | Severities | `CRITICAL,HIGH` (unfixed vulnerabilities ignored) |
>
> **Affected images**
>
> - `kubearmor/kubearmor:latest`
>
> <details><summary>Trivy report: <code>kubearmor/kubearmor:latest</code></summary>
>
> ```
> kubearmor.tar (debian 12.11)
> ============================
> Total: 2 (HIGH: 1, CRITICAL: 1)
> ...
> ```
>
> </details>
>
> The complete reports are attached to the workflow run as the `trivy-reports` artifact.

</details>

Follow-up scans add a `### Still failing on a newer commit` comment with the new SHA, run link and fresh report.

## Testing

Validated end to end on my fork across 9 workflow runs, covering both scan workflows and real KubeArmor images. That includes a real CVE on a genuinely built image opening a tracking issue, the dedup path commenting on it instead of creating a duplicate, clean scans correctly filing nothing, and a build failure before the scan correctly filing nothing. Full per-run breakdown with links in the [validation record](https://github.com/kubearmor/KubeArmor/pull/2852#issuecomment-5451341118).

Static checks:

- `shellcheck -x` clean on both scripts.
- `actionlint` reports no new findings. The 2 findings per Trivy workflow (`create` plus `branches`, and the self-hosted runner label) are identical on the unmodified files.
- `codespell` clean, and SPDX headers present per `.licenserc.yaml`.
- Confirmed the pinned `trivy-action` is a composite action whose `output` input maps to `TRIVY_OUTPUT`, so reports land in the workspace with normal ownership.

## Note for maintainers

The end-to-end path is exercised on my fork rather than here, since the build job is gated on `github.repository == 'kubearmor/kubearmor'` and fork PRs are not granted `issues: write`. Run 8 in the [validation record](https://github.com/kubearmor/KubeArmor/pull/2852#issuecomment-5451341118) shows a real CVE on a genuinely built KubeArmor image opening a tracking issue, and a later run commenting on it instead of duplicating. The first firing on this repo is still worth a look.
