### PR TITLE
fix(networkpolicy): resolve container/host network policy matching outside k8s

### DIFF
--- a/KubeArmor/common/common.go
+++ b/KubeArmor/common/common.go
@@ -16,6 +16,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"regexp"
+	"runtime"
 	"slices"
 	"strconv"
 	"strings"
@@ -367,6 +368,118 @@ func GetIPAddr(ifname string) string {
 func GetExternalIPAddr() string {
 	iface := GetExternalInterface()
 	return GetIPAddr(iface)
+}
+
+// GetContainerIPFromPid Function resolves a container's primary IP address by
+// entering its network namespace via /proc/<pid>/ns/net. Container runtimes
+// that don't expose an IP through their own API (e.g. containerd, CRI-O) rely
+// on this outside k8s, where no higher-level source (the K8s pod status)
+// already provides the address.
+func GetContainerIPFromPid(pid uint32) string {
+	if pid == 0 {
+		return ""
+	}
+
+	targetPath := filepath.Join(kc.GlobalCfg.ProcFsMount, strconv.Itoa(int(pid)), "ns", "net")
+	targetNS, err := os.Open(targetPath)
+	if err != nil {
+		kg.Warnf("Failed to open network namespace (%s): %s", targetPath, err.Error())
+		return ""
+	}
+	defer func() {
+		if err := targetNS.Close(); err != nil {
+			kg.Warnf("Failed to close network namespace handle (%s): %s", targetPath, err.Error())
+		}
+	}()
+
+	// Namespaces are per-thread on Linux. Lock this goroutine to its current
+	// OS thread so no other goroutine is scheduled onto it while we're inside
+	// the container's namespace, and so we restore the exact thread we moved.
+	runtime.LockOSThread()
+	restored := false
+	defer func() {
+		if !restored {
+			// We failed to move this thread back to the host namespace.
+			// Terminate it instead of unlocking it, so the Go runtime never
+			// reuses it to run unrelated goroutines from inside a
+			// container's network namespace. This also ends the calling
+			// goroutine, so only call this from a dedicated one (the
+			// container event monitors) - never from main.
+			runtime.Goexit()
+		}
+	}()
+
+	originalNS, err := os.Open("/proc/thread-self/ns/net")
+	if err != nil {
+		kg.Warnf("Failed to open current network namespace: %s", err.Error())
+		runtime.UnlockOSThread()
+		restored = true
+		return ""
+	}
+	defer func() {
+		if err := originalNS.Close(); err != nil {
+			kg.Warnf("Failed to close original network namespace handle: %s", err.Error())
+		}
+	}()
+
+	if err := unix.Setns(int(targetNS.Fd()), unix.CLONE_NEWNET); err != nil {
+		kg.Warnf("Failed to enter network namespace (%s): %s", targetPath, err.Error())
+		runtime.UnlockOSThread()
+		restored = true
+		return ""
+	}
+
+	ip := firstUsableAddr()
+
+	if err := unix.Setns(int(originalNS.Fd()), unix.CLONE_NEWNET); err != nil {
+		// Leave restored=false: the deferred cleanup above will terminate
+		// this thread rather than unlock it in a foreign namespace.
+		kg.Err("Failed to restore original network namespace: " + err.Error())
+		return ""
+	}
+	runtime.UnlockOSThread()
+	restored = true
+
+	return ip
+}
+
+// firstUsableAddr returns the first non-loopback, non-link-local address
+// visible on any up interface in the calling thread's current network
+// namespace, preferring IPv4. Meant to be called only after entering a
+// target namespace via GetContainerIPFromPid.
+func firstUsableAddr() string {
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		kg.Warnf("Failed to list interfaces: %s", err.Error())
+		return ""
+	}
+
+	var ipv6Fallback string
+	for _, iface := range ifaces {
+		if iface.Flags&net.FlagLoopback != 0 || iface.Flags&net.FlagUp == 0 {
+			continue
+		}
+
+		addrs, err := iface.Addrs()
+		if err != nil {
+			continue
+		}
+
+		for _, addr := range addrs {
+			ipNet, ok := addr.(*net.IPNet)
+			if !ok || ipNet.IP.IsLoopback() || ipNet.IP.IsLinkLocalUnicast() {
+				continue
+			}
+			if ip4 := ipNet.IP.To4(); ip4 != nil {
+				return ip4.String()
+			}
+			if ipv6Fallback == "" {
+				ipv6Fallback = ipNet.IP.String()
+			}
+		}
+	}
+
+	return ipv6Fallback
 }
 
 // ================ //

