### PR TITLE
fix(deploy): mount host /etc/machine-id for correct node_id reporting

### DIFF
--- a/deployments/helm/KubeArmor/templates/daemonset.yaml
+++ b/deployments/helm/KubeArmor/templates/daemonset.yaml
@@ -76,6 +76,11 @@ spec:
         terminationMessagePolicy: File
         volumeMounts:
         {{- toYaml .Values.kubearmor.commonMounts | trim | nindent 10 }}
+        {{- if ne .Values.environment.name "autopilot" }}
+          - mountPath: /etc/machine-id
+            name: machine-id
+            readOnly: true
+        {{- end }}
         {{- if .Values.tls.enabled -}}
           {{- toYaml .Values.kubearmor.tls.kubearmorCACertVolumeMount | trim | nindent 10 }}
         {{- end -}}
@@ -148,6 +153,12 @@ spec:
       terminationGracePeriodSeconds: 30
       volumes:
       {{- toYaml .Values.kubearmor.commonVolumes | trim | nindent 8}}
+      {{- if ne .Values.environment.name "autopilot" }}
+        - hostPath:
+            path: /etc/machine-id
+            type: File
+          name: machine-id
+      {{- end }}
       {{- if .Values.tls.enabled -}}
         {{- toYaml .Values.kubearmor.tls.kubearmorCACertVolume | trim | nindent 8 }}
       {{- end -}}

--- a/deployments/podman/docker-compose.yaml
+++ b/deployments/podman/docker-compose.yaml
@@ -59,6 +59,7 @@ services:
       - "/sys/kernel/security:/sys/kernel/security"
       - "/sys/kernel/debug:/sys/kernel/debug"
       - "/etc/apparmor.d:/etc/apparmor.d"
+      - "/etc/machine-id:/etc/machine-id:ro"
       - "/usr/share/kubearmor:/usr/share/kubearmor:rw"
       - "/var/run/kubearmor:/var/run/kubearmor:rw"
     restart: always

--- a/pkg/KubeArmorOperator/common/defaults.go
+++ b/pkg/KubeArmorOperator/common/defaults.go
@@ -357,6 +357,15 @@ var CommonVolumes = []corev1.Volume{
 			},
 		},
 	},
+	{
+		Name: "machine-id",
+		VolumeSource: corev1.VolumeSource{
+			HostPath: &corev1.HostPathVolumeSource{
+				Path: "/etc/machine-id",
+				Type: &HostPathFile,
+			},
+		},
+	},
 }
 
 var CommonVolumesMount = []corev1.VolumeMount{
@@ -373,6 +382,11 @@ var CommonVolumesMount = []corev1.VolumeMount{
 		Name:      deployments.KubeArmorConfigMapName,
 		MountPath: filepath.Join("/opt/kubearmor", KubeArmorConfigFileName),
 		SubPath:   KubeArmorConfigFileName,
+	},
+	{
+		Name:      "machine-id",
+		MountPath: "/etc/machine-id",
+		ReadOnly:  true,
 	},
 }
 


### PR DESCRIPTION
**Purpose of PR?**:

KubeArmor reports the wrong `node_id`/`machine_id` when it is not run directly on the
host (Docker/Podman deployment, and any Kubernetes DaemonSet installed via the Helm
chart or the KubeArmorOperator). `KubeArmor/core/kubeArmor.go` reads `/etc/machine-id`
(falling back to `/var/lib/dbus/machine-id`, then to the node name) to populate
`Node.NodeID`, but none of the container-based deployment manifests mounted the host's
`/etc/machine-id` into the KubeArmor container. Inside the container that path either
doesn't exist or belongs to the container's own filesystem, so both reads fail and the
code silently falls back to using the node name as the machine ID — exactly the symptom
described in the issue (systemd installs are unaffected because KubeArmor runs directly
on the host there).

Fixes #

**Does this PR introduce a breaking change?**

No. This only adds a new read-only hostPath mount of `/etc/machine-id` to existing
deployment manifests; no application code, CLI flags, or existing behavior changes.

**If the changes in this PR are manually verified, list down the scenarios covered:**:

This is a manifest-only fix (no cluster/docker available in the sandbox this was
prepared in), so validation was limited to static/template-level checks that mirror
what this repo's own CI runs for these paths:
- `helm lint ./deployments/helm/KubeArmor` and `./deployments/helm/KubeArmorOperator` — pass.
- `.github/workflows/helm-validate-values.sh` (the exact script `ci-test-helm-charts.yml` runs) — passes for docker/crio/k3s/microk8s/minikube/GKE/BottleRocket/EKS/generic.
- Rendered `helm template ... -s templates/daemonset.yaml --set environment.name=<env>` for all 11 supported environment values and confirmed the new `/etc/machine-id` volume + mount is present on the main `kubearmor` container for every environment except `GKE Autopilot` (excluded intentionally, see below), and is absent from the `init` container.
- `deployments/podman/docker-compose.yaml` validated as syntactically-correct YAML (`python3 -c "import yaml; yaml.safe_load(...)"`).
- `cd pkg/KubeArmorOperator && go build ./common/... ./internal/controller/...`, `go vet` on the same packages, and `go test ./common/... ./internal/controller/...` all pass; `gofmt -l` reports no issues on the changed Go file.
- Could not run this repo's live-cluster CI job (`ci-test-controllers.yml`, which installs the operator on a real k3s cluster) — no docker/k3s available here. That job also doesn't assert on `node_id`/`machine-id` values either way, so it wouldn't have specifically exercised this fix even if it were run.

GKE Autopilot (`deployments/helm/KubeArmor`, `environment.name=autopilot`) is deliberately
excluded from the new mount: Autopilot only permits a fixed, Google-controlled allowlist
of hostPath mounts for allowlisted system pods (this chart already opts KubeArmor into
that allowlist via `cloud.google.com/matching-allowlist`), so adding an arbitrary new
hostPath there risks breaking Autopilot installs outright.

**Additional information for reviewer?** :

Two of the three DaemonSet-generation code paths in this repo are updated:
`deployments/helm/KubeArmor` (used directly, and for GKE Autopilot) and the
KubeArmorOperator (`pkg/KubeArmorOperator/common/defaults.go`, the default path behind
`karmor install` / `helm install kubearmor-operator`). The third, legacy path
(`deployments/get/objects.go`, used only by an opt-in `--legacy` installer flag in the
separate `kubearmor-client` repo and marked deprecated in favor of `karmor install`/Helm
in this repo's development guide) is intentionally left out of scope here to keep this
change small; happy to follow up separately if maintainers would like it covered too.

**Checklist:**
- [x] Bug fix. Fixes #<issue number>
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Commit has unit tests
- [ ] Commit has integration tests

Fixes #2846