--- a/KubeArmor/common/common_netns_test.go
+++ b/KubeArmor/common/common_netns_test.go
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Authors of KubeArmor
+
+package common
+
+import (
+	"os"
+	"os/exec"
+	"syscall"
+	"testing"
+	"time"
+
+	kc "github.com/kubearmor/KubeArmor/KubeArmor/config"
+)
+
+// TestGetContainerIPFromPidRealNamespace exercises the real namespace-switch
+// path against an actual, isolated network namespace holding a known,
+// non-loopback address, rather than a mocked container. It needs root and
+// CAP_NET_ADMIN/CAP_SYS_ADMIN (available on the CI runners this repo already
+// requires them on for its nftables/eBPF tests), so it skips itself
+// everywhere else, including a default sandboxed container.
+func TestGetContainerIPFromPidRealNamespace(t *testing.T) {
+	if os.Geteuid() != 0 {
+		t.Skip("requires root to create a network namespace")
+	}
+	if _, err := exec.LookPath("ip"); err != nil {
+		t.Skip("requires the 'ip' binary (iproute2)")
+	}
+
+	oldProcFsMount := kc.GlobalCfg.ProcFsMount
+	kc.GlobalCfg.ProcFsMount = "/proc"
+	t.Cleanup(func() { kc.GlobalCfg.ProcFsMount = oldProcFsMount })
+
+	const wantIP = "10.211.99.5"
+	cmd := exec.Command("sh", "-c",
+		"ip link add dummy0 type dummy && ip link set dummy0 up && ip addr add "+wantIP+"/24 dev dummy0 && sleep 30")
+	cmd.SysProcAttr = &syscall.SysProcAttr{Cloneflags: syscall.CLONE_NEWNET}
+	if err := cmd.Start(); err != nil {
+		t.Skipf("could not create an isolated network namespace: %s", err)
+	}
+	t.Cleanup(func() {
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+	})
+
+	pid := uint32(cmd.Process.Pid)
+
+	// Give the child a moment to configure its interface before we read it.
+	var got string
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		got = GetContainerIPFromPid(pid)
+		if got != "" {
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	if got != wantIP {
+		t.Fatalf("GetContainerIPFromPid() = %q, want %q", got, wantIP)
+	}
+
+	// Namespaces are per-thread; repeat the call to confirm the calling
+	// goroutine's OS thread was correctly restored to the host namespace
+	// and isn't stuck (or leaking) in the child's namespace.
+	if again := GetContainerIPFromPid(pid); again != wantIP {
+		t.Fatalf("GetContainerIPFromPid() on second call = %q, want %q (namespace not restored cleanly)", again, wantIP)
+	}
+
+	// A pid with no such namespace (already exited) must fail closed, not
+	// return a stale or host address.
+	if empty := GetContainerIPFromPid(1 << 30); empty != "" {
+		t.Fatalf("GetContainerIPFromPid() for a bogus pid = %q, want empty", empty)
+	}
+}

--- a/KubeArmor/core/containerdHandler.go
+++ b/KubeArmor/core/containerdHandler.go
@@ -285,6 +285,14 @@ func (ch *ContainerdHandler) GetContainerInfo(ctx context.Context, containerID, 
 
 		container.NodeID = nodeID
 
+		// containerd doesn't expose a container's IP through its own API
+		// (unlike Docker); resolve it via the container's network namespace.
+		// NetworkPolicyEnforcer is the only consumer, so don't pay for the
+		// namespace switch when it's disabled.
+		if cfg.GlobalCfg.NetworkPolicyEnforcer {
+			container.ContainerIP = kl.GetContainerIPFromPid(container.Pid)
+		}
+
 		labels := []string{}
 		for k, v := range res.Labels {
 			labels = append(labels, k+"="+v)
@@ -543,6 +551,10 @@ func (dm *KubeArmorDaemon) UpdateContainerdContainer(ctx context.Context, contai
 			go dm.StateAgent.PushContainerEvent(container, state.EventAdded)
 		}
 
+		if !dm.K8sEnabled && cfg.GlobalCfg.NetworkPolicyEnforcer && dm.NetworkPolicyEnforcer != nil {
+			dm.UpdateNetworkSecurityPolicies()
+		}
+
 		dm.Logger.Printf("Detected a container (added/%.12s/pidns=%d/mntns=%d)", containerID, container.PidNS, container.MntNS)
 
 	} else if action == "destroy" {
@@ -610,6 +622,10 @@ func (dm *KubeArmorDaemon) UpdateContainerdContainer(ctx context.Context, contai
 		if cfg.GlobalCfg.StateAgent {
 			container.Status = "terminated"
 			go dm.StateAgent.PushContainerEvent(container, state.EventDeleted)
+		}
+
+		if !dm.K8sEnabled && cfg.GlobalCfg.NetworkPolicyEnforcer && dm.NetworkPolicyEnforcer != nil {
+			dm.UpdateNetworkSecurityPolicies()
 		}
 
 		dm.Logger.Printf("Detected a container (removed/%.12s/pidns=%d/mntns=%d)", containerID, container.PidNS, container.MntNS)

--- a/KubeArmor/core/crioHandler.go
+++ b/KubeArmor/core/crioHandler.go
@@ -147,6 +147,7 @@ func (ch *CrioHandler) GetContainerInfo(ctx context.Context, containerID, nodeID
 	}
 	container.Privileged = containerInfo.Privileged
 
+	container.Pid = uint32(containerInfo.Pid)
 	pid := strconv.Itoa(containerInfo.Pid)
 
 	if data, err := os.Readlink(filepath.Join(cfg.GlobalCfg.ProcFsMount, pid, "/ns/pid")); err == nil {
@@ -163,6 +164,14 @@ func (ch *CrioHandler) GetContainerInfo(ctx context.Context, containerID, nodeID
 		}
 	} else {
 		return container, err
+	}
+
+	if !cfg.GlobalCfg.K8sEnv && cfg.GlobalCfg.NetworkPolicyEnforcer {
+		// CRI-O doesn't expose a container's IP through ContainerStatus;
+		// resolve it via the container's network namespace. NetworkPolicyEnforcer
+		// is the only consumer, so don't pay for the namespace switch when it's
+		// disabled.
+		container.ContainerIP = kl.GetContainerIPFromPid(container.Pid)
 	}
 
 	return container, nil

--- a/KubeArmor/core/dockerHandler.go
+++ b/KubeArmor/core/dockerHandler.go
@@ -496,6 +496,10 @@ func (dm *KubeArmorDaemon) GetAlreadyDeployedDockerContainers() {
 					}
 				}
 
+				if !dm.K8sEnabled && cfg.GlobalCfg.NetworkPolicyEnforcer && dm.NetworkPolicyEnforcer != nil {
+					dm.UpdateNetworkSecurityPolicies()
+				}
+
 				dm.Logger.Printf("Detected a container (added/%.12s)", container.ContainerID)
 			}
 		}
@@ -703,6 +707,10 @@ func (dm *KubeArmorDaemon) UpdateDockerContainer(containerID, action string) {
 			go dm.StateAgent.PushContainerEvent(container, state.EventAdded)
 		}
 
+		if !dm.K8sEnabled && cfg.GlobalCfg.NetworkPolicyEnforcer && dm.NetworkPolicyEnforcer != nil {
+			dm.UpdateNetworkSecurityPolicies()
+		}
+
 		dm.Logger.Printf("Detected a container (added/%.12s)", containerID)
 
 	} else if action == "stop" || action == "destroy" {
@@ -775,6 +783,10 @@ func (dm *KubeArmorDaemon) UpdateDockerContainer(containerID, action string) {
 			if dm.Presets != nil {
 				dm.Presets.UnregisterContainer(containerID)
 			}
+		}
+
+		if !dm.K8sEnabled && cfg.GlobalCfg.NetworkPolicyEnforcer && dm.NetworkPolicyEnforcer != nil {
+			dm.UpdateNetworkSecurityPolicies()
 		}
 
 		dm.Logger.Printf("Detected a container (removed/%.12s)", containerID)

--- a/KubeArmor/core/kubeArmor.go
+++ b/KubeArmor/core/kubeArmor.go
@@ -503,8 +503,12 @@ func (dm *KubeArmorDaemon) SetHealthStatus(serviceName string, healthStatus grpc
 func KubeArmor() {
 	// create a daemon
 	dm := NewKubeArmorDaemon()
-	// Enable KubeArmorHostPolicy for both VM and KVMAgent and in non-k8s env
-	if cfg.GlobalCfg.KVMAgent || (!cfg.GlobalCfg.K8sEnv && cfg.GlobalCfg.HostPolicy) {
+	// Enable KubeArmorHostPolicy for both VM and KVMAgent and in non-k8s env.
+	// NetworkPolicyEnforcer also needs these node identities to match
+	// nodeSelector on host-level KubeArmorNetworkPolicy, so it must gate this
+	// block too - otherwise a host nodeSelector policy silently never matches
+	// when HostPolicy is off but NetworkPolicyEnforcer is on.
+	if cfg.GlobalCfg.KVMAgent || (!cfg.GlobalCfg.K8sEnv && (cfg.GlobalCfg.HostPolicy || cfg.GlobalCfg.NetworkPolicyEnforcer)) {
 
 		dm.NodeLock.Lock()
 

--- a/KubeArmor/core/networkPolicy_test.go
+++ b/KubeArmor/core/networkPolicy_test.go
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Authors of KubeArmor
+
+package core
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	cfg "github.com/kubearmor/KubeArmor/KubeArmor/config"
+	fd "github.com/kubearmor/KubeArmor/KubeArmor/feeder"
+	ne "github.com/kubearmor/KubeArmor/KubeArmor/networkPolicyEnforcer"
+	tp "github.com/kubearmor/KubeArmor/KubeArmor/types"
+)
+
+func TestContainerRemovalUpdatesNetworkPolicies(t *testing.T) {
+	oldNetwork, oldState, oldDebug := cfg.GlobalCfg.NetworkPolicyEnforcer, cfg.GlobalCfg.StateAgent, cfg.GlobalCfg.Debug
+	cfg.GlobalCfg.NetworkPolicyEnforcer, cfg.GlobalCfg.StateAgent, cfg.GlobalCfg.Debug = true, false, false
+	oldDocker, oldContainerd := Docker, Containerd
+	Docker, Containerd = &DockerHandler{}, &ContainerdHandler{}
+	t.Cleanup(func() {
+		cfg.GlobalCfg.NetworkPolicyEnforcer, cfg.GlobalCfg.StateAgent, cfg.GlobalCfg.Debug = oldNetwork, oldState, oldDebug
+		Docker, Containerd = oldDocker, oldContainerd
+	})
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "nft"), []byte("#!/bin/sh\nexit 0\n"), 0700); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	for _, runtime := range []string{"docker", "containerd"} {
+		t.Run(runtime, func(t *testing.T) {
+			dm := NewKubeArmorDaemon()
+			dm.Logger = &fd.Feeder{SecurityPolicies: map[string]tp.MatchPolicies{}, SecurityPoliciesLock: &sync.RWMutex{}}
+			dm.Logger.Node = &dm.Node
+			dm.NetworkPolicyEnforcer = &ne.NetworkPolicyEnforcer{
+				Logger: dm.Logger, RulesLock: &sync.RWMutex{}, EndPointsLock: &sync.RWMutex{}, QuotasLock: &sync.Mutex{},
+				QuotaTimers: map[string]*time.Ticker{}, QuotaCancel: map[string]context.CancelFunc{},
+			}
+			enforcer := dm.NetworkPolicyEnforcer
+			t.Cleanup(func() {
+				enforcer.QuotasLock.Lock()
+				defer enforcer.QuotasLock.Unlock()
+				for name, timer := range enforcer.QuotaTimers {
+					timer.Stop()
+					enforcer.QuotaCancel[name]()
+				}
+			})
+			dm.Containers["nginx"] = tp.Container{
+				ContainerID: "nginx", ContainerName: "nginx", ContainerIP: "172.18.0.2", NamespaceName: "container_namespace", Labels: "app=nginx",
+			}
+			dm.EndPoints = []tp.EndPoint{{EndPointName: "nginx", NamespaceName: "container_namespace", Containers: []string{"nginx"}, Identities: []string{"app=nginx"}}}
+			dm.NetworkSecurityPolicies = []tp.NetworkSecurityPolicy{{
+				Metadata: map[string]string{"policyName": "quota-test-policy"},
+				Spec: tp.NetworkSecuritySpec{
+					Selector: tp.SelectorType{Identities: []string{"app=nginx"}}, Action: "Block", Level: "Policy",
+					Egress: []tp.EgressType{{Limit: "2MB", Duration: "20m"}},
+				},
+			}}
+			dm.UpdateNetworkSecurityPolicies()
+			if len(enforcer.ActiveQuotas) != 1 {
+				t.Fatal("initial quota was not created")
+			}
+			if runtime == "docker" {
+				dm.UpdateDockerContainer("nginx", "destroy")
+			} else if err := dm.UpdateContainerdContainer(context.Background(), "nginx", 0, "destroy"); err != nil {
+				t.Fatal(err)
+			}
+			if len(enforcer.ActiveQuotas) != 0 || len(enforcer.QuotaTimers) != 0 || len(enforcer.EndPoints) != 0 {
+				t.Fatal("container removal left stale network policy state")
+			}
+			for _, rule := range enforcer.Rules {
+				if rule.Chain == "FORWARD" {
+					t.Fatalf("container removal left forwarding rule: %+v", rule)
+				}
+			}
+		})
+	}
+}

--- a/KubeArmor/networkPolicyEnforcer/networkPolicyEnforcer.go
+++ b/KubeArmor/networkPolicyEnforcer/networkPolicyEnforcer.go
@@ -6,6 +6,7 @@ package networkpolicyenforcer
 import (
 	"context"
 	"fmt"
+	"net"
 	"os"
 	"os/exec"
 	"sort"
@@ -462,8 +463,31 @@ func (ne *NetworkPolicyEnforcer) monitorLoggedPackets() {
 	}
 }
 
+// resolveNetworkEndpoints fills in standalone endpoint addresses from their containers.
+func resolveNetworkEndpoints(endpoints []tp.EndPoint, containers map[string]tp.Container) []tp.EndPoint {
+	var resolved []tp.EndPoint
+	for _, ep := range endpoints {
+		if ep.PodIP != "" {
+			resolved = append(resolved, ep)
+			continue
+		}
+		for _, id := range ep.Containers {
+			container, ok := containers[id]
+			if !ok || net.ParseIP(container.ContainerIP) == nil {
+				continue
+			}
+			endpoint := ep
+			endpoint.PodIP = container.ContainerIP
+			endpoint.Containers = []string{id}
+			resolved = append(resolved, endpoint)
+		}
+	}
+	return resolved
+}
+
 // UpdateNetworkSecurityPolicies Function
 func (ne *NetworkPolicyEnforcer) UpdateNetworkSecurityPolicies(secPolicies []tp.NetworkSecurityPolicy, endpoints []tp.EndPoint, containers map[string]tp.Container) {
+	endpoints = resolveNetworkEndpoints(endpoints, containers)
 
 	ne.EndPointsLock.Lock()
 	ne.EndPoints = make(map[string]tp.EndPoint)
@@ -513,14 +537,19 @@ func (ne *NetworkPolicyEnforcer) UpdateNetworkSecurityPolicies(secPolicies []tp.
 
 		if isPodPolicy {
 			// Find matching endpoints and collect their pod IPs
+			seenIPs := make(map[string]bool)
 			for _, ep := range endpoints {
 				matched := kl.MatchIdentities(policy.Spec.Selector.Identities, ep.Identities)
 				if matched {
-					if ep.PodIP != "" {
+					if ep.PodIP != "" && !seenIPs[ep.PodIP] {
 						podIPs = append(podIPs, ep.PodIP)
+						seenIPs[ep.PodIP] = true
 					}
 					matchedPods[ep.EndPointName] = true
 				}
+			}
+			if len(podIPs) == 0 {
+				continue
 			}
 		}
 

--- a/KubeArmor/networkPolicyEnforcer/nftables_integration_test.go
+++ b/KubeArmor/networkPolicyEnforcer/nftables_integration_test.go
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Authors of KubeArmor
+
+package networkpolicyenforcer
+
+import (
+	_ "embed"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+
+	tp "github.com/kubearmor/KubeArmor/KubeArmor/types"
+)
+
+//go:embed testdata/quota_traffic.py
+var quotaTrafficScript string
+
+// Run only in a disposable network namespace with nft and CAP_NET_ADMIN.
+// KUBEARMOR_TEST_TRAFFIC=1 additionally requires ip, python3, and CAP_NET_RAW
+// to check actual packet verdicts and quota accounting through veth/dummy links.
+func TestNetworkQuotaNFTables(t *testing.T) {
+	if os.Getenv("KUBEARMOR_TEST_NFTABLES") != "1" {
+		t.Skip("set KUBEARMOR_TEST_NFTABLES=1 inside a disposable network namespace")
+	}
+	nft := func(t *testing.T, args ...string) string {
+		t.Helper()
+		output, err := exec.Command("nft", args...).CombinedOutput()
+		if err != nil {
+			t.Fatalf("nft %v: %v\n%s", args, err, output)
+		}
+		return string(output)
+	}
+	for _, target := range []string{"host", "container"} {
+		t.Run(target, func(t *testing.T) {
+			ne := newTestNetworkEnforcer(t)
+			policy := standaloneQuotaPolicy()
+			if target == "host" {
+				policy.Metadata["policyName"] = "host-egress-quota"
+				policy.Spec.Selector = tp.SelectorType{}
+				policy.Spec.Level = ""
+				policy.Spec.Action = "Audit"
+				policy.Spec.Egress = []tp.EgressType{{Limit: "4MB", Duration: "1m"}}
+			}
+			endpoints := []tp.EndPoint{{EndPointName: "nginx", Identities: []string{"app=nginx"}, Containers: []string{"nginx"}}}
+			containers := map[string]tp.Container{"nginx": {ContainerIP: "172.18.0.2"}}
+			ne.UpdateNetworkSecurityPolicies([]tp.NetworkSecurityPolicy{policy}, endpoints, containers)
+			rules := nft(t, "list", "table", "inet", "kubearmor")
+			quotaName := sanitizeQuotaName("quota_" + policy.Metadata["policyName"] + "_Egress_0")
+			if !strings.Contains(rules, "quota "+quotaName+" {") {
+				t.Fatalf("quota missing:\n%s", rules)
+			}
+			if target == "container" && !strings.Contains(rules, "ip saddr 172.18.0.2 quota name") {
+				t.Fatalf("container rule missing:\n%s", rules)
+			}
+			if target == "host" && !strings.Contains(rules, `host-egress-quota Egress Audit host 4MB`) {
+				t.Fatalf("host audit rule missing:\n%s", rules)
+			}
+			if os.Getenv("KUBEARMOR_TEST_TRAFFIC") == "1" {
+				output, err := exec.Command("python3", "-c", quotaTrafficScript, target, quotaName).CombinedOutput()
+				if err != nil {
+					t.Fatalf("quota traffic verification: %v\n%s", err, output)
+				}
+				t.Logf("traffic verification: %s", output)
+			}
+			nft(t, "reset", "quota", "inet", "kubearmor", quotaName)
+			ne.UpdateNetworkSecurityPolicies(nil, nil, nil)
+			if rules = nft(t, "list", "table", "inet", "kubearmor"); strings.Contains(rules, quotaName) {
+				t.Fatalf("deleted quota remains:\n%s", rules)
+			}
+		})
+	}
+}

--- a/KubeArmor/networkPolicyEnforcer/standalone_test.go
+++ b/KubeArmor/networkPolicyEnforcer/standalone_test.go
@@ -1,0 +1,194 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Authors of KubeArmor
+
+package networkpolicyenforcer
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	cfg "github.com/kubearmor/KubeArmor/KubeArmor/config"
+	fd "github.com/kubearmor/KubeArmor/KubeArmor/feeder"
+	tp "github.com/kubearmor/KubeArmor/KubeArmor/types"
+)
+
+func newTestNetworkEnforcer(t *testing.T) *NetworkPolicyEnforcer {
+	t.Helper()
+	oldDebug := cfg.GlobalCfg.Debug
+	cfg.GlobalCfg.Debug = false
+	t.Cleanup(func() { cfg.GlobalCfg.Debug = oldDebug })
+	ne := &NetworkPolicyEnforcer{
+		Logger: &fd.Feeder{}, RulesLock: &sync.RWMutex{}, EndPointsLock: &sync.RWMutex{}, QuotasLock: &sync.Mutex{},
+		QuotaTimers: map[string]*time.Ticker{}, QuotaCancel: map[string]context.CancelFunc{},
+	}
+	t.Cleanup(func() {
+		ne.QuotasLock.Lock()
+		defer ne.QuotasLock.Unlock()
+		for name, timer := range ne.QuotaTimers {
+			timer.Stop()
+			ne.QuotaCancel[name]()
+		}
+	})
+	return ne
+}
+
+func captureNFTables(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	capture := filepath.Join(dir, "rules.nft")
+	t.Setenv("KUBEARMOR_NFT_CAPTURE", capture)
+	// Capture the transaction passed to nft without touching the host firewall.
+	if err := os.WriteFile(filepath.Join(dir, "nft"), []byte("#!/bin/sh\ncat \"$2\" > \"$KUBEARMOR_NFT_CAPTURE\"\n"), 0700); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	return capture
+}
+
+func standaloneQuotaPolicy() tp.NetworkSecurityPolicy {
+	return tp.NetworkSecurityPolicy{
+		Metadata: map[string]string{"policyName": "quota-test-policy"},
+		Spec: tp.NetworkSecuritySpec{
+			Selector: tp.SelectorType{Identities: []string{"app=nginx"}}, Action: "Block", Level: "Policy",
+			Egress: []tp.EgressType{{Limit: "2MB", Duration: "20m"}},
+		},
+	}
+}
+
+func TestUpdateNetworkSecurityPoliciesStandalone(t *testing.T) {
+	for _, tt := range []struct {
+		name         string
+		podIP        string
+		containerIPs []string
+		level        string
+		ingress      bool
+		unmatched    bool
+		wantIPs      []string
+		wantQuotas   int
+	}{
+		{name: "standalone", containerIPs: []string{"172.18.0.2"}, level: "Policy", wantIPs: []string{"172.18.0.2"}, wantQuotas: 1},
+		{name: "kubernetes IP takes precedence", podIP: "10.0.0.2", containerIPs: []string{"172.18.0.2"}, level: "Policy", wantIPs: []string{"10.0.0.2"}, wantQuotas: 1},
+		{name: "shared quota", containerIPs: []string{"172.18.0.2", "172.18.0.3"}, level: "Policy", wantIPs: []string{"172.18.0.2", "172.18.0.3"}, wantQuotas: 1},
+		{name: "individual quotas", containerIPs: []string{"172.18.0.2", "172.18.0.3"}, wantIPs: []string{"172.18.0.2", "172.18.0.3"}, wantQuotas: 2},
+		{name: "duplicate IP", containerIPs: []string{"172.18.0.2", "172.18.0.2"}, wantIPs: []string{"172.18.0.2"}, wantQuotas: 1},
+		{name: "IPv6 ingress", containerIPs: []string{"fd00::2"}, ingress: true, wantIPs: []string{"fd00::2"}, wantQuotas: 1},
+		{name: "missing and invalid addresses", containerIPs: []string{"", "invalid"}},
+		{name: "missing container"},
+		{name: "unmatched selector", containerIPs: []string{"172.18.0.2"}, unmatched: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			capture := captureNFTables(t)
+			ne := newTestNetworkEnforcer(t)
+			ep := tp.EndPoint{EndPointName: "nginx", PodIP: tt.podIP, Identities: []string{"app=nginx"}, Containers: []string{"missing"}}
+			containers := map[string]tp.Container{}
+			for i, ip := range tt.containerIPs {
+				id := string(rune('a' + i))
+				ep.Containers = append(ep.Containers, id)
+				containers[id] = tp.Container{ContainerID: id, ContainerIP: ip}
+			}
+			policy := standaloneQuotaPolicy()
+			policy.Spec.Level = tt.level
+			if tt.unmatched {
+				policy.Spec.Selector.Identities = []string{"app=other"}
+			}
+			if tt.ingress {
+				policy.Spec.Egress = nil
+				policy.Spec.Ingress = []tp.IngressType{{Limit: "2MB", Duration: "20m"}}
+			}
+			ne.UpdateNetworkSecurityPolicies([]tp.NetworkSecurityPolicy{policy}, []tp.EndPoint{ep}, containers)
+			if len(ne.ActiveQuotas) != tt.wantQuotas || len(ne.QuotaTimers) != tt.wantQuotas {
+				t.Fatalf("quotas=%d timers=%d, want %d", len(ne.ActiveQuotas), len(ne.QuotaTimers), tt.wantQuotas)
+			}
+			data, err := os.ReadFile(capture)
+			if err != nil {
+				t.Fatal(err)
+			}
+			script := string(data)
+			if got := strings.Count(script, "add rule inet kubearmor FORWARD"); got != 2*len(tt.wantIPs) {
+				t.Fatalf("forward rules=%d, want %d; transaction:\n%s", got, 2*len(tt.wantIPs), script)
+			}
+			direction, addr := "Egress", "saddr"
+			if tt.ingress {
+				direction, addr = "Ingress", "daddr"
+			}
+			for i, ip := range tt.wantIPs {
+				family := "ip"
+				if strings.Contains(ip, ":") {
+					family = "ip6"
+				}
+				if !strings.Contains(script, family+" "+addr+" "+ip+" quota name") {
+					t.Errorf("missing quota rule for %s:\n%s", ip, script)
+				}
+				info := packetInfo{srcIP: ip, dstIP: ip}
+				log := ne.buildKubeArmorLog(info, "", []string{"quota-test-policy", direction, "Block", "policy", "2MB"})
+				if log.PodName != "nginx" {
+					t.Errorf("missing endpoint metadata for %s: %+v", ip, log)
+				}
+				if tt.podIP == "" && len(tt.containerIPs) == len(tt.wantIPs) && log.ContainerID != string(rune('a'+i)) {
+					t.Errorf("wrong container attribution for %s: %s", ip, log.ContainerID)
+				}
+			}
+			if ep.PodIP != tt.podIP || len(ep.Containers) != len(tt.containerIPs)+1 {
+				t.Fatal("input endpoint was mutated")
+			}
+		})
+	}
+}
+
+func TestStandaloneQuotaLifecycle(t *testing.T) {
+	capture := captureNFTables(t)
+	ne := newTestNetworkEnforcer(t)
+	policies := []tp.NetworkSecurityPolicy{standaloneQuotaPolicy()}
+	endpoints := []tp.EndPoint{{EndPointName: "nginx", Identities: []string{"app=nginx"}, Containers: []string{"nginx"}}}
+	containers := map[string]tp.Container{}
+	update := func(wantIP string, wantQuota bool) {
+		t.Helper()
+		ne.UpdateNetworkSecurityPolicies(policies, endpoints, containers)
+		data, err := os.ReadFile(capture)
+		if err != nil {
+			t.Fatal(err)
+		}
+		wantCount := 0
+		if wantQuota {
+			wantCount = 1
+		}
+		if len(ne.ActiveQuotas) != wantCount || len(ne.QuotaTimers) != wantCount {
+			t.Fatalf("quotas=%d timers=%d, want %d", len(ne.ActiveQuotas), len(ne.QuotaTimers), wantCount)
+		}
+		if wantIP != "" && !strings.Contains(string(data), "ip saddr "+wantIP+" quota name") {
+			t.Fatalf("missing rule for %s", wantIP)
+		}
+	}
+	update("", false) // Policy arrives before the container.
+	containers["nginx"] = tp.Container{ContainerIP: "172.18.0.2"}
+	update("172.18.0.2", true)
+	quotaName := "quota_quota_test_policy_Egress_0"
+	timer := ne.QuotaTimers[quotaName]
+	update("172.18.0.2", true)
+	if ne.QuotaTimers[quotaName] != timer {
+		t.Fatal("unchanged quota window was reset")
+	}
+	containers["nginx"] = tp.Container{ContainerIP: "172.18.0.3"}
+	update("172.18.0.3", true)
+	if _, ok := ne.EndPoints["172.18.0.2"]; ok {
+		t.Fatal("stale endpoint IP retained")
+	}
+	delete(containers, "nginx")
+	update("", false)
+	data, err := os.ReadFile(capture)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), "delete quota inet kubearmor "+quotaName) {
+		t.Fatal("stale quota was not deleted")
+	}
+	containers["nginx"] = tp.Container{ContainerIP: "172.18.0.4"}
+	update("172.18.0.4", true)
+	policies = nil
+	update("", false)
+}

--- a/KubeArmor/networkPolicyEnforcer/testdata/quota_traffic.py
+++ b/KubeArmor/networkPolicyEnforcer/testdata/quota_traffic.py
@@ -1,0 +1,119 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Authors of KubeArmor
+
+"""Verify quota accounting and packet verdicts in a disposable network namespace."""
+
+import json
+import socket
+import struct
+import subprocess
+import sys
+import time
+
+
+def run(*args):
+    return subprocess.check_output(args, stderr=subprocess.STDOUT, text=True)
+
+
+def quota(name):
+    objects = json.loads(run("nft", "-j", "list", "quota", "inet", "kubearmor", name))
+    return next(obj["quota"] for obj in objects["nftables"] if "quota" in obj)
+
+
+def passed():
+    objects = json.loads(run("nft", "-j", "list", "counter", "inet", "ka_verify", "passed"))
+    return next(obj["counter"]["packets"] for obj in objects["nftables"] if "counter" in obj)
+
+
+def container_sender():
+    run("ip", "link", "add", "ka-in", "type", "veth", "peer", "name", "ka-send")
+    run("ip", "addr", "add", "172.18.0.1/24", "dev", "ka-in")
+    for interface in ("ka-in", "ka-send"):
+        run("ip", "link", "set", interface, "up")
+    with open("/proc/sys/net/ipv4/ip_forward", "w") as forwarding:
+        forwarding.write("1")
+    address = json.loads(run("ip", "-j", "link", "show", "ka-in"))[0]["address"]
+    mac = bytes.fromhex(address.replace(":", ""))
+
+    # Inject an Ethernet/IPv4/UDP packet through the veth peer into FORWARD.
+    header = struct.pack(
+        "!BBHHHBBH4s4s", 69, 0, 1028, 1, 0, 64, 17, 0,
+        socket.inet_aton("172.18.0.2"), socket.inet_aton("198.18.0.2"),
+    )
+    checksum = sum(struct.unpack("!10H", header))
+    checksum = (checksum & 65535) + (checksum >> 16)
+    checksum = (checksum & 65535) + (checksum >> 16)
+    header = header[:10] + struct.pack("!H", (~checksum) & 65535) + header[12:]
+    packet = (
+        mac + bytes.fromhex("020000000003") + b"\x08\x00" + header
+        + struct.pack("!HHHH", 50000, 9000, 1008, 0) + b"x" * 1000
+    )
+    sender = socket.socket(socket.AF_PACKET, socket.SOCK_RAW, socket.htons(3))
+    sender.bind(("ka-send", 0))
+    return sender, packet
+
+
+def main():
+    target, quota_name = sys.argv[1:]
+    run("ip", "link", "add", "ka-out", "type", "dummy")
+    run("ip", "addr", "add", "198.18.0.1/24", "dev", "ka-out")
+    run("ip", "link", "set", "ka-out", "up")
+    run(
+        "ip", "neigh", "replace", "198.18.0.2", "lladdr", "02:00:00:00:00:02",
+        "nud", "permanent", "dev", "ka-out",
+    )
+    run("nft", "add", "table", "inet", "ka_verify")
+    run("nft", "add", "counter", "inet", "ka_verify", "passed")
+    run(
+        "nft", "add", "chain", "inet", "ka_verify", "post",
+        "{ type filter hook postrouting priority 300; policy accept; }",
+    )
+    run(
+        "nft", "add", "rule", "inet", "ka_verify", "post",
+        "oifname", "ka-out", "counter", "name", "passed",
+    )
+    if target == "host":
+        sender = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        sender.connect(("198.18.0.2", 9000))
+        packet = b"x" * 1000
+    else:
+        sender, packet = container_sender()
+
+    try:
+        for _ in range(6000):
+            sender.send(packet)
+        time.sleep(0.2)
+        current_quota = quota(quota_name)
+        before = passed()
+        assert current_quota["used"] >= current_quota["bytes"], current_quota
+        assert before > 0, "no packets passed before quota exhaustion"
+        for _ in range(50):
+            sender.send(packet)
+        time.sleep(0.2)
+        after = passed()
+        if target == "host":
+            assert after > before, ("Audit blocked traffic", before, after)
+        else:
+            assert after == before, ("Block allowed traffic over quota", before, after)
+        print(json.dumps({
+            "target": target, "quota": current_quota,
+            "passed_before": before, "passed_after_over_quota": after,
+        }))
+
+        run("nft", "reset", "quota", "inet", "kubearmor", quota_name)
+        for _ in range(50):
+            sender.send(packet)
+        time.sleep(0.2)
+        reset = passed()
+        assert reset > after, ("traffic did not resume after reset", after, reset)
+        print(json.dumps({"reset_passed_packets": reset, "quota_after_reset": quota(quota_name)}))
+    finally:
+        sender.close()
+        run("nft", "delete", "table", "inet", "ka_verify")
+        run("ip", "link", "del", "ka-out")
+        if target != "host":
+            run("ip", "link", "del", "ka-in")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Fixes #2891

**Purpose of PR?**:

Two separate root causes were making `KubeArmorNetworkPolicy` (including bandwidth quotas) silently do nothing outside Kubernetes (Systemd/VM mode):

1. `EndPoint.PodIP` was only ever populated by the K8s pod-watch code. Outside k8s, a pod/container-selector policy had no IP to match against, so `generateRules()` returned zero rules with no error. Fixed by resolving the container's IP via its network namespace (`common.GetContainerIPFromPid`) for containerd/CRI-O (Docker already exposed this through its own inspect API), and backfilling `EndPoint.PodIP` from it in `NetworkPolicyEnforcer`. Policy evaluation also re-runs on container add/destroy, not just on policy change, so nftables stays correct when a container appears after its policy was already applied.

2. `dm.Node.Identities` (used to match `nodeSelector` on any host-scoped policy) was only populated outside k8s when `HostPolicy` was enabled — not when only `NetworkPolicyEnforcer` was on. A host-level `nodeSelector` policy would silently never match in that case. Fixed by including `NetworkPolicyEnforcer` in that gate.

**Does this PR introduce a breaking change?**

No. K8s-mode behavior is unchanged — a real K8s pod IP still takes precedence over the container-derived one, and that's covered by a test.

**If the changes in this PR are manually verified, list down the scenarios covered:**

- Unit tests for endpoint-IP resolution and the quota lifecycle: create/reuse/delete across container and policy changes, IPv4/IPv6, shared vs. per-pod quotas, and container add/remove triggering re-evaluation.
- A test that creates a real, isolated Linux network namespace with a known non-loopback address and verifies `GetContainerIPFromPid` resolves it correctly and restores the original namespace afterward (not mocked).
- **Not verified here**: an actual containerd/CRI-O daemon, or a live Systemd/VM KubeArmor deployment applying these policies against real nftables and real traffic — i.e. the exact repro in #2891. I don't have that environment available.

**Additional information for reviewer?**:

Split into two commits, one per root cause: the container-IP resolution fix (the bulk of the change) and the smaller host-identity fix.

`unix.Setns` is the standard technique for entering a container's network namespace (CNI plugins do the same), but it's new to this codebase, so `common.GetContainerIPFromPid` is the piece worth the closest read. It only runs when `NetworkPolicyEnforcer` is enabled, since that's its only consumer.

If someone has a VM handy, confirming the original repro now works — both policies, on whichever runtime that VM uses — would be a big help.

**Checklist:**
- [x] Bug fix. Fixes #2891
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] PR Title follows the convention of `<type>(<scope>): <subject>`
- [x] Commit has unit tests
- [ ] Commit has integration tests — a gated nft/traffic test is included at `KubeArmor/networkPolicyEnforcer/nftables_integration_test.go` for manual runs in a disposable namespace, but nothing here exercises a live containerd/CRI-O/systemd deployment
